### PR TITLE
428 resizable popup camera view window

### DIFF
--- a/src/aslm/controller/controller.py
+++ b/src/aslm/controller/controller.py
@@ -1094,6 +1094,7 @@ class Controller:
                 camera_view_controller = CameraViewController(
                     popup_window.camera_view, self
                 )
+                popup_window.popup.bind("<Configure>", camera_view_controller.resize)
                 self.additional_microscopes[microscope_name][
                     "camera_view_controller"
                 ] = camera_view_controller

--- a/src/aslm/controller/sub_controllers/camera_view_controller.py
+++ b/src/aslm/controller/sub_controllers/camera_view_controller.py
@@ -1102,12 +1102,15 @@ class CameraViewController(GUIController):
     def refresh(self, width, height):
         if width == self.width and height == self.height:
             return
-        self.canvas_width = width - 151
-        self.canvas_height = height - 85
-        self.view.canvas.config(width=self.canvas_width, height=self.canvas_height)
-        self.view.update_idletasks()
-        self.canvas_width = min(self.canvas_width, self.canvas_height)
-        self.canvas_height = self.canvas_width
+        if not self.view.is_docked:
+            self.canvas_width = width - 151
+            self.canvas_height = height - 85
+            self.view.canvas.config(width=self.canvas_width, height=self.canvas_height)
+            self.view.update_idletasks()
+            self.canvas_width = min(self.canvas_width, self.canvas_height)
+            self.canvas_height = self.canvas_width
+        else:
+            self.canvas_width, self.canvas_height = 512, 512
         if self.view.is_popup:
             self.width, self.height = self.view.winfo_width(), self.view.winfo_height()
         else:

--- a/src/aslm/controller/sub_controllers/camera_view_controller.py
+++ b/src/aslm/controller/sub_controllers/camera_view_controller.py
@@ -1089,7 +1089,9 @@ class CameraViewController(GUIController):
         self.ilastik_mask_ready_lock.release()
 
     def resize(self, event):
-        if event.widget != self.view:
+        if self.view.is_popup == False and event.widget != self.view:
+            return
+        if self.view.is_popup == True and event.widget.widgetName != "toplevel":
             return
         if self.resizie_event_id:
             self.view.after_cancel(self.resizie_event_id)

--- a/src/aslm/controller/sub_controllers/camera_view_controller.py
+++ b/src/aslm/controller/sub_controllers/camera_view_controller.py
@@ -158,8 +158,8 @@ class CameraViewController(GUIController):
         self.zoom_height = self.view.canvas_height
         self.canvas_width_scale = 4
         self.canvas_height_scale = 4
-        self.original_image_height = None
-        self.original_image_width = None
+        self.original_image_height = 2014
+        self.original_image_width = 2014
         self.number_of_slices = 0
         self.image_volume = None
         self.total_images_per_volume = 0
@@ -1103,10 +1103,19 @@ class CameraViewController(GUIController):
         if width == self.width and height == self.height:
             return
         self.canvas_width = width - 151
-        self.canvas_height = self.canvas_width
+        self.canvas_height = height - 85
         self.view.canvas.config(width=self.canvas_width, height=self.canvas_height)
         self.view.update_idletasks()
+        self.canvas_width = min(self.canvas_width, self.canvas_height)
+        self.canvas_height = self.canvas_width
         if self.view.is_popup:
             self.width, self.height = self.view.winfo_width(), self.view.winfo_height()
         else:
             self.width, self.height = width, height
+
+        # if resize the window during acquisition, the image showing should be updated
+        self.canvas_width_scale = float(self.original_image_width / self.canvas_width)
+        self.canvas_height_scale = float(
+            self.original_image_height / self.canvas_height
+        )
+        self.reset_display(False)

--- a/src/aslm/controller/sub_controllers/camera_view_controller.py
+++ b/src/aslm/controller/sub_controllers/camera_view_controller.py
@@ -88,6 +88,14 @@ class CameraViewController(GUIController):
             "<<ComboboxSelected>>", self.update_display_state
         )
 
+        self.resizie_event_id = None
+        self.view.bind("<Configure>", self.resize)
+        self.width, self.height = 663, 597
+        self.canvas_width, self.canvas_height = (
+            self.view.canvas_width,
+            self.view.canvas_height,
+        )
+
         # Left Click Binding
         # self.canvas.bind("<Button-1>", self.left_click)
 
@@ -380,13 +388,13 @@ class CameraViewController(GUIController):
             "microscopes"
         ][microscope_name]["zoom"]["pixel_size"][zoom_value]
 
-        offset_x = (
+        offset_x = int(
             (self.move_to_x - current_center_x)
             / self.zoom_scale
             * self.canvas_width_scale
             * pixel_size
         )
-        offset_y = (
+        offset_y = int(
             (self.move_to_y - current_center_y)
             / self.zoom_scale
             * self.canvas_height_scale
@@ -430,14 +438,12 @@ class CameraViewController(GUIController):
         --------
         >>> self.reset_display()
         """
-        self.zoom_rect = np.array(
-            [[0, self.view.canvas_width], [0, self.view.canvas_height]]
-        )
+        self.zoom_width = self.canvas_width
+        self.zoom_height = self.canvas_height
+        self.zoom_rect = np.array([[0, self.zoom_width], [0, self.zoom_height]])
         self.zoom_offset = np.array([[0], [0]])
         self.zoom_value = 1
         self.zoom_scale = 1
-        self.zoom_width = self.view.canvas_width
-        self.zoom_height = self.view.canvas_height
         if display_flag:
             self.process_image()
 
@@ -533,20 +539,20 @@ class CameraViewController(GUIController):
         # crosshair
         crosshair_x = (self.zoom_rect[0][0] + self.zoom_rect[0][1]) / 2
         crosshair_y = (self.zoom_rect[1][0] + self.zoom_rect[1][1]) / 2
-        if crosshair_x < 0 or crosshair_x >= self.view.canvas_width:
+        if crosshair_x < 0 or crosshair_x >= self.canvas_width:
             crosshair_x = -1
-        if crosshair_y < 0 or crosshair_y >= self.view.canvas_height:
+        if crosshair_y < 0 or crosshair_y >= self.canvas_height:
             crosshair_y = -1
         self.crosshair_x = int(crosshair_x)
         self.crosshair_y = int(crosshair_y)
 
         self.zoom_image = self.image[
-            y_start_index
-            * self.canvas_height_scale : y_end_index
-            * self.canvas_height_scale,
-            x_start_index
-            * self.canvas_width_scale : x_end_index
-            * self.canvas_width_scale,
+            int(y_start_index * self.canvas_height_scale) : int(
+                y_end_index * self.canvas_height_scale
+            ),
+            int(x_start_index * self.canvas_width_scale) : int(
+                x_end_index * self.canvas_width_scale
+            ),
         ]
 
     def left_click(self, event):
@@ -613,7 +619,7 @@ class CameraViewController(GUIController):
         -------
         >>> self.down_sample_image()
         """
-        sx, sy = self.view.canvas_width, self.view.canvas_height
+        sx, sy = self.canvas_width, self.canvas_height
         self.down_sampled_image = cv2.resize(self.zoom_image, (sx, sy))
 
     def scale_image_intensity(self):
@@ -690,11 +696,9 @@ class CameraViewController(GUIController):
         self.total_images_per_volume = self.number_of_channels * self.number_of_slices
         self.original_image_width = int(camera_parameters["x_pixels"])
         self.original_image_height = int(camera_parameters["y_pixels"])
-        self.canvas_width_scale = int(
-            self.original_image_width / self.view.canvas_width
-        )
-        self.canvas_height_scale = int(
-            self.original_image_height / self.view.canvas_height
+        self.canvas_width_scale = float(self.original_image_width / self.canvas_width)
+        self.canvas_height_scale = float(
+            self.original_image_height / self.canvas_height
         )
         self.reset_display(False)
 
@@ -1083,3 +1087,24 @@ class CameraViewController(GUIController):
         """
         self.ilastik_seg_mask = cv2.applyColorMap(mask, self.mask_color_table)
         self.ilastik_mask_ready_lock.release()
+
+    def resize(self, event):
+        if event.widget != self.view:
+            return
+        if self.resizie_event_id:
+            self.view.after_cancel(self.resizie_event_id)
+        self.resizie_event_id = self.view.after(
+            1000, lambda: self.refresh(event.width, event.height)
+        )
+
+    def refresh(self, width, height):
+        if width == self.width and height == self.height:
+            return
+        self.canvas_width = width - 151
+        self.canvas_height = self.canvas_width
+        self.view.canvas.config(width=self.canvas_width, height=self.canvas_height)
+        self.view.update_idletasks()
+        if self.view.is_popup:
+            self.width, self.height = self.view.winfo_width(), self.view.winfo_height()
+        else:
+            self.width, self.height = width, height

--- a/src/aslm/view/custom_widgets/DockableNotebook.py
+++ b/src/aslm/view/custom_widgets/DockableNotebook.py
@@ -194,6 +194,7 @@ class DockableNotebook(ttk.Notebook):
         tk.Wm.protocol(tab, "WM_DELETE_WINDOW", lambda: self.dismiss(tab, tab_text))
         if tab_text == "Camera View":
             tk.Wm.minsize(tab, 663, 597)
+            tab.is_docked = False
 
     def dismiss(self, tab, tab_text):
         """Dismisses the popup menu
@@ -224,3 +225,4 @@ class DockableNotebook(ttk.Notebook):
         self.tab_list.append(tab)
         if tab_text == "Camera View":
             tab.canvas.configure(width=512, height=512)
+            tab.is_docked = True

--- a/src/aslm/view/custom_widgets/DockableNotebook.py
+++ b/src/aslm/view/custom_widgets/DockableNotebook.py
@@ -192,6 +192,8 @@ class DockableNotebook(ttk.Notebook):
         # self.root.wm_title(tab, tab_text)
         tk.Wm.title(tab, tab_text)
         tk.Wm.protocol(tab, "WM_DELETE_WINDOW", lambda: self.dismiss(tab, tab_text))
+        if tab_text == "Camera View":
+            tk.Wm.minsize(tab, 663, 597)
 
     def dismiss(self, tab, tab_text):
         """Dismisses the popup menu
@@ -220,3 +222,5 @@ class DockableNotebook(ttk.Notebook):
             self.insert("end", tab)
         self.tab(tab, text=tab_text)
         self.tab_list.append(tab)
+        if tab_text == "Camera View":
+            tab.canvas.configure(width=512, height=512)

--- a/src/aslm/view/main_window_content/display_notebook.py
+++ b/src/aslm/view/main_window_content/display_notebook.py
@@ -145,6 +145,7 @@ class CameraTab(tk.Frame):
 
         # Frame for the Image View
         self.is_popup = False
+        self.is_docked = True
         self.canvas_width, self.canvas_height = 512, 512
         self.canvas = tk.Canvas(
             self.cam_image, width=self.canvas_width, height=self.canvas_height

--- a/src/aslm/view/main_window_content/display_notebook.py
+++ b/src/aslm/view/main_window_content/display_notebook.py
@@ -143,7 +143,8 @@ class CameraTab(tk.Frame):
         self.cam_image = ttk.Frame(self)
         self.cam_image.grid(row=0, column=0, rowspan=3, sticky=tk.NSEW)
 
-        # Frame for the Waveforms
+        # Frame for the Image View
+        self.is_popup = False
         self.canvas_width, self.canvas_height = 512, 512
         self.canvas = tk.Canvas(
             self.cam_image, width=self.canvas_width, height=self.canvas_height

--- a/src/aslm/view/popups/camera_view_popup_window.py
+++ b/src/aslm/view/popups/camera_view_popup_window.py
@@ -110,6 +110,7 @@ class CameraViewPopupWindow:
 
         self.camera_view = CameraTab(content_frame)
         self.camera_view.is_popup = True
+        self.camera_view.is_docked = False
         self.camera_view.grid(row=0, column=0, sticky=tk.NSEW)
 
     # Getters

--- a/src/aslm/view/popups/camera_view_popup_window.py
+++ b/src/aslm/view/popups/camera_view_popup_window.py
@@ -88,6 +88,7 @@ class CameraViewPopupWindow:
             top=False,
             transient=False,
         )
+        self.popup.resizable(tk.TRUE, tk.TRUE)
 
         # Storing the content frame of the popup, this will be the parent of
         # the widgets
@@ -108,6 +109,7 @@ class CameraViewPopupWindow:
         self.buttons = {}
 
         self.camera_view = CameraTab(content_frame)
+        self.camera_view.is_popup = True
         self.camera_view.grid(row=0, column=0, sticky=tk.NSEW)
 
     # Getters

--- a/test/controller/sub_controllers/test_camera_view_controller.py
+++ b/test/controller/sub_controllers/test_camera_view_controller.py
@@ -439,8 +439,9 @@ class TestCameraViewController:
         self.zoom_image = test_image
 
         # set the widget size
-        self.camera_view.view.canvas_width = np.random.randint(5, 99)
-        self.camera_view.view.canvas_height = np.random.randint(5, 99)
+        widget = type("MyWidget", (object,), {"widget": self.camera_view.view})
+        event = type("MyEvent", (object,), {"widget": widget, "width": np.random.randint(5, 1000), "height": np.random.randint(5, 1000)})
+        self.camera_view.resize(event)
 
         # monkeypatch cv2.resize
         def mocked_resize(img, size):
@@ -569,10 +570,10 @@ class TestCameraViewController:
         assert self.camera_view.original_image_height == int(
             camera_parameters["y_pixels"]
         )
-        assert self.camera_view.canvas_width_scale == int(
+        assert self.camera_view.canvas_width_scale == float(
             self.camera_view.original_image_width / self.camera_view.view.canvas_width
         )
-        assert self.camera_view.canvas_height_scale == int(
+        assert self.camera_view.canvas_height_scale == float(
             self.camera_view.original_image_height / self.camera_view.view.canvas_height
         )
 


### PR DESCRIPTION
The image will appear completely as a square on the screen. If we want the image to take up the entire screen (usually a rectangle), I need to add a scrollbar to the canvas. However, the image is only partially displayed unless the canvas is scrolled.