### PR TITLE
Update camera_view_controller.py

### DIFF
--- a/src/aslm/controller/sub_controllers/camera_view_controller.py
+++ b/src/aslm/controller/sub_controllers/camera_view_controller.py
@@ -588,17 +588,17 @@ class CameraViewController(GUIController):
         # Get the number of frames to average from the VIEW
         self.rolling_frames = int(self.image_metrics["Frames"].get())
 
+        # Make sure the array is longer than the number of frames to average.
+        if self.rolling_frames > len(self.max_intensity_history):
+            self.rolling_frames = len(self.max_intensity_history)
+
         if self.rolling_frames == 0:
             # Cannot average 0 frames. Set to 1, and report max intensity
             self.image_metrics["Frames"].set(1)
             self.image_metrics["Image"].set(f"{self.max_intensity_history[-1]:.0f}")
-
         elif self.rolling_frames == 1:
-            # Report max intensity for most recent frame.
             self.image_metrics["Image"].set(f"{self.max_intensity_history[-1]:.0f}")
-
         elif self.rolling_frames > 1:
-            #  Rolling Average
             rolling_average = np.mean(
                 self.max_intensity_history[-self.rolling_frames :]
             )

--- a/src/aslm/controller/sub_controllers/camera_view_controller.py
+++ b/src/aslm/controller/sub_controllers/camera_view_controller.py
@@ -600,8 +600,9 @@ class CameraViewController(GUIController):
         elif self.rolling_frames == 1:
             self.image_metrics["Image"].set(f"{self.max_intensity_history[-1]:.0f}")
         elif self.rolling_frames > 1:
-            rolling_average = np.mean(
-                self.max_intensity_history[-self.rolling_frames :]
+            rolling_average = (
+                sum(self.max_intensity_history[-self.rolling_frames :])
+                / self.rolling_frames
             )
             self.image_metrics["Image"].set(f"{rolling_average:.0f}")
 

--- a/src/aslm/controller/sub_controllers/camera_view_controller.py
+++ b/src/aslm/controller/sub_controllers/camera_view_controller.py
@@ -138,6 +138,7 @@ class CameraViewController(GUIController):
         self.image_count = 0
         self.temp_array = None
         self.rolling_frames = 1
+        self.max_intensity_history = []
         self.bit_depth = 8  # bit-depth for PIL presentation.
         self.zoom_value = 1
         self.zoom_scale = 1
@@ -567,37 +568,41 @@ class CameraViewController(GUIController):
         """Update the max counts in the camera view.
 
         Function gets the number of frames to average from the VIEW.
-        If frames to average == 0 or 1,
-        provides the maximum value from the last acquired data.
 
-        If frames to average >1, initializes a temporary array,
-        and appends each subsequent image to it.
+        If frames to average == 0 or 1, provides the maximum value from the last
+        acquired data.
 
-        Once the number of frames to average has been reached,
-        deletes the first image in.
+        Parameters
+        ----------
+        None
 
-        Reports the rolling average.
+        Returns
+        -------
+        None
         """
+
+        # If the array is larger than 32 entries, remove the 0th entry.
+        if len(self.max_intensity_history) > (2**5) - 1:
+            self.max_intensity_history = self.max_intensity_history[1:]
+
+        # Get the number of frames to average from the VIEW
         self.rolling_frames = int(self.image_metrics["Frames"].get())
-        self.image_metrics["Image"].set(f"{self.max_counts:.2f}")
 
         if self.rolling_frames == 0:
             # Cannot average 0 frames. Set to 1, and report max intensity
             self.image_metrics["Frames"].set(1)
+            self.image_metrics["Image"].set(f"{self.max_intensity_history[-1]:.0f}")
+
+        elif self.rolling_frames == 1:
+            # Report max intensity for most recent frame.
+            self.image_metrics["Image"].set(f"{self.max_intensity_history[-1]:.0f}")
+
         elif self.rolling_frames > 1:
             #  Rolling Average
-            self.image_count = self.image_count + 1
-            if self.image_count == 1:
-                # First frame of the rolling average
-                self.temp_array = self.down_sampled_image
-            else:
-                # Subsequent frames of the rolling average
-                self.temp_array = np.dstack((self.temp_array, self.down_sampled_image))
-                if np.shape(self.temp_array)[2] > self.rolling_frames:
-                    self.temp_array = np.delete(self.temp_array, 0, 2)
-
-                # Update GUI
-                self.image_metrics["Image"].set(np.max(self.temp_array))
+            rolling_average = np.mean(
+                self.max_intensity_history[-self.rolling_frames :]
+            )
+            self.image_metrics["Image"].set(f"{rolling_average:.0f}")
 
     def down_sample_image(self):
         """Down-sample the data for image display according to widget size.
@@ -834,12 +839,14 @@ class CameraViewController(GUIController):
         # self.image_volume[:, :, self.slice_index,
         # self.channel_index] = image[:, ] # copy
 
+        # Store the maximum intensity value for the image.
+        self.max_intensity_history.append(np.max(image))
+
+        # If the user has toggled the transpose button, transpose the image.
         if self.transpose:
             self.image = image.T
         else:
             self.image = image
-            # self.image_volume[:, :, self.slice_index, self.channel_index]
-            # pass by reference
 
         if self._snr_selected:
             self.image = compute_signal_to_noise(

--- a/src/aslm/controller/sub_controllers/camera_view_controller.py
+++ b/src/aslm/controller/sub_controllers/camera_view_controller.py
@@ -582,7 +582,7 @@ class CameraViewController(GUIController):
         """
 
         # If the array is larger than 32 entries, remove the 0th entry.
-        if len(self.max_intensity_history) > (2**5) - 1:
+        if len(self.max_intensity_history) > (2**5):
             self.max_intensity_history = self.max_intensity_history[1:]
 
         # Get the number of frames to average from the VIEW
@@ -591,6 +591,7 @@ class CameraViewController(GUIController):
         # Make sure the array is longer than the number of frames to average.
         if self.rolling_frames > len(self.max_intensity_history):
             self.rolling_frames = len(self.max_intensity_history)
+            self.image_metrics["Frames"].set(self.rolling_frames)
 
         if self.rolling_frames == 0:
             # Cannot average 0 frames. Set to 1, and report max intensity

--- a/src/aslm/view/main_window_content/display_notebook.py
+++ b/src/aslm/view/main_window_content/display_notebook.py
@@ -450,7 +450,7 @@ class MetricsFrame(ttk.Labelframe):
                     label=self.labels[i],
                     input_class=ttk.Spinbox,
                     input_var=tk.IntVar(),
-                    input_args={"from_": 1, "to": 20, "increment": 1, "width": 5},
+                    input_args={"from_": 1, "to": 32, "increment": 1, "width": 5},
                     label_pos="top",
                 )
                 self.inputs[self.names[i]].grid(

--- a/test/controller/sub_controllers/test_camera_view_controller.py
+++ b/test/controller/sub_controllers/test_camera_view_controller.py
@@ -2,7 +2,8 @@
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without
-# modification, are permitted for academic and research use only (subject to the limitations in the disclaimer below)
+# modification, are permitted for academic and research use only
+# (subject to the limitations in the disclaimer below)
 # provided that the following conditions are met:
 
 #      * Redistributions of source code must retain the above copyright notice,
@@ -36,156 +37,182 @@ import random
 from unittest.mock import MagicMock
 import numpy as np
 
-class TestCameraViewController():
-    
+
+class TestCameraViewController:
     @pytest.fixture(autouse=True)
     def setup_class(self, dummy_controller):
         c = dummy_controller
         self.v = dummy_controller.view
         c.model = MagicMock()
-        c.model.get_offset_variance_maps = MagicMock(return_value=[None,None])
-        
+        c.model.get_offset_variance_maps = MagicMock(return_value=[None, None])
+
         self.camera_view = CameraViewController(self.v.camera_waveform.camera_tab, c)
 
     def test_init(self):
 
         assert isinstance(self.camera_view, CameraViewController)
 
-    
     def test_slider_update(self, monkeypatch):
-        
+
         # Testing it can be triggered, other functions within are tested later
-        self.image = (int(random.random()),int(random.random()))
+        self.image = (int(random.random()), int(random.random()))
         self.reset = False
+
         def mock_retrieve(slider_index, channel_display_index):
             self.x = int(random.random())
             self.y = int(random.random())
-            self.image = (self.x,self.y)
+            self.image = (self.x, self.y)
+
         def mock_reset():
             self.reset = True
-        monkeypatch.setattr(self.camera_view, "retrieve_image_slice_from_volume", mock_retrieve)
+
+        monkeypatch.setattr(
+            self.camera_view, "retrieve_image_slice_from_volume", mock_retrieve
+        )
         monkeypatch.setattr(self.camera_view, "reset_display", mock_reset)
-        event = type('Event', (object,), {})()
+        event = type("Event", (object,), {})()
 
         self.camera_view.slider_update(event)
 
-        assert self.image == (self.x,self.y)
-        assert self.reset == True
+        assert self.image == (self.x, self.y)
+        assert self.reset is True
 
     def test_update_display_state(self):
         pass
 
-
     def test_get_absolute_position(self, monkeypatch):
-        
         def mock_winfo_pointerx():
             self.x = int(random.random())
             return self.x
+
         def mock_winfo_pointery():
             self.y = int(random.random())
             return self.y
-        monkeypatch.setattr(self.v, 'winfo_pointerx', mock_winfo_pointerx)
-        monkeypatch.setattr(self.v, 'winfo_pointery', mock_winfo_pointery)
-        
+
+        monkeypatch.setattr(self.v, "winfo_pointerx", mock_winfo_pointerx)
+        monkeypatch.setattr(self.v, "winfo_pointery", mock_winfo_pointery)
+
         # call the function under test
         x, y = self.camera_view.get_absolute_position()
-        
+
         # make assertions about the return value
         assert x == self.x
         assert y == self.y
 
     def test_popup_menu(self, monkeypatch):
-        
+
         # create a fake event object
         self.startx = int(random.random())
         self.starty = int(random.random())
-        event = type('Event', (object,), {'x': self.startx, 'y': self.starty})()
+        event = type("Event", (object,), {"x": self.startx, "y": self.starty})()
         self.grab_released = False
         self.x = int(random.random())
         self.y = int(random.random())
         self.absx = int(random.random())
         self.absy = int(random.random())
 
-
         # monkey patch the get_absolute_position method to return specific values
         def mock_get_absolute_position():
             self.absx = int(random.random())
             self.absy = int(random.random())
             return self.absx, self.absy
-        monkeypatch.setattr(self.camera_view, 'get_absolute_position', mock_get_absolute_position)
+
+        monkeypatch.setattr(
+            self.camera_view, "get_absolute_position", mock_get_absolute_position
+        )
 
         def mock_tk_popup(x, y):
             self.x = x
             self.y = y
+
         def mock_grab_release():
             self.grab_released = True
-        monkeypatch.setattr(self.camera_view.menu, 'tk_popup', mock_tk_popup)
-        monkeypatch.setattr(self.camera_view.menu, 'grab_release', mock_grab_release)
+
+        monkeypatch.setattr(self.camera_view.menu, "tk_popup", mock_tk_popup)
+        monkeypatch.setattr(self.camera_view.menu, "grab_release", mock_grab_release)
 
         # call the function under test
         self.camera_view.popup_menu(event)
 
-        
         # make assertions about the state of the view object
         assert self.camera_view.move_to_x == self.startx
         assert self.camera_view.move_to_y == self.starty
         assert self.x == self.absx
         assert self.y == self.absy
-        assert self.grab_released == True
+        assert self.grab_released is True
 
-    @pytest.mark.parametrize("name", ['minmax', 'image'])
+    @pytest.mark.parametrize("name", ["minmax", "image"])
     @pytest.mark.parametrize("data", [[random.randint(0, 49), random.randint(50, 100)]])
     def test_initialize(self, name, data):
-        
+
         self.camera_view.initialize(name, data)
 
         # Checking values
-        if name == 'minmax':
-            assert self.camera_view.image_palette['Min'].get() == data[0]
-            assert self.camera_view.image_palette['Max'].get() == data[1]
-        if name == 'image':
-            assert self.camera_view.image_metrics['Frames'].get() == data[0]
+        if name == "minmax":
+            assert self.camera_view.image_palette["Min"].get() == data[0]
+            assert self.camera_view.image_palette["Max"].get() == data[1]
+        if name == "image":
+            assert self.camera_view.image_metrics["Frames"].get() == data[0]
 
-    
     def test_set_mode(self):
 
         # Test default mode
         self.camera_view.set_mode()
-        assert self.camera_view.mode == ''
-        assert self.camera_view.menu.entrycget("Move Here", 'state') == 'disabled'
+        assert self.camera_view.mode == ""
+        assert self.camera_view.menu.entrycget("Move Here", "state") == "disabled"
 
         # Test 'live' mode
-        self.camera_view.set_mode('live')
-        assert self.camera_view.mode == 'live'
-        assert self.camera_view.menu.entrycget("Move Here", 'state') == 'normal'
+        self.camera_view.set_mode("live")
+        assert self.camera_view.mode == "live"
+        assert self.camera_view.menu.entrycget("Move Here", "state") == "normal"
 
         # Test 'stop' mode
-        self.camera_view.set_mode('stop')
-        assert self.camera_view.mode == 'stop'
-        assert self.camera_view.menu.entrycget("Move Here", 'state') == 'normal'
+        self.camera_view.set_mode("stop")
+        assert self.camera_view.mode == "stop"
+        assert self.camera_view.menu.entrycget("Move Here", "state") == "normal"
 
         # Test invalid mode
-        self.camera_view.set_mode('invalid')
-        assert self.camera_view.mode == 'invalid'
-        assert self.camera_view.menu.entrycget("Move Here", 'state') == 'disabled'
+        self.camera_view.set_mode("invalid")
+        assert self.camera_view.mode == "invalid"
+        assert self.camera_view.menu.entrycget("Move Here", "state") == "disabled"
 
-    @pytest.mark.parametrize('mode', ['stop', 'live'])
+    @pytest.mark.parametrize("mode", ["stop", "live"])
     def test_move_stage(self, mode):
 
         # Setup to check formula inside func is correct
-        microscope_name = self.camera_view.parent_controller.configuration['experiment']['MicroscopeState']['microscope_name']
-        zoom_value = self.camera_view.parent_controller.configuration['experiment']['MicroscopeState']['zoom']
-        pixel_size = self.camera_view.parent_controller.configuration['configuration']['microscopes'][microscope_name]['zoom']['pixel_size'][zoom_value]
-        
-        current_center_x = (self.camera_view.zoom_rect[0][0] + self.camera_view.zoom_rect[0][1]) / 2
-        current_center_y = (self.camera_view.zoom_rect[1][0] + self.camera_view.zoom_rect[1][1]) / 2
+        microscope_name = self.camera_view.parent_controller.configuration[
+            "experiment"
+        ]["MicroscopeState"]["microscope_name"]
+        zoom_value = self.camera_view.parent_controller.configuration["experiment"][
+            "MicroscopeState"
+        ]["zoom"]
+        pixel_size = self.camera_view.parent_controller.configuration["configuration"][
+            "microscopes"
+        ][microscope_name]["zoom"]["pixel_size"][zoom_value]
+
+        current_center_x = (
+            self.camera_view.zoom_rect[0][0] + self.camera_view.zoom_rect[0][1]
+        ) / 2
+        current_center_y = (
+            self.camera_view.zoom_rect[1][0] + self.camera_view.zoom_rect[1][1]
+        ) / 2
 
         self.camera_view.move_to_x = int(random.random())
         self.camera_view.move_to_y = int(random.random())
-        
+
         # This is the formula to check
-        offset_x = (self.camera_view.move_to_x - current_center_x) / self.camera_view.zoom_scale * self.camera_view.canvas_width_scale * pixel_size
-        offset_y = (self.camera_view.move_to_y - current_center_y) / self.camera_view.zoom_scale * self.camera_view.canvas_width_scale * pixel_size
+        offset_x = (
+            (self.camera_view.move_to_x - current_center_x)
+            / self.camera_view.zoom_scale
+            * self.camera_view.canvas_width_scale
+            * pixel_size
+        )
+        offset_y = (
+            (self.camera_view.move_to_y - current_center_y)
+            / self.camera_view.zoom_scale
+            * self.camera_view.canvas_width_scale
+            * pixel_size
+        )
 
         # Set the mode to check if statements
         self.camera_view.mode = mode
@@ -194,42 +221,48 @@ class TestCameraViewController():
         self.camera_view.move_stage()
 
         # Check
-        assert self.camera_view.parent_controller.pop() == 'get_stage_position'
+        assert self.camera_view.parent_controller.pop() == "get_stage_position"
         res = self.camera_view.parent_controller.pop()
-        if mode == 'stop':
-            assert res == 'move_stage_and_acquire_image'
+        if mode == "stop":
+            assert res == "move_stage_and_acquire_image"
         else:
-            assert res == 'move_stage_and_update_info'
+            assert res == "move_stage_and_update_info"
         # Checking that move stage properly changed pos
         new_pos = self.camera_view.parent_controller.pop()
-        self.camera_view.parent_controller.stage_pos['x'] -= offset_x
-        self.camera_view.parent_controller.stage_pos['y'] += offset_y
+        self.camera_view.parent_controller.stage_pos["x"] -= offset_x
+        self.camera_view.parent_controller.stage_pos["y"] += offset_y
         assert new_pos == self.camera_view.parent_controller.stage_pos
 
-    
     def test_reset_display(self, monkeypatch):
-        
+
         # Mock process image function
         process_image_called = False
+
         def mock_process_image():
             nonlocal process_image_called
             process_image_called = True
 
         monkeypatch.setattr(self.camera_view, "process_image", mock_process_image)
 
-        # Reset and check 
+        # Reset and check
         self.camera_view.reset_display()
-        assert np.array_equal(self.camera_view.zoom_rect, np.array([[0, self.camera_view.view.canvas_width],[0, self.camera_view.view.canvas_height]]))
-        assert np.array_equal(self.camera_view.zoom_offset ,np.array([[0], [0]]))
+        assert np.array_equal(
+            self.camera_view.zoom_rect,
+            np.array(
+                [
+                    [0, self.camera_view.view.canvas_width],
+                    [0, self.camera_view.view.canvas_height],
+                ]
+            ),
+        )
+        assert np.array_equal(self.camera_view.zoom_offset, np.array([[0], [0]]))
         assert self.camera_view.zoom_value == 1
         assert self.camera_view.zoom_scale == 1
         assert self.camera_view.zoom_width == self.camera_view.view.canvas_width
         assert self.camera_view.zoom_height == self.camera_view.view.canvas_height
-        assert process_image_called == True
-
+        assert process_image_called is True
 
     def test_process_image(self):
-
         self.camera_view.digital_zoom = MagicMock()
         self.camera_view.detect_saturation = MagicMock()
         self.camera_view.down_sample_image = MagicMock()
@@ -237,7 +270,7 @@ class TestCameraViewController():
         self.camera_view.add_crosshair = MagicMock()
         self.camera_view.apply_LUT = MagicMock()
         self.camera_view.populate_image = MagicMock()
-        
+
         self.camera_view.process_image()
 
         self.camera_view.digital_zoom.assert_called()
@@ -248,9 +281,9 @@ class TestCameraViewController():
         self.camera_view.apply_LUT.assert_called()
         self.camera_view.populate_image.assert_called()
 
-    @pytest.mark.parametrize('num,value', [(4, 0.95), (5, 1.05)])
+    @pytest.mark.parametrize("num,value", [(4, 0.95), (5, 1.05)])
     def test_mouse_wheel(self, num, value):
-        
+
         # Test zoom in and out
         event = MagicMock()
         event.num = num
@@ -268,15 +301,20 @@ class TestCameraViewController():
         assert self.camera_view.zoom_value == value
         assert self.camera_view.zoom_scale == value
         assert self.camera_view.zoom_width == self.camera_view.view.canvas_width / value
-        assert self.camera_view.zoom_height == self.camera_view.view.canvas_height / value
+        assert (
+            self.camera_view.zoom_height == self.camera_view.view.canvas_height / value
+        )
 
-        if self.camera_view.zoom_width > self.camera_view.view.canvas_width or self.camera_view.zoom_height > self.camera_view.view.canvas_height:
-            assert self.camera_view.reset_display.called == True
+        if (
+            self.camera_view.zoom_width > self.camera_view.view.canvas_width
+            or self.camera_view.zoom_height > self.camera_view.view.canvas_height
+        ):
+            assert self.camera_view.reset_display.called is True
             self.camera_view.process_image.assert_called()
         else:
-            assert self.camera_view.reset_display.called == False
+            assert self.camera_view.reset_display.called is False
             not self.camera_view.process_image.assert_called()
-    
+
     @pytest.mark.skip("AssertionError: Expected 'mock' to have been called.")
     def test_digital_zoom(self):
 
@@ -289,10 +327,10 @@ class TestCameraViewController():
         self.camera_view.zoom_offset = np.array([[e], [f]])
         self.camera_view.zoom_value = val
         self.camera_view.zoom_scale = scale
-        self.camera_view.zoom_width = g # 300
-        self.camera_view.zoom_height = h # 400
-        self.camera_view.view.canvas_width = i #800
-        self.camera_view.view.canvas_height = j #600
+        self.camera_view.zoom_width = g  # 300
+        self.camera_view.zoom_height = h  # 400
+        self.camera_view.view.canvas_width = i  # 800
+        self.camera_view.view.canvas_height = j  # 600
         self.camera_view.canvas_width_scale = widthsc
         self.camera_view.canvas_height_scale = heightsc
         self.camera_view.image = np.random.randint(0, 256, (600, 800))
@@ -303,9 +341,9 @@ class TestCameraViewController():
         new_zoom_rec *= self.camera_view.zoom_value
         new_zoom_rec += self.camera_view.zoom_offset
 
-        x_start_index = int(- new_zoom_rec[0][0] / self.camera_view.zoom_scale)
+        x_start_index = int(-new_zoom_rec[0][0] / self.camera_view.zoom_scale)
         x_end_index = int(x_start_index + self.camera_view.zoom_width)
-        y_start_index = int(- new_zoom_rec[1][0] / self.camera_view.zoom_scale)
+        y_start_index = int(-new_zoom_rec[1][0] / self.camera_view.zoom_scale)
         y_end_index = int(y_start_index + self.camera_view.zoom_height)
 
         crosshair_x = (new_zoom_rec[0][0] + new_zoom_rec[0][1]) / 2
@@ -315,10 +353,14 @@ class TestCameraViewController():
         if crosshair_y < 0 or crosshair_y >= self.camera_view.view.canvas_height:
             crosshair_y = -1
 
-        new_image = self.camera_view.image[y_start_index * self.camera_view.canvas_height_scale : y_end_index * self.camera_view.canvas_height_scale,
-                                     x_start_index * self.camera_view.canvas_width_scale : x_end_index * self.camera_view.canvas_width_scale]
-
-
+        new_image = self.camera_view.image[
+            y_start_index
+            * self.camera_view.canvas_height_scale : y_end_index
+            * self.camera_view.canvas_height_scale,
+            x_start_index
+            * self.camera_view.canvas_width_scale : x_end_index
+            * self.camera_view.canvas_width_scale,
+        ]
 
         # Call func
         self.camera_view.digital_zoom()
@@ -337,9 +379,9 @@ class TestCameraViewController():
         # Check reset display
         self.camera_view.reset_display.assert_called()
 
-    @pytest.mark.parametrize('onoff', [True, False])
+    @pytest.mark.parametrize("onoff", [True, False])
     def test_left_click(self, onoff):
-        
+
         self.camera_view.add_crosshair = MagicMock()
         self.camera_view.apply_LUT = MagicMock()
         self.camera_view.populate_image = MagicMock()
@@ -355,15 +397,16 @@ class TestCameraViewController():
         self.camera_view.populate_image.assert_called()
         assert self.camera_view.apply_cross_hair == (not onoff)
 
-    @pytest.mark.parametrize('frames', [0, 1, 2])
-    @pytest.mark.parametrize('count', [0, 1])
+    @pytest.mark.parametrize("frames", [0, 1, 2])
+    @pytest.mark.parametrize("count", [0, 1])
     def test_update_max_count(self, frames, count):
-        
+
         # Arrange
-        max = random.randint(10,50)
-        self.camera_view.image_metrics['Frames'].set(frames)
+        max = random.randint(10, 50)
+        self.camera_view.image_metrics["Frames"].set(frames)
         self.camera_view.max_counts = max
         self.camera_view.image_count = count
+        self.camera_view.max_intensity_history = [max]
         if count == 1:
             self.camera_view.down_sampled_image = [max]
             self.camera_view.temp_array = [max]
@@ -373,45 +416,51 @@ class TestCameraViewController():
 
         # Assert
         if frames == 0:
-            assert self.camera_view.image_metrics['Frames'].get() == 1
-            assert self.camera_view.image_metrics['Image'].get() == max
+            assert self.camera_view.image_metrics["Frames"].get() == 1
+            assert self.camera_view.image_metrics["Image"].get() == max
 
         if frames == 1:
-            assert self.camera_view.image_metrics['Image'].get() == max
+            assert self.camera_view.image_metrics["Image"].get() == max
 
         if frames == 2:
             if count == 0:
-                assert self.camera_view.temp_array == self.camera_view.down_sampled_image
-                assert self.camera_view.image_metrics['Image'].get() == max
+                assert (
+                    self.camera_view.temp_array == self.camera_view.down_sampled_image
+                )
+                assert self.camera_view.image_metrics["Image"].get() == max
             else:
-                assert self.camera_view.image_metrics['Image'].get() == max
+                assert self.camera_view.image_metrics["Image"].get() == max
 
-        
     def test_down_sample_image(self, monkeypatch):
         import cv2
+
         # create a test image
         test_image = np.random.rand(100, 100)
         self.zoom_image = test_image
 
         # set the widget size
-        self.camera_view.view.canvas_width = np.random.randint(5,99)
-        self.camera_view.view.canvas_height = np.random.randint(5,99)
+        self.camera_view.view.canvas_width = np.random.randint(5, 99)
+        self.camera_view.view.canvas_height = np.random.randint(5, 99)
 
-         # monkeypatch cv2.resize
+        # monkeypatch cv2.resize
         def mocked_resize(img, size):
             return np.ones((size[0], size[1]))
+
         monkeypatch.setattr(cv2, "resize", mocked_resize)
 
         # call the function
         self.camera_view.down_sample_image()
 
         # assert that the image has been resized correctly
-        assert np.shape(self.camera_view.down_sampled_image) == (self.camera_view.view.canvas_width, self.camera_view.view.canvas_height)
+        assert np.shape(self.camera_view.down_sampled_image) == (
+            self.camera_view.view.canvas_width,
+            self.camera_view.view.canvas_height,
+        )
 
         # assert that the image has not been modified
         assert not np.array_equal(self.camera_view.down_sampled_image, test_image)
 
-    @pytest.mark.parametrize('auto', [True, False])
+    @pytest.mark.parametrize("auto", [True, False])
     def test_scale_image_intensity(self, auto):
         # Create a test image
         test_image = np.random.rand(100, 100)
@@ -420,7 +469,7 @@ class TestCameraViewController():
         # Set autoscale to True
         self.camera_view.autoscale = auto
 
-        if auto == False:
+        if auto is False:
             self.camera_view.max_counts = 1.5
             self.camera_view.min_counts = 0.5
 
@@ -428,18 +477,18 @@ class TestCameraViewController():
         self.camera_view.scale_image_intensity()
 
         # Assert that max_counts and min_counts have been set correctly
-        if auto == True:
+        if auto is True:
             assert self.camera_view.max_counts == np.max(test_image)
             assert self.camera_view.min_counts == np.min(test_image)
-    
+
         # Assert that the image has been scaled correctly
         assert np.min(self.camera_view.down_sampled_image) >= 0
         assert np.max(self.camera_view.down_sampled_image) <= 1
 
-    
     def test_populate_image(self, monkeypatch):
         from PIL import Image, ImageTk
         import cv2
+
         # Create test image
         self.camera_view.cross_hair_image = np.random.rand(100, 100)
         self.camera_view.ilastik_seg_mask = np.random.rand(100, 100)
@@ -450,24 +499,27 @@ class TestCameraViewController():
         # Monkeypatch the Image.fromarray() method of PIL
         def mocked_fromarray(arr):
             return arr
+
         monkeypatch.setattr(Image, "fromarray", mocked_fromarray)
 
         # Monkeypatch the cv2.resize() function
         def mocked_resize(arr, size):
             return arr
+
         monkeypatch.setattr(cv2, "resize", mocked_resize)
 
         # Monkeypatch the Image.blend() method of PIL
         def mocked_blend(img1, img2, alpha):
-            return img1 * alpha + img2 * (1-alpha)
+            return img1 * alpha + img2 * (1 - alpha)
+
         monkeypatch.setattr(Image, "blend", mocked_blend)
 
         def mocked_PhotoImage(img):
             return img
+
         monkeypatch.setattr(ImageTk, "PhotoImage", mocked_PhotoImage)
 
         self.camera_view.canvas.create_image = MagicMock()
-
 
         # Call the function
         self.camera_view.populate_image()
@@ -485,56 +537,73 @@ class TestCameraViewController():
         # Assert that the tk_image has been created correctly
         assert self.camera_view.tk_image is not None
 
-
     def test_initialize_non_live_display(self):
         # Create test buffer and microscope_state
         buffer = np.random.rand(100, 100)
-        microscope_state = {'channels': ['channel1', 'channel2', 'channel3'], 'number_z_steps': np.random.randint(0, 100)}
-        camera_parameters = {'x_pixels': np.random.randint(1, 200), 'y_pixels': np.random.randint(1, 200)}
+        microscope_state = {
+            "channels": ["channel1", "channel2", "channel3"],
+            "number_z_steps": np.random.randint(0, 100),
+        }
+        camera_parameters = {
+            "x_pixels": np.random.randint(1, 200),
+            "y_pixels": np.random.randint(1, 200),
+        }
 
         # Call the function
-        self.camera_view.initialize_non_live_display(buffer, microscope_state, camera_parameters)
+        self.camera_view.initialize_non_live_display(
+            buffer, microscope_state, camera_parameters
+        )
 
         # Assert that the variables have been set correctly
         assert self.camera_view.image_counter == 0
         assert self.camera_view.slice_index == 0
-        assert self.camera_view.number_of_channels == len(microscope_state['channels'])
-        assert self.camera_view.number_of_slices == microscope_state['number_z_steps']
-        assert self.camera_view.total_images_per_volume == self.camera_view.number_of_channels * self.camera_view.number_of_slices
-        assert self.camera_view.original_image_width == int(camera_parameters['x_pixels'])
-        assert self.camera_view.original_image_height == int(camera_parameters['y_pixels'])
-        assert self.camera_view.canvas_width_scale == int(self.camera_view.original_image_width / self.camera_view.view.canvas_width)
-        assert self.camera_view.canvas_height_scale == int(self.camera_view.original_image_height / self.camera_view.view.canvas_height)
+        assert self.camera_view.number_of_channels == len(microscope_state["channels"])
+        assert self.camera_view.number_of_slices == microscope_state["number_z_steps"]
+        assert (
+            self.camera_view.total_images_per_volume
+            == self.camera_view.number_of_channels * self.camera_view.number_of_slices
+        )
+        assert self.camera_view.original_image_width == int(
+            camera_parameters["x_pixels"]
+        )
+        assert self.camera_view.original_image_height == int(
+            camera_parameters["y_pixels"]
+        )
+        assert self.camera_view.canvas_width_scale == int(
+            self.camera_view.original_image_width / self.camera_view.view.canvas_width
+        )
+        assert self.camera_view.canvas_height_scale == int(
+            self.camera_view.original_image_height / self.camera_view.view.canvas_height
+        )
 
-        
     def test_identify_channel_index_and_slice(self):
         # Not currently in use
         pass
 
-    
     def test_retrieve_image_slice_from_volume(self):
         # Not currently in use
         pass
 
-    @pytest.mark.parametrize('transpose', [True, False])
+    @pytest.mark.parametrize("transpose", [True, False])
     def test_display_image(self, transpose):
         image = np.random.rand(100, 100)
-        microscope_state = {'stack_cycling_mode': 'per_stack'}
+        microscope_state = {"stack_cycling_mode": "per_stack"}
         images_received = 0
 
         self.camera_view.transpose = transpose
         count = np.random.randint(0, 10)
         self.camera_view.image_count = count
-        self.camera_view.image_metrics = {'Channel': MagicMock()}
+        self.camera_view.image_metrics = {"Channel": MagicMock()}
         self.camera_view.process_image = MagicMock()
         self.camera_view.update_max_counts = MagicMock()
 
         self.camera_view.display_image(image, microscope_state, images_received)
 
         assert np.shape(self.camera_view.image) == np.shape(image)
-        self.camera_view.image_metrics['Channel'].set.assert_called_with(self.camera_view.channel_index)
+        self.camera_view.image_metrics["Channel"].set.assert_called_with(
+            self.camera_view.channel_index
+        )
         assert self.camera_view.image_count == count + 1
-
 
     def test_add_crosshair(self):
 
@@ -550,9 +619,12 @@ class TestCameraViewController():
         self.camera_view.add_crosshair()
 
         # Assert
-        assert np.all(self.camera_view.cross_hair_image[:, self.camera_view.crosshair_x] == 1)
-        assert np.all(self.camera_view.cross_hair_image[self.camera_view.crosshair_y, :] == 1)
-
+        assert np.all(
+            self.camera_view.cross_hair_image[:, self.camera_view.crosshair_x] == 1
+        )
+        assert np.all(
+            self.camera_view.cross_hair_image[self.camera_view.crosshair_y, :] == 1
+        )
 
     def test_apply_LUT(self):
         # Someone else with better numpy understanding will need to do this TODO
@@ -563,33 +635,31 @@ class TestCameraViewController():
         # Same as apply LUT TODO
         pass
 
-
     def test_detect_saturation(self):
         test_image = np.random.randint(0, 2**16, size=(100, 100))
-        test_image[:50, :50] = 2**16-1  # set top left corner to saturation value
+        test_image[:50, :50] = 2**16 - 1  # set top left corner to saturation value
         self.camera_view.zoom_image = test_image
 
         # Call the function to detect saturation
         self.camera_view.detect_saturation()
 
         # Assert that the saturated pixels were correctly detected
-        assert np.all(self.camera_view.saturated_pixels == 2**16-1)
+        assert np.all(self.camera_view.saturated_pixels == 2**16 - 1)
 
-    
     def test_toggle_min_max_button(self):
 
         # Setup for true path
-        self.camera_view.image_palette['Autoscale'].set(True)
+        self.camera_view.image_palette["Autoscale"].set(True)
 
         # Act by calling function
         self.camera_view.toggle_min_max_buttons()
 
         # Assert things are correct
-        assert str(self.camera_view.image_palette['Min'].widget['state']) == 'disabled'
-        assert str(self.camera_view.image_palette['Max'].widget['state']) == 'disabled'
+        assert str(self.camera_view.image_palette["Min"].widget["state"]) == "disabled"
+        assert str(self.camera_view.image_palette["Max"].widget["state"]) == "disabled"
 
         # Setup for false path
-        self.camera_view.image_palette['Autoscale'].set(False)
+        self.camera_view.image_palette["Autoscale"].set(False)
 
         # Mock function call to isolate
         self.camera_view.update_min_max_counts = MagicMock()
@@ -598,40 +668,38 @@ class TestCameraViewController():
         self.camera_view.toggle_min_max_buttons()
 
         # Assert things are correct and called
-        assert str(self.camera_view.image_palette['Min'].widget['state']) == 'normal'
-        assert str(self.camera_view.image_palette['Max'].widget['state']) == 'normal'
+        assert str(self.camera_view.image_palette["Min"].widget["state"]) == "normal"
+        assert str(self.camera_view.image_palette["Max"].widget["state"]) == "normal"
         self.camera_view.update_min_max_counts.assert_called()
-
 
     def test_transpose_image(self):
         # Create test data
-        self.camera_view.image_palette['Flip XY'].set(True)
+        self.camera_view.image_palette["Flip XY"].set(True)
         self.camera_view.transpose = None
-        
+
         # Call the function
         self.camera_view.transpose_image()
-        
+
         # Assert the output
-        assert self.camera_view.transpose == True
+        assert self.camera_view.transpose is True
 
         # Create test data
-        self.camera_view.image_palette['Flip XY'].set(False)
+        self.camera_view.image_palette["Flip XY"].set(False)
         self.camera_view.transpose = None
-        
+
         # Call the function
         self.camera_view.transpose_image()
-        
-        # Assert the output
-        assert self.camera_view.transpose == False
 
+        # Assert the output
+        assert self.camera_view.transpose is False
 
     def test_update_min_max_counts(self):
         # Create test data
         min = np.random.randint(0, 10)
         max = np.random.randint(0, 10)
-        self.camera_view.image_palette['Min'].set(min)
-        self.camera_view.image_palette['Max'].set(max)
-        
+        self.camera_view.image_palette["Min"].set(min)
+        self.camera_view.image_palette["Max"].set(max)
+
         self.camera_view.min_counts = None
         self.camera_view.max_counts = None
 
@@ -642,18 +710,17 @@ class TestCameraViewController():
         assert self.camera_view.min_counts == min
         assert self.camera_view.max_counts == max
 
-
     def test_set_mask_color_table(self):
         # This is beyond me currently TODO
         pass
 
-    
     def test_display_mask(self, monkeypatch):
         import cv2
+
         # Create test data
         self.camera_view.ilastik_seg_mask = None
         self.camera_view.ilastik_mask_ready_lock.acquire()
-        mask = np.zeros((5,5), dtype=np.uint8)
+        mask = np.zeros((5, 5), dtype=np.uint8)
         self.camera_view.mask_color_table = np.zeros((256, 1, 3), dtype=np.uint8)
 
         # Define the monkeypatch
@@ -669,4 +736,3 @@ class TestCameraViewController():
         # Assert the output
         assert (self.camera_view.ilastik_seg_mask == mask).all()
         assert not self.camera_view.ilastik_mask_ready_lock.locked()
-


### PR DESCRIPTION
#418 fixed. 

Significant improvement on code readability too as a bonus. Now you can change the number of frames to average when you report the intensity max counts. This is particularly useful for when you are imaging very fast and that value can change faster than you can visualize it. 