### PR TITLE
Adds a validation filter to the remote focus portion of the model

### DIFF
--- a/src/aslm/model/devices/remote_focus/remote_focus_base.py
+++ b/src/aslm/model/devices/remote_focus/remote_focus_base.py
@@ -98,6 +98,12 @@ class RemoteFocusBase:
 
                 # ETL Parameters
                 etl_amplitude = float(etl_constants['ETLConstants'][imaging_mode][zoom][laser]['amplitude'])
+
+                # Validation for when user puts a '-' in spinbox
+                temp = etl_constants['ETLConstants'][imaging_mode][zoom][laser]['offset']
+                if temp == '-' or temp == '.':
+                    etl_constants['ETLConstants'][imaging_mode][zoom][laser]['offset'] = '0'
+
                 etl_offset = float(etl_constants['ETLConstants'][imaging_mode][zoom][laser]['offset'])
 
                 # Calculate the Waveforms

--- a/src/aslm/view/custom_widgets/validation.py
+++ b/src/aslm/view/custom_widgets/validation.py
@@ -176,6 +176,13 @@ class ValidatedEntry(ValidatedMixin, ttk.Entry):
         self.focus_update_var = focus_update_var
         self.bind('<FocusOut>', self._set_focus_update_var)
 
+    def set_precision(self, prec):
+        """
+        Given a precision it will update the spinboxes ability to handle more or less precision for validation.
+        This is separate from the increment value.
+        """
+        self.precision = prec
+
     def _get_precision(self):
         nums_after = self.resolution.find('.')
         
@@ -188,7 +195,6 @@ class ValidatedEntry(ValidatedMixin, ttk.Entry):
         max_val = self.max
 
         # check if there are range limits
-        # TODO: I add a line here, please make sure is it okay?
         if min_val == '-Infinity' or max_val == 'Infinity':
             return True
 
@@ -233,7 +239,6 @@ class ValidatedEntry(ValidatedMixin, ttk.Entry):
         max_val = self.max
         min_val = self.min
         # Check for error upon leaving widget
-        # TODO: I add some lines here, please make sure are they okay?
         if value.strip() == '' and self.required:
             self.error.set('A value is required')
             return False
@@ -259,8 +264,6 @@ class ValidatedEntry(ValidatedMixin, ttk.Entry):
         if value > int(max_val):
             self.error.set('Value is too high (max {})'.format(max_val))
 
-        
-
         return valid
     
     # Gets current value of widget and if focus_update_var is present it sets it to the same value
@@ -275,8 +278,6 @@ class ValidatedEntry(ValidatedMixin, ttk.Entry):
         try:
             new_min = self.min_var.get()
             self.min = new_min
-            print(self.max)
-            logger.info(self.max)
         except (tk.TclError, ValueError):
             pass
         if not current:
@@ -345,11 +346,12 @@ class ValidatedCombobox(ValidatedMixin, ttk.Combobox):
 # On focusout, make sure number is a valid number string and greater than from value
 # If given a min_var, max_var, or focus_update_var then the spinbox range will update dynamically when those valuse are changed (can be used to link to other widgets)
 class ValidatedSpinbox(ValidatedMixin, ttk.Spinbox):
-    def __init__(self, *args, min_var=None, max_var=None, focus_update_var=None, from_='-Infinity', to='Infinity', **kwargs):
+    def __init__(self, *args, min_var=None, max_var=None, focus_update_var=None, from_='-Infinity', to='Infinity', required=False, **kwargs):
         super().__init__(*args, from_=from_, to=to, **kwargs)
         self.resolution = str(kwargs.get('increment', '1.0')) # Number put into spinbox
         self.precision = self._get_precision()
         self.variable = kwargs.get('textvariable') or tk.DoubleVar
+        self.required = required
 
         # Dynamic range checker
         if min_var:
@@ -373,14 +375,41 @@ class ValidatedSpinbox(ValidatedMixin, ttk.Spinbox):
         
         return (-1) * len(self.resolution[nums_after + 1:])
 
+    # def _key_invalid(self, char, index, current, proposed, action, **kwargs):
+    #     new_prop = '0'
+    #     cursor_val = 0
+    #     if proposed == '.':
+    #         new_prop = '0.0'
+    #         cursor_val = 3
+    #     elif proposed == '-':
+    #         new_prop = '-0'
+    #         cursor_val = 2
+    #     else:
+    #         if proposed[0:1:1] == '-0' and len(proposed) > 2:
+    #             new_prop = '-' + proposed[2:]
+    #             cursor_val = self.index(tk.END)
+    #         proposed = Decimal(new_prop)
+    #         proposed_precision = proposed.as_tuple().exponent
+    #         if any([
+    #             (proposed > self.cget('to')),
+    #             (proposed_precision < self.precision)
+    #         ]):
+    #             return False
+    #     self.variable.set(new_prop)
+    #     self.icursor(cursor_val)
+
     def _key_validate(self, char, index, current, proposed, action, **kwargs):
 
         valid = True
         min_val = self.cget('from')
         max_val = self.cget('to')
-        no_negative = min_val >= 0
-        no_decimal = self.precision >= 0
+        
 
+        if min_val == '-Infinity' or max_val == 'Infinity':
+            return True
+
+        no_negative = int(min_val) >= 0
+        no_decimal = self.precision >= 0
 
         # Allow deletion
         if action == '0':
@@ -396,8 +425,8 @@ class ValidatedSpinbox(ValidatedMixin, ttk.Spinbox):
             return False
 
         # # Proposed is either a Decimal, '-', '.', or '-.' need one final check for '-' and '.' 
-        # if proposed in '-.':
-        #     return True
+        if proposed == '-' or proposed == '.':
+            return True
 
         # Proposed value is a Decimal, so convert and check further
         proposed = Decimal(proposed)
@@ -416,6 +445,16 @@ class ValidatedSpinbox(ValidatedMixin, ttk.Spinbox):
         max_val = self.cget('to')
         min_val = self.cget('from')
         # Check for error upon leaving widget
+        if value.strip() == '' and self.required:
+            self.error.set('A value is required')
+            return False
+        else:
+            self.error.set('')
+        
+        # check if there are range limits
+        if min_val == '-Infinity' or max_val == 'Infinity':
+            return True
+
         try:
             value = Decimal(value)
         except InvalidOperation:


### PR DESCRIPTION
This can now be merged. Going forward if we have a hardware device that handles negative or decimal values we can do a check to filter out the single character ' - ' and ' . ' as these will cause a float conversion error. The front end validates all other cases discovered thus far. Now a user can input ' - ' and it will not quit the model thread. If this starts to happen in other places this is how we will fix it. Our second layer of validation.