### PR TITLE
Logging enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -287,5 +287,5 @@ temp-BICF-JG-LE4350.txt
 
 # Custom Ignore
 *.log
-src/log_files/*.log
 *.icloud
+src/aslm/log_files/LOGS

--- a/src/aslm/log_files/log_functions.py
+++ b/src/aslm/log_files/log_functions.py
@@ -1,8 +1,9 @@
-from email.mime import base
 import logging.config
 import logging.handlers
-import yaml
 from pathlib import Path
+import os
+
+import yaml
 
 def update_nested_dict(d, find_func, apply_func):
     """
@@ -56,13 +57,17 @@ def log_setup(fname):
 
     # the path to fname is set relative to the location of the folder containing this file (log_functions.py)
     base_directory = Path(__file__).resolve().parent
-    logging_path = Path.joinpath(base_directory, fname)
+    config_path = Path.joinpath(base_directory, fname)
+
+    logging_path = Path.joinpath(base_directory, 'LOGS')
+    if not os.path.exists(logging_path):
+        os.mkdir(logging_path)
 
     # Function to map filename to base_directory/filename in the dictionary
     def update_filename(v):
         return Path.joinpath(base_directory, v)
 
-    with open(logging_path, 'r') as f:
+    with open(config_path, 'r') as f:
         try:
             config_data = yaml.load(f.read(), Loader=yaml.FullLoader)
             # Force all log files to be created relative to base_directory

--- a/src/aslm/log_files/logging.yml
+++ b/src/aslm/log_files/logging.yml
@@ -17,26 +17,26 @@ handlers:
     stream: ext://sys.stdout
     filters: [not_performance]
   vc_info:
-    class: logging.FileHandler
+    class: logging.handlers.RotatingFileHandler
     level: INFO
     formatter: base
-    filename: view_controller_info.log
+    filename: LOGS/view_controller_info.log
     filters: [not_performance]
-    mode: w
+    mode: a
   vc_debug:
-    class: logging.FileHandler
+    class: logging.handlers.RotatingFileHandler
     level: DEBUG
     formatter: base
-    filename: view_controller_debug.log
+    filename: LOGS/view_controller_debug.log
     filters: [not_performance]
-    mode: w
+    mode: a
   performance:
-    class: logging.FileHandler
+    class: logging.handlers.RotatingFileHandler
     level: DEBUG
     formatter: base
-    filename: performance.log
+    filename: LOGS/performance.log
     filters: [performance_specs]
-    mode: w
+    mode: a
 loggers:
   view:
     level: DEBUG

--- a/src/aslm/log_files/model_logging.yml
+++ b/src/aslm/log_files/model_logging.yml
@@ -17,26 +17,33 @@ handlers:
     stream: ext://sys.stdout
     filters: [not_performance]
   model_info:
-    class: logging.FileHandler
+    class: logging.handlers.RotatingFileHandler
     level: INFO
     formatter: base
-    filename: model_info.log
+    filename: LOGS/model_info.log
     filters: [not_performance]
-    mode: w
+    mode: a
   model_debug:
-    class: logging.FileHandler
+    class: logging.handlers.RotatingFileHandler
     level: DEBUG
     formatter: base
-    filename: model_debug.log
+    filename: LOGS/model_debug.log
     filters: [not_performance]
-    mode: w
+    mode: a
+  model_error:
+    class: logging.handlers.RotatingFileHandler
+    level: ERROR
+    formatter: base
+    filename: LOGS/model_error.log
+    filters: [not_performance]
+    mode: a
   model_performance:
-    class: logging.FileHandler
+    class: logging.handlers.RotatingFileHandler
     level: DEBUG
     formatter: base
-    filename: model_performance.log
+    filename: LOGS/model_performance.log
     filters: [performance_specs]
-    mode: w
+    mode: a
 loggers:
   model:
     level: DEBUG


### PR DESCRIPTION
A partial response to #194.

* Moves logs into `LOGS` subdirectory, but this directory is still in `src/aslm/log_files`. Do we want to move this to `LOCALAPPDATA`?
* Logs are still not per-run, but now append to the same log file. This prevents the previous logs from being overwritten every time the program is launched. Log file is switched to a rotating logger to prevent giant logging files. Is this the desired behavior?

Curious to hear your thoughts, @codeCollision4 and @annie-xd-wang.