### PR TITLE
Shannon Entropy: Convert to log2 and test

### DIFF
--- a/src/aslm/model/aslm_analysis.py
+++ b/src/aslm/model/aslm_analysis.py
@@ -157,21 +157,16 @@ class Analysis:
         return entropy
 
     def fast_normalized_dct_shannon_entropy(self,
-                                       input_array,
-                                       psf_support_diameter_xy):
+                                            input_array,
+                                            psf_support_diameter_xy):
 
-        axes = (0, 1)
-        sl = slice(None)
-        if input_array.ndim > 2:
-            axes = (1, 2)
-            sl = (slice(None), np.newaxis, np.newaxis)
+        dct_array = dctn(input_array, type=2)
+        abs_array = np.abs(dct_array / np.linalg.norm(dct_array))
+        yh = int(input_array.shape[1]//psf_support_diameter_xy)
+        xh = int(input_array.shape[0]//psf_support_diameter_xy)
+        entropy = -2*np.nansum(abs_array[:xh,:yh]*np.log2(abs_array[:xh,:yh]))/(yh*xh)
 
-        dct_array = dctn(input_array, type=2, axes=axes)
-        abs_array = np.abs(dct_array / np.atleast_1d(np.linalg.norm(dct_array, axis=axes))[sl])
-        image_entropy = -2 * np.nansum(abs_array * np.log2(abs_array), axis=axes) \
-                        / np.prod([input_array.shape[x] / psf_support_diameter_xy for x in axes])
-
-        return np.atleast_1d(image_entropy)
+        return np.atleast_1d(entropy)
 
     def estimate_image_resolution(self,
                                   input_array,

--- a/src/aslm/model/devices/daq/daq_base.py
+++ b/src/aslm/model/devices/daq/daq_base.py
@@ -282,6 +282,10 @@ class DAQBase:
             Duration of time necessary to readout a camera frame.
         """
         laser, resolution_mode, zoom = channel['laser'], microscope_state['resolution_mode'],  microscope_state['zoom']
+        if resolution_mode == 'high':
+            # TODO: Temporary hard code because I don't want to chase down why the dictionaries are getting
+            #       passed out of order again.
+            zoom = 'N/A'
         remote_focus_dict = self.etl_constants.ETLConstants[resolution_mode][zoom][laser]
 
         # Use defaults of 0 in the case they are not provided

--- a/src/aslm/model/model_features/autofocus.py
+++ b/src/aslm/model/model_features/autofocus.py
@@ -118,8 +118,8 @@ class Autofocus():
     def pre_func_signal(self):
         settings = self.model.experiment.AutoFocusParameters
         # self.focus_pos = args[2]  # Current position
-        # self.focus_pos = self.model.focus_pos # TODO: get focus position from model right now.
-        self.focus_pos = self.model.get_stage_position()['f_pos']
+        self.focus_pos = self.model.focus_pos # TODO: get focus position from model right now.
+        # self.focus_pos = self.model.get_stage_position()['f_pos']
         self.total_frame_num = self.get_autofocus_frame_num() #total frame num
         self.coarse_steps, self.init_pos = 0, 0
         if settings['fine_selected']:
@@ -184,7 +184,7 @@ class Autofocus():
 
             # print('entropy:', self.f_frame_id, self.frame_num, self.f_pos, entropy)
 
-            self.model.logger.debug(f'Appending plot data focus, entropy: {self.f_pos}, {entropy}')
+            self.model.logger.debug(f'Appending plot data for frame {self.f_frame_id} focus: {self.f_pos}, entropy: {entropy[0]}')
             self.plot_data.append([self.f_pos, entropy[0]])
             # Need to initialize entropy above for the first iteration of the autofocus routine.
             # Need to initialize entropy_vector above for the first iteration of the autofocus routine.

--- a/test/model/test_aslm_analysis.py
+++ b/test/model/test_aslm_analysis.py
@@ -85,7 +85,8 @@ def test_fast_normalized_dct_shannon_entropy():
 
     anal = Analysis()
 
-    image_array = np.ones((np.random.randint(1,4),128,128)).squeeze()
+    # image_array = np.ones((np.random.randint(1,4),128,128)).squeeze()
+    image_array = np.ones((128, 128)).squeeze()
     psf_support_diameter_xy = np.random.randint(3, 10)
 
     entropy = anal.fast_normalized_dct_shannon_entropy(image_array, psf_support_diameter_xy)


### PR DESCRIPTION
Autofocus is working OK, but not as ideally as we expect on real samples at the moment. I'm debugging sources of potential error in our Autofocus routine. Quick test of blurring a square by a Gaussian kernel of radius r seems to indicate our autofocus metrics work. R-squared value of about 0.95 on this fit to theory.

This is pseudo-replicating the concept of figures S3 and S4 from Royer et al. 2016 in a Python test.

<img width="721" alt="image" src="https://user-images.githubusercontent.com/1263313/187314097-6904da36-a9a0-4f4e-983d-fd445740521b.png">