### PR TITLE
Data source fixes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,8 @@ numpy==1.21.6; sys_platform == "darwin"
 scikit-image==0.19.1
 tensorflow==2.9.1; sys_platform != "darwin"
 cupy-cuda112==10.2.0; sys_platform != "darwin"
-zarr==2.11.3
-fsspec
-h5py
+zarr==2.14.2
+fsspec==2022.8.2; sys_platform != "darwin"
+fsspec==2022.5.0; sys_platform == "darwin"
+h5py==3.7.0
 requests==2.28.1

--- a/src/aslm/model/data_sources/bdv_data_source.py
+++ b/src/aslm/model/data_sources/bdv_data_source.py
@@ -178,28 +178,7 @@ class BigDataViewerDataSource(DataSource):
 
     def close(self) -> None:
         try:
-            # Check if we've closed this prior to completion
-            c, z, t, p = self._cztp_indices(
-                self._current_frame, self.metadata.per_stack
-            )
-            if (
-                (z != 0)
-                or (c != 0)
-                or (t < (self.shape_t - 1))
-                or (p < (self.positions - 1))
-            ):
-                # If we have, update our shape accordingly
-                maxc, maxz, maxt, maxp = 0, 0, 0, 0
-                for idx in range(self._current_frame):
-                    c, z, t, p = self._cztp_indices(idx, self.metadata.per_stack)
-                    maxc = max(maxc, c)
-                    maxz = max(maxz, z)
-                    maxt = max(maxt, t)
-                    maxp = max(maxp, p)
-                self.shape_c, self.shape_z = maxc + 1, maxz + 1
-                self.shape_t, self.positions = maxt + 1, maxp + 1
-                self.metadata.shape_c, self.metadata.shape_z = maxc + 1, maxz + 1
-                self.metadata.shape_t, self.metadata.positions = maxt + 1, maxp + 1
+            self._check_shape(self._current_frame, self.metadata.per_stack)
 
             self.image.close()
             self.metadata.write_xml(self.file_name, views=self._views)

--- a/src/aslm/model/data_sources/bdv_data_source.py
+++ b/src/aslm/model/data_sources/bdv_data_source.py
@@ -2,8 +2,8 @@
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without
-# modification, are permitted for academic and research use only (subject to the limitations in the disclaimer below)
-# provided that the following conditions are met:
+# modification, are permitted for academic and research use only (subject to the
+# limitations in the disclaimer below) provided that the following conditions are met:
 
 #      * Redistributions of source code must retain the above copyright notice,
 #      this list of conditions and the following disclaimer.
@@ -114,7 +114,8 @@ class BigDataViewerDataSource(DataSource):
                 dataset_name = "/".join(
                     [time_group_name, setup_group_name, f"{i}", "cells"]
                 )
-                # print(z, dz, dataset_name, self.image[dataset_name].shape, data[::dx, ::dy].shape)
+                # print(z, dz, dataset_name, self.image[dataset_name].shape,
+                #       data[::dx, ::dy].shape)
                 zs = np.minimum(
                     z // dz, self.shapes[i, 0] - 1
                 )  # TODO: Is this necessary?

--- a/src/aslm/model/data_sources/bdv_data_source.py
+++ b/src/aslm/model/data_sources/bdv_data_source.py
@@ -180,16 +180,12 @@ class BigDataViewerDataSource(DataSource):
     def close(self) -> None:
         if self._closed:
             return
-        try:
-            self._check_shape(self._current_frame - 1, self.metadata.per_stack)
-            # print(
-            #     f"Post-check current_frame: {self._current_frame-1} x: {self.shape_x}"
-            #     f" y: {self.shape_y} z: {self.shape_z} c: {self.shape_c} "
-            #     f"t: {self.shape_t} p: {self.positions}"
-            # )
-            self.image.close()
-            self.metadata.write_xml(self.file_name, views=self._views)
-        except AttributeError:
-            # image wasn't instantiated, no need to close anything
-            pass
+        self._check_shape(self._current_frame - 1, self.metadata.per_stack)
+        # print(
+        #     f"Post-check current_frame: {self._current_frame-1} x: {self.shape_x}"
+        #     f" y: {self.shape_y} z: {self.shape_z} c: {self.shape_c} "
+        #     f"t: {self.shape_t} p: {self.positions}"
+        # )
+        self.image.close()
+        self.metadata.write_xml(self.file_name, views=self._views)
         self._closed = True

--- a/src/aslm/model/data_sources/bdv_data_source.py
+++ b/src/aslm/model/data_sources/bdv_data_source.py
@@ -126,7 +126,7 @@ class BigDataViewerDataSource(DataSource):
 
         # Check if this was the last frame to write
         c, z, t, p = self._cztp_indices(self._current_frame, self.metadata.per_stack)
-        if (z == 0) and (c == 0) and (t == self.shape_t) and (p == self.positions):
+        if (z == 0) and (c == 0) and ((t >= self.shape_t) or (p >= self.positions)):
             self.close()
 
     def read(self) -> None:
@@ -178,6 +178,29 @@ class BigDataViewerDataSource(DataSource):
 
     def close(self) -> None:
         try:
+            # Check if we've closed this prior to completion
+            c, z, t, p = self._cztp_indices(
+                self._current_frame, self.metadata.per_stack
+            )
+            if (
+                (z != 0)
+                or (c != 0)
+                or (t < (self.shape_t - 1))
+                or (p < (self.positions - 1))
+            ):
+                # If we have, update our shape accordingly
+                maxc, maxz, maxt, maxp = 0, 0, 0, 0
+                for idx in range(self._current_frame):
+                    c, z, t, p = self._cztp_indices(idx, self.metadata.per_stack)
+                    maxc = max(maxc, c)
+                    maxz = max(maxz, z)
+                    maxt = max(maxt, t)
+                    maxp = max(maxp, p)
+                self.shape_c, self.shape_z = maxc + 1, maxz + 1
+                self.shape_t, self.positions = maxt + 1, maxp + 1
+                self.metadata.shape_c, self.metadata.shape_z = maxc + 1, maxz + 1
+                self.metadata.shape_t, self.metadata.positions = maxt + 1, maxp + 1
+
             self.image.close()
             self.metadata.write_xml(self.file_name, views=self._views)
         except AttributeError:

--- a/src/aslm/model/data_sources/bdv_data_source.py
+++ b/src/aslm/model/data_sources/bdv_data_source.py
@@ -178,8 +178,12 @@ class BigDataViewerDataSource(DataSource):
 
     def close(self) -> None:
         try:
-            self._check_shape(self._current_frame, self.metadata.per_stack)
-
+            self._check_shape(self._current_frame - 1, self.metadata.per_stack)
+            # print(
+            #     f"Post-check current_frame: {self._current_frame-1} x: {self.shape_x}"
+            #     f" y: {self.shape_y} z: {self.shape_z} c: {self.shape_c} "
+            #     f"t: {self.shape_t} p: {self.positions}"
+            # )
             self.image.close()
             self.metadata.write_xml(self.file_name, views=self._views)
         except AttributeError:

--- a/src/aslm/model/data_sources/bdv_data_source.py
+++ b/src/aslm/model/data_sources/bdv_data_source.py
@@ -175,8 +175,11 @@ class BigDataViewerDataSource(DataSource):
             self._setup_h5()
         else:
             self.read()
+        self._closed = False
 
     def close(self) -> None:
+        if self._closed:
+            return
         try:
             self._check_shape(self._current_frame - 1, self.metadata.per_stack)
             # print(
@@ -189,3 +192,4 @@ class BigDataViewerDataSource(DataSource):
         except AttributeError:
             # image wasn't instantiated, no need to close anything
             pass
+        self._closed = True

--- a/src/aslm/model/data_sources/data_source.py
+++ b/src/aslm/model/data_sources/data_source.py
@@ -80,6 +80,7 @@ class DataSource:
         self.file_name = file_name
         self.metadata = None  # Expect a metadata object
         self._mode = None
+        self._closed = True
 
         self.dx, self.dy, self.dz = 1, 1, 1  # pixel sizes (um)
         self.dt = 1  # time displacement (s)
@@ -272,6 +273,10 @@ class DataSource:
             t = (frame_id // (self.shape_c * self.shape_z)) % self.shape_t
             p = frame_id // (self.shape_c * self.shape_z * self.shape_t)
 
+            # NOTE: Uncomment this if we want positions to vary faster than time
+            # t = frame_id // (self.shape_c * self.shape_z * self.positions)
+            # p = (frame_id // (self.shape_c * self.shape_z)) % self.positions
+
         else:
             # Timepoint acquisition, only c varies faster than t
             c = frame_id % self.shape_c
@@ -284,15 +289,14 @@ class DataSource:
     def _check_shape(self, max_frame: int = 0, per_stack: bool = True):
         # Check if we've closed this prior to completion
         c, z, t, p = self._cztp_indices(max_frame, per_stack)
-        print(f"max_frame: {max_frame} c: {c} z: {z} t: {t} p: {p}")
-        print(f"XYCZTP: {self.shape} {self.positions}")
+        # print(f"max_frame: {max_frame} c: {c} z: {z} t: {t} p: {p}")
+        # print(f"XYCZTP: {self.shape} {self.positions}")
         if (
             (z < (self.shape_z - 1))
             or (c < (self.shape_c - 1))
             or (t < (self.shape_t - 1))
             or (p < (self.positions - 1))
         ):
-            print("IN HERE")
             # If we have, update our shape accordingly
             maxc, maxz, maxt, maxp = 0, 0, 0, 0
             for idx in range(max_frame + 1):
@@ -306,10 +310,10 @@ class DataSource:
             if self.metadata is not None:
                 self.metadata.shape_c, self.metadata.shape_z = maxc + 1, maxz + 1
                 self.metadata.shape_t, self.metadata.positions = maxt + 1, maxp + 1
-        print(
-            f"result c: {self.shape_c} z: {self.shape_z} "
-            f"t: {self.shape_t} p: {self.positions}"
-        )
+        # print(
+        #     f"result c: {self.shape_c} z: {self.shape_z} "
+        #     f"t: {self.shape_t} p: {self.positions}"
+        # )
 
     def _mode_checks(self) -> None:
         """Run additional checks after setting the mode.
@@ -381,4 +385,5 @@ class DataSource:
 
     def __del__(self):
         """Destructor"""
-        self.close()
+        if not self._closed:
+            self.close()

--- a/src/aslm/model/data_sources/data_source.py
+++ b/src/aslm/model/data_sources/data_source.py
@@ -269,29 +269,33 @@ class DataSource:
                 c = frame_id % self.shape_c
                 z = (frame_id // self.shape_c) % self.shape_z
 
-            t = frame_id // (self.shape_c * self.shape_z * self.positions)
-            p = (frame_id // (self.shape_c * self.shape_z)) % self.positions
+            t = (frame_id // (self.shape_c * self.shape_z)) % self.shape_t
+            p = frame_id // (self.shape_c * self.shape_z * self.shape_t)
+
         else:
             # Timepoint acquisition, only c varies faster than t
             c = frame_id % self.shape_c
             t = (frame_id // self.shape_c) % self.shape_t
             z = (frame_id // (self.shape_c * self.shape_t)) % self.shape_z
-            p = (frame_id // (self.shape_c * self.shape_t)) % self.positions
+            p = frame_id // (self.shape_c * self.shape_t * self.shape_z)
 
         return c, z, t, p
 
     def _check_shape(self, max_frame: int = 0, per_stack: bool = True):
         # Check if we've closed this prior to completion
         c, z, t, p = self._cztp_indices(max_frame, per_stack)
+        print(f"max_frame: {max_frame} c: {c} z: {z} t: {t} p: {p}")
+        print(f"XYCZTP: {self.shape} {self.positions}")
         if (
-            (z != 0)
-            or (c != 0)
+            (z < (self.shape_z - 1))
+            or (c < (self.shape_c - 1))
             or (t < (self.shape_t - 1))
             or (p < (self.positions - 1))
         ):
+            print("IN HERE")
             # If we have, update our shape accordingly
             maxc, maxz, maxt, maxp = 0, 0, 0, 0
-            for idx in range(max_frame):
+            for idx in range(max_frame + 1):
                 c, z, t, p = self._cztp_indices(idx, per_stack)
                 maxc = max(maxc, c)
                 maxz = max(maxz, z)
@@ -302,6 +306,10 @@ class DataSource:
             if self.metadata is not None:
                 self.metadata.shape_c, self.metadata.shape_z = maxc + 1, maxz + 1
                 self.metadata.shape_t, self.metadata.positions = maxt + 1, maxp + 1
+        print(
+            f"result c: {self.shape_c} z: {self.shape_z} "
+            f"t: {self.shape_t} p: {self.positions}"
+        )
 
     def _mode_checks(self) -> None:
         """Run additional checks after setting the mode.

--- a/src/aslm/model/data_sources/tiff_data_source.py
+++ b/src/aslm/model/data_sources/tiff_data_source.py
@@ -230,28 +230,24 @@ class TiffDataSource(DataSource):
         if self._closed and not internal:
             return
         # internal flag needed to avoid _check_shape call until last file is written
-        try:
-            if self._write_mode:
-                if not internal:
-                    self._check_shape(self._current_frame - 1, self.metadata.per_stack)
-                for ch in range(len(self.image)):
-                    self.image[ch].close()
-                    if self.is_ome and len(self._views) > 0:
-                        # Attach OME metadata at the end of the write
-                        tifffile.tiffcomment(
-                            self.file_name[ch],
-                            self.metadata.to_xml(
-                                c=ch,
-                                t=self._current_time,
-                                file_name=self.file_name,
-                                uid=self.uid,
-                                views=self._views,
-                            ).encode(),
-                        )
-            else:
-                self.image.close()
-        except (TypeError, AttributeError, ValueError):
-            # image wasn't instantiated, no need to close anything
-            pass
+        if self._write_mode:
+            if not internal:
+                self._check_shape(self._current_frame - 1, self.metadata.per_stack)
+            for ch in range(len(self.image)):
+                self.image[ch].close()
+                if self.is_ome and len(self._views) > 0:
+                    # Attach OME metadata at the end of the write
+                    tifffile.tiffcomment(
+                        self.file_name[ch],
+                        self.metadata.to_xml(
+                            c=ch,
+                            t=self._current_time,
+                            file_name=self.file_name,
+                            uid=self.uid,
+                            views=self._views,
+                        ).encode(),
+                    )
+        else:
+            self.image.close()
         if not internal:
             self._closed = True

--- a/src/aslm/model/data_sources/tiff_data_source.py
+++ b/src/aslm/model/data_sources/tiff_data_source.py
@@ -227,8 +227,10 @@ class TiffDataSource(DataSource):
 
     def close(self) -> None:
         try:
+            self._check_shape(self._current_frame, self.metadata.per_stack)
+
             if self._write_mode:
-                for ch in range(self.shape_c):
+                for ch in range(len(self.image)):
                     self.image[ch].close()
                     if self.is_ome and len(self._views) > 0:
                         # Attach OME metadata at the end of the write

--- a/src/aslm/model/data_sources/tiff_data_source.py
+++ b/src/aslm/model/data_sources/tiff_data_source.py
@@ -227,9 +227,8 @@ class TiffDataSource(DataSource):
 
     def close(self) -> None:
         try:
-            self._check_shape(self._current_frame, self.metadata.per_stack)
-
             if self._write_mode:
+                # self._check_shape(self._current_frame-1, self.metadata.per_stack)
                 for ch in range(len(self.image)):
                     self.image[ch].close()
                     if self.is_ome and len(self._views) > 0:

--- a/src/aslm/model/data_sources/tiff_data_source.py
+++ b/src/aslm/model/data_sources/tiff_data_source.py
@@ -229,6 +229,8 @@ class TiffDataSource(DataSource):
     def close(self, internal=False) -> None:
         if self._closed and not internal:
             return
+        if self.image is None:
+            return
         # internal flag needed to avoid _check_shape call until last file is written
         if self._write_mode:
             if not internal:

--- a/src/aslm/model/metadata_sources/bdv_metadata.py
+++ b/src/aslm/model/metadata_sources/bdv_metadata.py
@@ -2,8 +2,8 @@
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without
-# modification, are permitted for academic and research use only (subject to the limitations in the disclaimer below)
-# provided that the following conditions are met:
+# modification, are permitted for academic and research use only (subject to the
+# limitations in the disclaimer below) provided that the following conditions are met:
 
 #      * Redistributions of source code must retain the above copyright notice,
 #      this list of conditions and the following disclaimer.
@@ -137,7 +137,8 @@ class BigDataViewerMetadata(XMLMetadata):
                 }
                 bdv_dict["SequenceDescription"]["ViewSetups"]["ViewSetup"].append(d)
                 view_id += 1
-        # Finish up the Tile Attributes outside of the channels loop so we have one per tile
+        # Finish up the Tile Attributes outside of the channels loop so we have
+        # one per tile
         for p in range(self.positions):
             tile = {"id": {"text": str(p)}, "name": {"text": str(p)}}
             bdv_dict["SequenceDescription"]["ViewSetups"]["Attributes"][2][
@@ -220,8 +221,8 @@ class BigDataViewerMetadata(XMLMetadata):
             if base_path.attrib["type"] == "relative":
                 file_path = os.path.join(os.getcwd(), file_path)
 
-        # Get setups. Each setup represents a visualisation data source in the viewer that
-        # provides one image volume per timepoint
+        # Get setups. Each setup represents a visualisation data source in the viewer
+        # that provides one image volume per timepoint
         setups = [
             x.text for x in root.findall("SequenceDescription/ViewSetups/ViewSetup/id")
         ]

--- a/src/aslm/model/metadata_sources/bdv_metadata.py
+++ b/src/aslm/model/metadata_sources/bdv_metadata.py
@@ -169,10 +169,17 @@ class BigDataViewerMetadata(XMLMetadata):
 
                         # Construct centroid of volume matrix
                         # print(matrix_id, views[matrix_id])
-                        mat += (
-                            self.stage_positions_to_affine_matrix(**views[matrix_id])
-                            / self.shape_z
-                        )
+                        try:
+                            mat += (
+                                self.stage_positions_to_affine_matrix(
+                                    **views[matrix_id]
+                                )
+                                / self.shape_z
+                            )
+                        except IndexError:
+                            # We have most likely canceled in the middle of
+                            # an acquisition.
+                            pass
                     d = {"timepoint": t, "setup": view_id}
                     d["ViewTransform"] = {"type": "affine"}
                     d["ViewTransform"]["affine"] = {

--- a/src/aslm/model/metadata_sources/metadata.py
+++ b/src/aslm/model/metadata_sources/metadata.py
@@ -2,8 +2,8 @@
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without
-# modification, are permitted for academic and research use only (subject to the limitations in the disclaimer below)
-# provided that the following conditions are met:
+# modification, are permitted for academic and research use only (subject to the
+# limitations in the disclaimer below) provided that the following conditions are met:
 
 #      * Redistributions of source code must retain the above copyright notice,
 #      this list of conditions and the following disclaimer.
@@ -47,8 +47,8 @@ logger = logging.getLogger(p)
 class Metadata:
     def __init__(self) -> None:
         """
-        Store and convert internal representation of metadata (configuration, experiment, etc.)
-        to alternative file types.
+        Store and convert internal representation of metadata (configuration,
+        experiment, etc.) to alternative file types.
 
         Concept and some of the code borrowed from python-microscopy
         (https://github.com/python-microscopy/python-microscopy/).
@@ -118,11 +118,23 @@ class Metadata:
         self.shape_y = int(
             self.configuration["experiment"]["CameraParameters"]["y_pixels"]
         )
-        if (self.configuration["experiment"]["MicroscopeState"]["image_mode"] == "z-stack") or \
-            (self.configuration["experiment"]["MicroscopeState"]["image_mode"] == "ConstantVelocityAcquisition"):
-            self.shape_z = int(self.configuration["experiment"]["MicroscopeState"]["number_z_steps"])
-        elif (self.configuration["experiment"]["MicroscopeState"]["image_mode"] == "confocal-projection"):
-            self.shape_z = int(self.configuration["experiment"]["MicroscopeState"]["n_plane"])
+        if (
+            self.configuration["experiment"]["MicroscopeState"]["image_mode"]
+            == "z-stack"
+        ) or (
+            self.configuration["experiment"]["MicroscopeState"]["image_mode"]
+            == "ConstantVelocityAcquisition"
+        ):
+            self.shape_z = int(
+                self.configuration["experiment"]["MicroscopeState"]["number_z_steps"]
+            )
+        elif (
+            self.configuration["experiment"]["MicroscopeState"]["image_mode"]
+            == "confocal-projection"
+        ):
+            self.shape_z = int(
+                self.configuration["experiment"]["MicroscopeState"]["n_plane"]
+            )
         else:
             self.shape_z = 1
         self.shape_t = int(
@@ -130,7 +142,7 @@ class Metadata:
         )
         self.shape_c = sum(
             [
-                v["is_selected"] == True
+                v["is_selected"] is True
                 for k, v in self.configuration["experiment"]["MicroscopeState"][
                     "channels"
                 ].items()
@@ -151,7 +163,11 @@ class Metadata:
     def set_stack_order_from_configuration_experiment(self) -> None:
         self._per_stack = (
             self.configuration["experiment"]["MicroscopeState"]["stack_cycling_mode"]
-            == "per_stack" or self.configuration["experiment"]["MicroscopeState"]["conpro_cycling_mode"] == "per_stack"
+            == "per_stack"
+            or self.configuration["experiment"]["MicroscopeState"][
+                "conpro_cycling_mode"
+            ]
+            == "per_stack"
         )
 
     @property
@@ -167,23 +183,28 @@ class Metadata:
 
 class XMLMetadata(Metadata):
     """
-    This is a base class for dealing with metadata that is stored as an XML, e.g. in OME-TIFF or BigDataViewer.
-    There are multiple methods for storing XML. In OME-TIFF, the XML is stored in the header of the first OME-TIFF
-    file in a directory. In BigDataViewer, it is stored in a separate XML. Both have proprietary XML formats. To
-    address this, we store their metadata in a nested dictionary, defined by file_type_xml_dict()
-    (e.g. ome_tiff_xml_dict()) (see to_xml()). We then parse this nested dictionary into an XML file. Similarly,
-    we can parse from an XML file to a nested dictionary and map these values back to our internal representation
-    of metadata values (TODO: Not implemented. Will use xml_tools.parse_xml() for the first bit.)
+    This is a base class for dealing with metadata that is stored as an XML, e.g. in
+    OME-TIFF or BigDataViewer. There are multiple methods for storing XML. In OME-TIFF,
+    the XML is stored in the header of the first OME-TIFF file in a directory. In
+    BigDataViewer, it is stored in a separate XML. Both have proprietary XML formats. To
+    address this, we store their metadata in a nested dictionary, defined by
+    {file_type}_xml_dict() (e.g. ome_tiff_xml_dict()) (see to_xml()). We then parse this
+    nested dictionary into an XML file. Similarly, we can parse from an XML file to a
+    nested dictionary and map these values back to our internal representation of
+    metadata values (TODO: Not implemented. Will use xml_tools.parse_xml() for the
+    first bit.)
     """
 
     def write_xml(
         self, file_name: str, file_type: str, root: Optional[str] = None, **kw
     ) -> None:
-        """Write to XML file. Assumes we do not include the XML header in our nested metadata dictionary."""
+        """Write to XML file. Assumes we do not include the XML header in our nested
+        metadata dictionary."""
         xml = '<?xml version="1.0" encoding="UTF-8"?>'  # XML file header
-        # TODO: should os.path.basename be the default? Added this for BigDataViewer's relative path.
+        # TODO: should os.path.basename be the default? Added this for BigDataViewer's
+        # relative path.
         xml += self.to_xml(file_type, root, file_name=os.path.basename(file_name), **kw)
-        file_name = ".".join(file_name.split(".")[:-1]) + ".xml"
+        file_name = os.path.splitext(file_name)[0] + ".xml"
         with open(file_name, "w") as fp:
             fp.write(xml)
 
@@ -199,6 +220,7 @@ class XMLMetadata(Metadata):
             xml = xml_tools.dict_to_xml(d, root)
         except AttributeError:
             logging.debug(
-                f"Metadata Writer - I do not know how to export {file_type} metadata to XML."
+                f"Metadata Writer - I do not know how to export {file_type} "
+                f"metadata to XML."
             )
         return xml

--- a/src/aslm/model/metadata_sources/ome_tiff_metadata.py
+++ b/src/aslm/model/metadata_sources/ome_tiff_metadata.py
@@ -2,8 +2,8 @@
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without
-# modification, are permitted for academic and research use only (subject to the limitations in the disclaimer below)
-# provided that the following conditions are met:
+# modification, are permitted for academic and research use only (subject to the
+# limitations in the disclaimer below) provided that the following conditions are met:
 
 #      * Redistributions of source code must retain the above copyright notice,
 #      this list of conditions and the following disclaimer.
@@ -91,8 +91,8 @@ class OMETIFFMetadata(XMLMetadata):
             self.configuration["experiment"]["CameraParameters"]["y_pixels"]
         )
 
-        # The following two are commented since we split our TIFFs into one TIFF stack per
-        # channel per time point
+        # The following two are commented since we split our TIFFs into one TIFF stack
+        # per channel per time point
         ome_dict["Image"]["Pixels"]["SizeT"] = int(
             self.configuration["experiment"]["MicroscopeState"]["timepoints"]
         )

--- a/src/aslm/model/metadata_sources/ome_tiff_metadata.py
+++ b/src/aslm/model/metadata_sources/ome_tiff_metadata.py
@@ -84,49 +84,41 @@ class OMETIFFMetadata(XMLMetadata):
             "Type"
         ] = "uint16"  # Hardcoded from SharedNDArray call
 
-        ome_dict["Image"]["Pixels"]["SizeX"] = int(
-            self.configuration["experiment"]["CameraParameters"]["x_pixels"]
-        )
-        ome_dict["Image"]["Pixels"]["SizeY"] = int(
-            self.configuration["experiment"]["CameraParameters"]["y_pixels"]
-        )
+        ome_dict["Image"]["Pixels"]["SizeX"] = self.shape_x
+        ome_dict["Image"]["Pixels"]["SizeY"] = self.shape_y
 
         # The following two are commented since we split our TIFFs into one TIFF stack
         # per channel per time point
-        ome_dict["Image"]["Pixels"]["SizeT"] = int(
-            self.configuration["experiment"]["MicroscopeState"]["timepoints"]
-        )
-        ome_dict["Image"]["Pixels"]["SizeC"] = len(
-            self.configuration["experiment"]["MicroscopeState"]["channels"]
-        )
+        ome_dict["Image"]["Pixels"]["SizeT"] = self.shape_t
+        ome_dict["Image"]["Pixels"]["SizeC"] = self.shape_c
 
         ome_dict["Image"]["Pixels"]["DimensionOrder"] = "XYZCT"
-        z_steps = 1
-        if (
-            self.configuration["experiment"]["MicroscopeState"]["image_mode"]
-            == "z-stack"
-        ):
-            z_steps = int(
-                self.configuration["experiment"]["MicroscopeState"]["number_z_steps"]
-            )
-            ome_dict["Image"]["Pixels"]["PhysicalSizeZ"] = float(
-                self.configuration["experiment"]["MicroscopeState"]["step_size"]
-            )
-        elif (
-            self.configuration["experiment"]["MicroscopeState"]["image_mode"]
-            == "confocal-projection"
-        ):
-            z_steps = int(
-                self.configuration["experiment"]["MicroscopeState"]["n_plane"]
-            )
-            ome_dict["Image"]["Pixels"]["PhysicalSizeZ"] = (
-                float(self.configuration["experiment"]["MicroscopeState"]["offset_end"])
-                - float(
-                    self.configuration["experiment"]["MicroscopeState"]["offset_start"]
-                )
-            ) / (z_steps - 1)
+        # z_steps = 1
+        # if (
+        #     self.configuration["experiment"]["MicroscopeState"]["image_mode"]
+        #     == "z-stack"
+        # ):
+        #     z_steps = int(
+        #         self.configuration["experiment"]["MicroscopeState"]["number_z_steps"]
+        #     )
+        #     ome_dict["Image"]["Pixels"]["PhysicalSizeZ"] = float(
+        #         self.configuration["experiment"]["MicroscopeState"]["step_size"]
+        #     )
+        # elif (
+        #     self.configuration["experiment"]["MicroscopeState"]["image_mode"]
+        #     == "confocal-projection"
+        # ):
+        #     z_steps = int(
+        #         self.configuration["experiment"]["MicroscopeState"]["n_plane"]
+        #     )
+        #     ome_dict["Image"]["Pixels"]["PhysicalSizeZ"] = (
+        #         float(self.configuration["experiment"]["MicroscopeState"]["offset_end"])
+        #         - float(
+        #             self.configuration["experiment"]["MicroscopeState"]["offset_start"]
+        #         )
+        #     ) / (z_steps - 1)
 
-        ome_dict["Image"]["Pixels"]["SizeZ"] = z_steps
+        ome_dict["Image"]["Pixels"]["SizeZ"] = self.shape_z
 
         zoom = self.configuration["experiment"]["MicroscopeState"]["zoom"]
         pixel_size = float(
@@ -158,7 +150,7 @@ class OMETIFFMetadata(XMLMetadata):
                         "FirstT": str(t),
                         "FirstZ": "0",
                         "IFD": "0",
-                        "PlaneCount": str(z_steps),
+                        "PlaneCount": str(self.shape_z),
                     }
                     d["UUID"] = {
                         "FileName": os.path.basename(fn),

--- a/test/log_files/test_log_functions.py
+++ b/test/log_files/test_log_functions.py
@@ -74,25 +74,3 @@ def test_log_setup(logging_configuration, logging_path):
     log_setup(logging_configuration, logging_path)
 
     assert Path.joinpath(todays_path, "performance.log").is_file()
-
-
-#     delete_folder(todays_path)
-
-
-# def delete_folder(top):
-#     # https://docs.python.org/3/library/os.html#os.walk
-#     # Delete everything reachable from the directory named in "top",
-#     # assuming there are no symbolic links.
-#     # CAUTION:  This is dangerous!  For example, if top == '/', it
-#     # could delete all your disk files.
-#     import os
-
-#     print(top)
-
-#     for root, dirs, files in os.walk(top, topdown=False):
-#         for name in files:
-#             os.remove(os.path.join(root, name))
-#         for name in dirs:
-#             os.rmdir(os.path.join(root, name))
-
-#     os.rmdir(top)

--- a/test/model/data_sources/test_bdv_data_source.py
+++ b/test/model/data_sources/test_bdv_data_source.py
@@ -65,8 +65,8 @@ def test_bdv_write(multiposition, per_stack, z_stack, stop_early):
     ds.close()
 
     try:
+        xml_fn = os.path.splitext(ds.file_name)[0] + ".xml"
         os.remove(ds.file_name)
-        xml_fn = ".".join(ds.file_name.split(".")[:-1]) + ".xml"
         os.remove(xml_fn)
     except PermissionError:
         # Windows seems to think these files are still open

--- a/test/model/data_sources/test_data_source.py
+++ b/test/model/data_sources/test_data_source.py
@@ -1,3 +1,6 @@
+import numpy as np
+
+
 def test_data_source_mode():
     from aslm.model.data_sources.data_source import DataSource
 
@@ -13,3 +16,76 @@ def test_data_source_mode():
     # set unknown mode, default to read
     ds.mode = "goblin"
     assert ds.mode == "r"
+
+
+def test_data_source_cztp_indices():
+    import itertools
+    from aslm.model.data_sources.data_source import DataSource
+
+    MAX = 25
+
+    ds = DataSource()
+
+    ds.shape_c = np.random.randint(1, MAX)
+    ds.shape_z = 1
+    ds.shape_t = np.random.randint(1, MAX)
+    ds.positions = np.random.randint(1, MAX)
+    n_inds = ds.shape_c * ds.shape_z * ds.shape_t * ds.positions
+
+    print(f"n_inds : {n_inds}")
+
+    cztp_inds = itertools.product(
+        range(ds.positions), range(ds.shape_z), range(ds.shape_t), range(ds.shape_c)
+    )
+
+    for i, inds in zip(range(n_inds), cztp_inds):
+        c, z, t, p = ds._cztp_indices(i, False)
+        pt, zt, tt, ct = inds
+        assert c == ct
+        assert z == zt
+        assert t == tt
+        assert p == pt
+
+    print(
+        f"Shape (XYCZTP): {ds.shape} {ds.positions} "
+        f"Final (CZTP): {ds._cztp_indices(n_inds-1, False)}"
+    )
+
+    ds.shape_z = np.random.randint(2, MAX)
+    n_inds = ds.shape_c * ds.shape_z * ds.shape_t * ds.positions
+
+    cztp_inds = itertools.product(
+        range(ds.positions), range(ds.shape_t), range(ds.shape_z), range(ds.shape_c)
+    )
+
+    for i, inds in zip(range(n_inds), cztp_inds):
+        c, z, t, p = ds._cztp_indices(i, False)
+        pt, tt, zt, ct = inds
+        assert c == ct
+        assert z == zt
+        assert t == tt
+        assert p == pt
+
+    print(
+        f"Shape (XYCZTP): {ds.shape} {ds.positions} "
+        f"Final (CZTP): {ds._cztp_indices(n_inds-1, False)}"
+    )
+
+    cztp_inds = itertools.product(
+        range(ds.positions), range(ds.shape_t), range(ds.shape_c), range(ds.shape_z)
+    )
+
+    for i, inds in zip(range(n_inds), cztp_inds):
+        c, z, t, p = ds._cztp_indices(i, True)
+        pt, tt, ct, zt = inds
+        assert c == ct
+        assert z == zt
+        assert t == tt
+        assert p == pt
+
+    print(
+        f"Shape (XYCZTP): {ds.shape} {ds.positions} "
+        f"Final (CZTP): {ds._cztp_indices(n_inds-1, False)}"
+    )
+
+    # assert False

--- a/test/model/data_sources/test_tiff_data_source.py
+++ b/test/model/data_sources/test_tiff_data_source.py
@@ -122,4 +122,8 @@ def delete_folder(top):
                 # Windows locks these files sometimes
                 pass
         for name in dirs:
-            os.rmdir(os.path.join(root, name))
+            try:
+                os.rmdir(os.path.join(root, name))
+            except OSError:
+                # One of the directories containing a file Windows decided to lock
+                pass

--- a/test/model/data_sources/test_tiff_data_source.py
+++ b/test/model/data_sources/test_tiff_data_source.py
@@ -40,7 +40,8 @@ def test_tiff_write_read(is_ome, multiposition, per_stack, z_stack, stop_early):
             "stack_cycling_mode"
         ] == "per_slice"
 
-    os.mkdir("test_save_dir")
+    if not os.path.exists("test_save_dir"):
+        os.mkdir("test_save_dir")
 
     # Establish a TIFF data source
     if is_ome:
@@ -115,7 +116,11 @@ def delete_folder(dir):
         if os.path.isdir(cp):
             delete_folder(cp)
         elif os.path.isfile(cp):
-            os.remove(cp)
+            try:
+                os.remove(cp)
+            except PermissionError:
+                # Windows permission error, file is still open somehow
+                pass
         else:
             raise TypeError(f"Unknown entity {cand} cannot be deleted. Aborting.")
 

--- a/test/model/data_sources/test_tiff_data_source.py
+++ b/test/model/data_sources/test_tiff_data_source.py
@@ -106,22 +106,20 @@ def test_tiff_write_read(is_ome, multiposition, per_stack, z_stack, stop_early):
         delete_folder("test_save_dir")
 
 
-def delete_folder(dir):
-    bn = os.path.basename(dir)
-    if bn == "." or bn == "..":
-        raise OSError("Cannot delete the directory '{dir}'.")
+def delete_folder(top):
+    # https://docs.python.org/3/library/os.html#os.walk
+    # Delete everything reachable from the directory named in "top",
+    # assuming there are no symbolic links.
+    # CAUTION:  This is dangerous!  For example, if top == '/', it
+    # could delete all your disk files.
+    import os
 
-    for cand in os.listdir(dir):
-        cp = os.path.join(dir, cand)
-        if os.path.isdir(cp):
-            delete_folder(cp)
-        elif os.path.isfile(cp):
+    for root, dirs, files in os.walk(top, topdown=False):
+        for name in files:
             try:
-                os.remove(cp)
+                os.remove(os.path.join(root, name))
             except PermissionError:
-                # Windows permission error, file is still open somehow
+                # Windows locks these files sometimes
                 pass
-        else:
-            raise TypeError(f"Unknown entity {cand} cannot be deleted. Aborting.")
-
-    os.rmdir(dir)
+        for name in dirs:
+            os.rmdir(os.path.join(root, name))

--- a/test/model/data_sources/test_tiff_data_source.py
+++ b/test/model/data_sources/test_tiff_data_source.py
@@ -5,7 +5,8 @@ import pytest
 @pytest.mark.parametrize("multiposition", [True, False])
 @pytest.mark.parametrize("per_stack", [True, False])
 @pytest.mark.parametrize("z_stack", [True, False])
-def test_tiff_write_read(is_ome, multiposition, per_stack, z_stack):
+@pytest.mark.parametrize("stop_early", [False])
+def test_tiff_write_read(is_ome, multiposition, per_stack, z_stack, stop_early):
     import os
     import numpy as np
 
@@ -50,6 +51,8 @@ def test_tiff_write_read(is_ome, multiposition, per_stack, z_stack):
     for i in range(n_images):
         ds.write(data[i, ...].squeeze())
         file_names_raw.extend(ds.file_name)
+        if stop_early and np.random.rand() > 0.5:
+            break
     ds.close()
 
     file_names = []

--- a/test/model/data_sources/test_tiff_data_source.py
+++ b/test/model/data_sources/test_tiff_data_source.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 
 
@@ -5,13 +7,17 @@ import pytest
 @pytest.mark.parametrize("multiposition", [True, False])
 @pytest.mark.parametrize("per_stack", [True, False])
 @pytest.mark.parametrize("z_stack", [True, False])
-@pytest.mark.parametrize("stop_early", [False])
+@pytest.mark.parametrize("stop_early", [True, False])
 def test_tiff_write_read(is_ome, multiposition, per_stack, z_stack, stop_early):
-    import os
     import numpy as np
 
     from aslm.model.dummy import DummyModel
     from aslm.model.data_sources.tiff_data_source import TiffDataSource
+
+    print(
+        f"Conditions are is_ome: {is_ome} multiposition: {multiposition} "
+        f"per_stack: {per_stack} z_stack: {z_stack} stop_early: {stop_early}"
+    )
 
     # Set up model with a random number of z-steps to modulate the shape
     model = DummyModel()
@@ -34,11 +40,13 @@ def test_tiff_write_read(is_ome, multiposition, per_stack, z_stack, stop_early):
             "stack_cycling_mode"
         ] == "per_slice"
 
+    os.mkdir("test_save_dir")
+
     # Establish a TIFF data source
     if is_ome:
-        fn = "test.ome.tif"
+        fn = "./test_save_dir/test.ome.tif"
     else:
-        fn = ""
+        fn = "./test_save_dir/test.tif"
     ds = TiffDataSource(fn)
     ds.set_metadata_from_configuration_experiment(model.configuration)
 
@@ -55,38 +63,60 @@ def test_tiff_write_read(is_ome, multiposition, per_stack, z_stack, stop_early):
             break
     ds.close()
 
+    # Cannot use list(set()) trick here because ordering is important
     file_names = []
     for fn in file_names_raw:
         if fn not in file_names:
             file_names.append(fn)
-    print(file_names)
-
-    # For each file...
-    for i, fn in enumerate(file_names):
-        ds2 = TiffDataSource(fn, "r")
-        # Make sure XYZ size is correct (and C and T are each of size 1)
-        assert (
-            (ds2.shape_x == ds.shape_x)
-            and (ds2.shape_y == ds.shape_y)
-            and (ds2.shape_c == 1)
-            and (ds2.shape_z == ds.shape_z)
-            and (ds2.shape_t == 1)
-        )
-        # Make sure the data copied properly
-        np.testing.assert_equal(
-            ds2.data, data[i * ds.shape_z : (i + 1) * ds.shape_z, ...].squeeze()
-        )
-        ds2.close()
+    # print(file_names)
 
     try:
-        # Clean up
-        dirs = []
-        for fn in file_names:
-            os.remove(fn)
-            dirs.append(os.path.dirname(fn))
-        for dn in list(set(dirs)):
-            if dn != ".":
-                os.rmdir(dn)
-    except PermissionError:
-        # Windows seems to think these files are still open
-        pass
+        # For each file...
+        for i, fn in enumerate(file_names):
+            ds2 = TiffDataSource(fn, "r")
+            # Make sure XYZ size is correct (and C and T are each of size 1)
+            assert (
+                (ds2.shape_x == ds.shape_x)
+                and (ds2.shape_y == ds.shape_y)
+                and (ds2.shape_c == 1)
+                and (ds2.shape_t == 1)
+                and (ds2.shape_z == ds.shape_z)
+            )
+            # Make sure the data copied properly
+            np.testing.assert_equal(
+                ds2.data, data[i * ds.shape_z : (i + 1) * ds.shape_z, ...].squeeze()
+            )
+            ds2.close()
+    except IndexError as e:
+        if stop_early:
+            # This file was not written
+            pass
+        else:
+            raise e
+    except AssertionError as e:
+        if stop_early:
+            # This file has an underfilled axes
+            pass
+        else:
+            raise e
+    except Exception as e:
+        raise e
+    finally:
+        delete_folder("test_save_dir")
+
+
+def delete_folder(dir):
+    bn = os.path.basename(dir)
+    if bn == "." or bn == "..":
+        raise OSError("Cannot delete the directory '{dir}'.")
+
+    for cand in os.listdir(dir):
+        cp = os.path.join(dir, cand)
+        if os.path.isdir(cp):
+            delete_folder(cp)
+        elif os.path.isfile(cp):
+            os.remove(cp)
+        else:
+            raise TypeError(f"Unknown entity {cand} cannot be deleted. Aborting.")
+
+    os.rmdir(dir)

--- a/test/model/features/test_image_writer.py
+++ b/test/model/features/test_image_writer.py
@@ -33,24 +33,20 @@ def test_image_write(image_writer):
     delete_folder("test_save_dir")
 
 
-def delete_folder(dir):
+def delete_folder(top):
+    # https://docs.python.org/3/library/os.html#os.walk
+    # Delete everything reachable from the directory named in "top",
+    # assuming there are no symbolic links.
+    # CAUTION:  This is dangerous!  For example, if top == '/', it
+    # could delete all your disk files.
     import os
 
-    bn = os.path.basename(dir)
-    if bn == "." or bn == "..":
-        raise OSError("Cannot delete the directory '{dir}'.")
-
-    for cand in os.listdir(dir):
-        cp = os.path.join(dir, cand)
-        if os.path.isdir(cp):
-            delete_folder(cp)
-        elif os.path.isfile(cp):
+    for root, dirs, files in os.walk(top, topdown=False):
+        for name in files:
             try:
-                os.remove(cp)
+                os.remove(os.path.join(root, name))
             except PermissionError:
-                # Windows permission error, file is still open somehow
+                # Windows locks these files sometimes
                 pass
-        else:
-            raise TypeError(f"Unknown entity {cand} cannot be deleted. Aborting.")
-
-    os.rmdir(dir)
+        for name in dirs:
+            os.rmdir(os.path.join(root, name))

--- a/test/model/features/test_image_writer.py
+++ b/test/model/features/test_image_writer.py
@@ -45,7 +45,11 @@ def delete_folder(dir):
         if os.path.isdir(cp):
             delete_folder(cp)
         elif os.path.isfile(cp):
-            os.remove(cp)
+            try:
+                os.remove(cp)
+            except PermissionError:
+                # Windows permission error, file is still open somehow
+                pass
         else:
             raise TypeError(f"Unknown entity {cand} cannot be deleted. Aborting.")
 

--- a/test/model/features/test_image_writer.py
+++ b/test/model/features/test_image_writer.py
@@ -30,4 +30,23 @@ def test_image_write(image_writer):
 
     image_writer.save_image(list(range(image_writer.model.number_of_frames)))
 
-    # TODO: Delete files
+    delete_folder("test_save_dir")
+
+
+def delete_folder(dir):
+    import os
+
+    bn = os.path.basename(dir)
+    if bn == "." or bn == "..":
+        raise OSError("Cannot delete the directory '{dir}'.")
+
+    for cand in os.listdir(dir):
+        cp = os.path.join(dir, cand)
+        if os.path.isdir(cp):
+            delete_folder(cp)
+        elif os.path.isfile(cp):
+            os.remove(cp)
+        else:
+            raise TypeError(f"Unknown entity {cand} cannot be deleted. Aborting.")
+
+    os.rmdir(dir)

--- a/test/model/features/test_image_writer.py
+++ b/test/model/features/test_image_writer.py
@@ -49,4 +49,8 @@ def delete_folder(top):
                 # Windows locks these files sometimes
                 pass
         for name in dirs:
-            os.rmdir(os.path.join(root, name))
+            try:
+                os.rmdir(os.path.join(root, name))
+            except OSError:
+                # One of the directories containing a file Windows decided to lock
+                pass

--- a/test/model/metadata_sources/test_ome_tiff_metadata.py
+++ b/test/model/metadata_sources/test_ome_tiff_metadata.py
@@ -41,22 +41,20 @@ def test_ome_metadata_valid(dummy_model):
     assert "No validation errors found." in output
 
 
-def delete_folder(dir):
-    bn = os.path.basename(dir)
-    if bn == "." or bn == "..":
-        raise OSError("Cannot delete the directory '{dir}'.")
+def delete_folder(top):
+    # https://docs.python.org/3/library/os.html#os.walk
+    # Delete everything reachable from the directory named in "top",
+    # assuming there are no symbolic links.
+    # CAUTION:  This is dangerous!  For example, if top == '/', it
+    # could delete all your disk files.
+    import os
 
-    for cand in os.listdir(dir):
-        cp = os.path.join(dir, cand)
-        if os.path.isdir(cp):
-            delete_folder(cp)
-        elif os.path.isfile(cp):
+    for root, dirs, files in os.walk(top, topdown=False):
+        for name in files:
             try:
-                os.remove(cp)
+                os.remove(os.path.join(root, name))
             except PermissionError:
-                # Windows permission error, file is still open somehow
+                # Windows locks these files sometimes
                 pass
-        else:
-            raise TypeError(f"Unknown entity {cand} cannot be deleted. Aborting.")
-
-    os.rmdir(dir)
+        for name in dirs:
+            os.rmdir(os.path.join(root, name))

--- a/test/model/metadata_sources/test_ome_tiff_metadata.py
+++ b/test/model/metadata_sources/test_ome_tiff_metadata.py
@@ -41,16 +41,18 @@ def test_ome_metadata_valid(dummy_model):
     assert "No validation errors found." in output
 
 
-def delete_folder(top):
-    # https://docs.python.org/3/library/os.html#os.walk
-    # Delete everything reachable from the directory named in "top",
-    # assuming there are no symbolic links.
-    # CAUTION:  This is dangerous!  For example, if top == '/', it
-    # could delete all your disk files.
-    import os
+def delete_folder(dir):
+    bn = os.path.basename(dir)
+    if bn == "." or bn == "..":
+        raise OSError("Cannot delete the directory '{dir}'.")
 
-    for root, dirs, files in os.walk(top, topdown=False):
-        for name in files:
-            os.remove(os.path.join(root, name))
-        for name in dirs:
-            os.rmdir(os.path.join(root, name))
+    for cand in os.listdir(dir):
+        cp = os.path.join(dir, cand)
+        if os.path.isdir(cp):
+            delete_folder(cp)
+        elif os.path.isfile(cp):
+            os.remove(cp)
+        else:
+            raise TypeError(f"Unknown entity {cand} cannot be deleted. Aborting.")
+
+    os.rmdir(dir)

--- a/test/model/metadata_sources/test_ome_tiff_metadata.py
+++ b/test/model/metadata_sources/test_ome_tiff_metadata.py
@@ -51,7 +51,11 @@ def delete_folder(dir):
         if os.path.isdir(cp):
             delete_folder(cp)
         elif os.path.isfile(cp):
-            os.remove(cp)
+            try:
+                os.remove(cp)
+            except PermissionError:
+                # Windows permission error, file is still open somehow
+                pass
         else:
             raise TypeError(f"Unknown entity {cand} cannot be deleted. Aborting.")
 

--- a/test/model/metadata_sources/test_ome_tiff_metadata.py
+++ b/test/model/metadata_sources/test_ome_tiff_metadata.py
@@ -57,4 +57,8 @@ def delete_folder(top):
                 # Windows locks these files sometimes
                 pass
         for name in dirs:
-            os.rmdir(os.path.join(root, name))
+            try:
+                os.rmdir(os.path.join(root, name))
+            except OSError:
+                # One of the directories containing a file Windows decided to lock
+                pass


### PR DESCRIPTION
This stabilizes our existing data sources. In particular, it is now possible to cancel in the middle of saving without throwing an error that crashes ASLM and keep the data already collected in a readable format (cleanup). This is on my way to creating the new Zarr data source and adding N5 to BDV, but I figured I'd split this off since it's already getting quite large.

I also flipped the order of position and time again. I'm still not sure which way to go with it, but we can always flip it back.

This fixes #331.