### PR TITLE
Attempt to explicitly kill splash screen at exit

### DIFF
--- a/src/aslm/controller/controller.py
+++ b/src/aslm/controller/controller.py
@@ -99,7 +99,11 @@ def destroy_splash_screen(root, splash_screen):
     splash_screen : Tk top-level widget.
         Tk.tk GUI instance.
     """
-    splash_screen.destroy()
+
+    if hasattr(root, "splash_screen"):
+        splash_screen.destroy()
+    else:
+        pass
     root.deiconify()
 
 

--- a/src/aslm/controller/controller.py
+++ b/src/aslm/controller/controller.py
@@ -38,6 +38,7 @@ from tkinter import filedialog, messagebox
 import multiprocessing as mp
 import threading
 import sys
+import atexit
 
 # Third Party Imports
 
@@ -88,6 +89,20 @@ p = __name__.split(".")[1]
 logger = logging.getLogger(p)
 
 
+def destroy_splash_screen(root, splash_screen):
+    """Destroy splash screen and show main screen
+
+    Parameters
+    ----------
+    root : Tk top-level widget.
+        Tk.tk GUI instance.
+    splash_screen : Tk top-level widget.
+        Tk.tk GUI instance.
+    """
+    splash_screen.destroy()
+    root.deiconify()
+
+
 class Controller:
     """ASLM Controller
 
@@ -122,13 +137,15 @@ class Controller:
         use_gpu,
         args,
     ):
+        # Register to destroy the splash screen when the program exits
+        atexit.register(destroy_splash_screen, root=root, splash_screen=splash_screen)
 
         # Create a thread pool
         self.threads_pool = SynchronizedThreadPool()
-        self.event_queue = mp.Queue(
-            100
-        )  # pass events from the model to the view via controller
+
+        # Event queue passes events from the model to the view via controller
         # accepts tuples, ('event_name', value)
+        self.event_queue = mp.Queue(100)
 
         # Create a shared memory manager
         self.manager = Manager()
@@ -230,9 +247,8 @@ class Controller:
         # Camera View Tab
         self.initialize_cam_view()
 
-        # destroy splash screen and show main screen
-        splash_screen.destroy()
-        root.deiconify()
+        # Destroy the Splash Screen
+        destroy_splash_screen(root, splash_screen)
 
     def update_buffer(self):
         """Update the buffer size according to the camera

--- a/src/aslm/view/splash_screen.py
+++ b/src/aslm/view/splash_screen.py
@@ -2,7 +2,8 @@
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without
-# modification, are permitted for academic and research use only (subject to the limitations in the disclaimer below)
+# modification, are permitted for academic and research use only
+# (subject to the limitations in the disclaimer below)
 # provided that the following conditions are met:
 
 #      * Redistributions of source code must retain the above copyright notice,
@@ -46,6 +47,23 @@ class SplashScreen(tk.Toplevel):
     """
 
     def __init__(self, root, imgDir, *args, **kargs):
+        """Initialize the splash screen
+
+        Parameters
+        ----------
+        root : tk window
+            Top level GUI.
+        imgDir : str
+            Path to the splash screen image.
+        *args : tk args
+            Tk args.
+        **kargs : tk kargs
+            Tk kargs.
+
+        Returns
+        -------
+        None
+        """
         tk.Toplevel.__init__(self, root)
         # without navigation panel
         self.overrideredirect(True)
@@ -55,9 +73,11 @@ class SplashScreen(tk.Toplevel):
             img = tk.PhotoImage(file=img_dir)
             w, h = img.width(), img.height()  # width, height of the image
             loading_label = tk.Label(self, image=img)
-        except:
+        except tk.TclError:
             w, h = 300, 100
             loading_label = tk.Label(self, text="Loading ASLM Software ...")
+
+        # set the window size
         loading_label.pack()
 
         # get screen width and height


### PR DESCRIPTION
Not sure about the tk.TclError. Could revert back to the standard bare except clause.

The same problem that is reported in #355 does not occur when I run the software in the synthetic hardware mode on a Mac. Perhaps you could see if this prevents the splash screen from hanging on a Windows machine.

Basically created a function that kills the splash screen, which is called at the end of the initialization sequence. However, I register this same function to be called with atexit at the beginning of initialization. This way, if initialization fails, then the destroy splash screen sequence is called.  When we normally exit the program, and the splash screen has already been destroyed, then of course we cannot close it again. So, I use a hasattr call to see if it still exists...

One exception clause was deemed too broad by Rust, so I attempted to put what I think is the appropriate exception clause. We can revert back if necessary.  