### PR TITLE
436 multiposition table focus needs to be ignored when switching from low to high res

### DIFF
--- a/src/aslm/config/config.py
+++ b/src/aslm/config/config.py
@@ -133,10 +133,18 @@ def get_configuration_paths():
 
     if not os.path.exists(waveform_templates_path):
         copy_base_directory = Path(__file__).resolve().parent
-        copy_waveform_templates_path = Path.joinpath(copy_base_directory, "waveform_templates.yml")
+        copy_waveform_templates_path = Path.joinpath(
+            copy_base_directory, "waveform_templates.yml"
+        )
         shutil.copyfile(copy_waveform_templates_path, waveform_templates_path)
 
-    return configuration_path, experiment_path, waveform_constants_path, rest_api_path, waveform_templates_path
+    return (
+        configuration_path,
+        experiment_path,
+        waveform_constants_path,
+        rest_api_path,
+        waveform_templates_path,
+    )
 
 
 def load_configs(manager, **kwargs):
@@ -235,7 +243,7 @@ def update_config_dict(manager, parent_dict, config_name, new_config) -> bool:
     --------
     >>> update_config_dict(manager, parent_dict, config_name, new_config)
     """
-    if type(new_config) != dict:
+    if type(new_config) != dict and type(new_config) != list:
         file_path = str(new_config)
         if isfile(file_path) and (
             file_path.endswith(".yml") or file_path.endswith(".yaml")

--- a/src/aslm/config/experiment.yml
+++ b/src/aslm/config/experiment.yml
@@ -63,6 +63,7 @@ MicroscopeState:
   timepoint_interval: 0
   experiment_duration: 600.0899999999995
   is_multiposition: False
+  multipostion_count: 2
   selected_channels: 3
   channels: {'channel_1': {'is_selected': True, 'laser': '488nm', 'laser_index': 0, 'filter': 'GFP - FF01-515/30-32', 'filter_position': 1, 'camera_exposure_time': 200.0, 'laser_power': '20', 'interval_time': '1', 'defocus': 0.0}, 'channel_2': {'is_selected': True, 'laser': '562nm', 'laser_index': 1, 'filter': 'RFP - FF01-595/31-32', 'filter_position': 2, 'camera_exposure_time': 200.0, 'laser_power': '20', 'interval_time': '1', 'defocus': 0.0}, 'channel_3': {'is_selected': True, 'laser': '642nm', 'laser_index': 2, 'filter': 'Far-Red - BLP01-647R/31-32', 'filter_position': 3, 'camera_exposure_time': 200.0, 'laser_power': '20', 'interval_time': '1', 'defocus': 0.0}}
   stack_z_origin: 0

--- a/src/aslm/controller/controller.py
+++ b/src/aslm/controller/controller.py
@@ -594,6 +594,7 @@ class Controller:
             "Ilastik Segmentation",
             "Volume Search",
             "Time Series",
+            "Decoupled Focus Stage Multiposition",
         ]
         self.feature_id_val = tkinter.IntVar(0)
         for i in range(len(feature_list)):
@@ -700,6 +701,7 @@ class Controller:
             "stage_positions",
             positions,
         )
+        self.configuration["experiment"]["MicroscopeState"]["multipostion_count"] = len(positions)
 
         # set waveform template
         if self.acquire_bar_controller.mode == "confocal-projection":

--- a/src/aslm/controller/sub_controllers/multi_position_controller.py
+++ b/src/aslm/controller/sub_controllers/multi_position_controller.py
@@ -99,7 +99,7 @@ class MultiPositionController(GUIController):
         >>> get_positions()
         """
         axis_dict = {"X": "x", "Y": "y", "Z": "z", "R": "theta", "F": "f"}
-        positions = {}
+        positions = []
         rows = self.table.model.df.shape[0]
         for i in range(rows):
             temp = list(self.table.model.df.iloc[i])
@@ -110,7 +110,7 @@ class MultiPositionController(GUIController):
                 == 5
             ):
                 temp = dict(self.table.model.df.iloc[i])
-                positions[i] = {}
+                positions.append({})
                 for k in axis_dict:
                     positions[i][axis_dict[k]] = temp[k]
         return positions

--- a/src/aslm/model/devices/stages/stage_pi.py
+++ b/src/aslm/model/devices/stages/stage_pi.py
@@ -237,13 +237,18 @@ class PIStage(StageBase):
                 continue
             success = self.move_axis_absolute(ax, n, move_dictionary)
 
+        if not success:
+            return False
         if wait_until_done is True:
             try:
-                self.pi_tools.waitontarget(self.pi_device)
+                self.pi_tools.waitontarget(self.pi_device, timeout=2.0)
             except GCSError as e:
                 print("Wait on target failed")
                 success = False
                 logger.exception(f"Wait on target failed - {e}")
+            except Exception as e:
+                success = False
+                logger.exception(f"Wait on target timeout error - {e}")
         return success
 
     def stop(self):

--- a/src/aslm/model/features/autofocus.py
+++ b/src/aslm/model/features/autofocus.py
@@ -303,6 +303,7 @@ class Autofocus:
         if self.signal_id < self.coarse_steps:
             self.init_pos += self.coarse_step_size
             self.model.move_stage({"f_abs": self.init_pos}, wait_until_done=True)
+            self.model.logger.debug(f"*** Autofocus move stage: (f, {self.init_pos})")
             self.autofocus_frame_queue.put(
                 (self.model.frame_id, self.coarse_steps - self.signal_id, self.init_pos)
             )
@@ -315,6 +316,7 @@ class Autofocus:
                 self.init_pos -= self.fine_pos_offset
             self.init_pos += self.fine_step_size
             self.model.move_stage({"f_abs": self.init_pos}, wait_until_done=True)
+            self.model.logger.debug(f"*** Autofocus move stage: (f, {self.init_pos})")
             self.autofocus_frame_queue.put(
                 (
                     self.model.frame_id,
@@ -326,6 +328,7 @@ class Autofocus:
         else:
             self.init_pos = self.autofocus_pos_queue.get(timeout=self.coarse_steps * 10)
             self.model.move_stage({"f_abs": self.init_pos}, wait_until_done=True)
+            self.model.logger.debug(f"*** Autofocus move stage: (f, {self.init_pos})")
 
         self.signal_id += 1
         return self.init_pos if self.signal_id > self.total_frame_num else None

--- a/src/aslm/model/model.py
+++ b/src/aslm/model/model.py
@@ -241,12 +241,16 @@ class Model:
 
         self.feature_list.append(
             [
-                ({"name": MoveToNextPositionInMultiPostionTable},
-                 {"name": Autofocus},
-                 {"name": ZStackAcquisition},
-                 {"name": WaitToContinue},
-                 {"name": LoopByCount, "args": ("experiment.MicroscopeState.multipostion_count",)}
-                 )
+                (
+                    {"name": MoveToNextPositionInMultiPostionTable},
+                    {"name": Autofocus},
+                    {"name": ZStackAcquisition, "args": (True,)},
+                    {"name": WaitToContinue},
+                    {
+                        "name": LoopByCount,
+                        "args": ("experiment.MicroscopeState.multipostion_count",),
+                    },
+                )
             ]
         )
 
@@ -609,7 +613,12 @@ class Model:
         success : bool
             Was the move successful?
         """
-        return self.active_microscope.move_stage(pos_dict, wait_until_done)
+        try:
+            r = self.active_microscope.move_stage(pos_dict, wait_until_done)
+        except Exception as e:
+            self.logger.debug(f"*** stage move failed: {e}")
+            return False
+        return r
 
     def get_stage_position(self):
         """Get the position of the stage.

--- a/src/aslm/model/model.py
+++ b/src/aslm/model/model.py
@@ -54,6 +54,8 @@ from aslm.model.features.common_features import (
     LoopByCount,
     ConProAcquisition,  # noqa
     StackPause,
+    MoveToNextPositionInMultiPostionTable,
+    WaitToContinue,
 )
 from aslm.model.features.feature_container import load_features
 from aslm.model.features.restful_features import IlastikSegmentation
@@ -234,6 +236,17 @@ class Model:
                         "args": ("experiment.MicroscopeState.timepoints",),
                     },
                 )
+            ]
+        )
+
+        self.feature_list.append(
+            [
+                ({"name": MoveToNextPositionInMultiPostionTable},
+                 {"name": Autofocus},
+                 {"name": ZStackAcquisition},
+                 {"name": WaitToContinue},
+                 {"name": LoopByCount, "args": ("experiment.MicroscopeState.multipostion_count",)}
+                 )
             ]
         )
 


### PR DESCRIPTION
Please test to see if it works with the device. Load feature "Decoupled Focus Stage Multiposition", run in "Customized" mode. Do not select "Enable Multi-Position" on the GUI. It works as (Loop) Move To the Next Position -> Autofocus -> ZStack. 
Do not merge it. If-else for the Autofocus needs to be added in the feature sequence.