### PR TITLE
Add pre-commit checks

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,6 +1,6 @@
 name: Lint
 
-on: [push, pull_request]
+on: workflow_dispatch
 
 jobs:
   lint:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,18 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.3.0
+    hooks:
+    -   id: check-yaml
+    -   id: end-of-file-fixer
+    -   id: trailing-whitespace
+-   repo: https://github.com/psf/black
+    rev: 22.10.0
+    hooks:
+    -   id: black
+- repo: https://github.com/charliermarsh/ruff-pre-commit
+  # Ruff version.
+  rev: 'v0.0.191'
+  hooks:
+    - id: ruff
+      # Respect `exclude` and `extend-exclude` settings.
+      args: ["--force-exclude"]


### PR DESCRIPTION
This uses the package `pre-commit` to run linting and formatting on code prior to committing. To use these checks, they must be set up on your local machine following the instructions here: https://pre-commit.com/#1-install-pre-commit. 

Nominally,

```
pip install pre-commit
cd /path/to/ASLM
pre-commit install
```

Installation is optional. Use this only if it helps you. You could alternatively install Ruff (linter) and Black (code formatter) extensions in VSCode and have them do the work there. Whatever you like.