### PR TITLE
ASI Filter Wheel, Save GUI Settings on Exit, and Microscope Object

### DIFF
--- a/src/aslm/controller/controller.py
+++ b/src/aslm/controller/controller.py
@@ -39,6 +39,7 @@ import multiprocessing as mp
 import threading
 import sys
 import platform
+import os
 
 # Third Party Imports
 
@@ -78,7 +79,7 @@ from aslm.model.model import Model
 from aslm.model.concurrency.concurrency_tools import ObjectInSubprocess
 
 # Misc. Local Imports
-from aslm.config.config import load_configs, update_config_dict
+from aslm.config.config import load_configs, update_config_dict, get_aslm_path
 from aslm.tools.file_functions import create_save_path, save_yaml_file
 from aslm.tools.common_dict_tools import update_stage_dict
 from aslm.tools.multipos_table_tools import update_table
@@ -984,6 +985,14 @@ class Controller:
 
         elif command == "exit":
             """Exit the program."""
+            # Save current GUI settings to .ASLM/config/experiment.yml file.
+            self.update_experiment_setting()
+            file_directory = os.path.join(get_aslm_path(), "config")
+            save_yaml_file(
+                file_directory=file_directory,
+                content_dict=self.configuration["experiment"],
+                filename="experiment.yml",
+            )
 
             # self.model.run_command('stop')
             self.sloppy_stop()

--- a/src/aslm/model/device_startup_functions.py
+++ b/src/aslm/model/device_startup_functions.py
@@ -355,37 +355,30 @@ def start_stage(
 
     if device_type == "PI":
         from aslm.model.devices.stages.stage_pi import PIStage
-
         return PIStage(microscope_name, device_connection, configuration, id)
 
     elif device_type == "MP285":
         from aslm.model.devices.stages.stage_sutter import SutterStage
-
         return SutterStage(microscope_name, device_connection, configuration, id)
 
     elif device_type == "Thorlabs":
         from aslm.model.devices.stages.stage_tl_kcube_inertial import TLKIMStage
-
         return TLKIMStage(microscope_name, device_connection, configuration, id)
 
     elif device_type == "MCL":
         from aslm.model.devices.stages.stage_mcl import MCLStage
-
         return MCLStage(microscope_name, device_connection, configuration, id)
 
     elif device_type == "ASI":
         from aslm.model.devices.stages.stage_asi import ASIStage
-
         return ASIStage(microscope_name, device_connection, configuration, id)
 
     elif device_type == "GalvoNIStage":
         from aslm.model.devices.stages.stage_galvo import GalvoNIStage
-
         return GalvoNIStage(microscope_name, device_connection, configuration, id)
 
     elif device_type.lower() == "syntheticstage" or device_type.lower() == "synthetic":
         from aslm.model.devices.stages.stage_synthetic import SyntheticStage
-
         return SyntheticStage(microscope_name, device_connection, configuration, id)
 
     else:
@@ -498,35 +491,29 @@ def load_filter_wheel_connection(configuration, is_synthetic=False):
     -------
     Filter : class
         Filter class.
-
-    Examples
-    --------
-    >>> load_filter_wheel_connection(configuration, is_synthetic=False)
     """
     device_info = configuration["configuration"]["hardware"]["filter_wheel"]
     if is_synthetic:
         device_type = "SyntheticFilterWheel"
+
     else:
         device_type = device_info["type"]
 
     if device_type == "SutterFilterWheel":
-        from aslm.model.devices.filter_wheel.filter_wheel_sutter import (
-            build_filter_wheel_connection,
-        )
-
+        from aslm.model.devices.filter_wheel.filter_wheel_sutter import build_filter_wheel_connection
         return auto_redial(
             build_filter_wheel_connection,
             (device_info["port"], device_info["baudrate"], 0.25),
             exception=Exception,
         )
+
     elif device_type == "ASI":
         # Communication vis the Tiger Controller.
-        pass
-    elif (
-        device_type.lower() == "syntheticfilterwheel"
-        or device_type.lower() == "synthetic"
-    ):
+        return []
+
+    elif device_type.lower() == "syntheticfilterwheel" or device_type.lower() == "synthetic":
         return DummyDeviceConnection()
+
     else:
         device_not_found("filter_wheel", device_type)
 
@@ -611,17 +598,18 @@ def start_daq(configuration, is_synthetic=False):
     """
     if is_synthetic:
         device_type = "SyntheticDAQ"
+
     else:
         device_type = configuration["configuration"]["hardware"]["daq"]["type"]
 
     if device_type == "NI":
         from aslm.model.devices.daq.daq_ni import NIDAQ
-
         return NIDAQ(configuration)
+
     elif device_type.lower() == "syntheticdaq" or device_type.lower() == "synthetic":
         from aslm.model.devices.daq.daq_synthetic import SyntheticDAQ
-
         return SyntheticDAQ(configuration)
+
     else:
         device_not_found(configuration["configuration"]["hardware"]["daq"]["type"])
 

--- a/src/aslm/model/device_startup_functions.py
+++ b/src/aslm/model/device_startup_functions.py
@@ -508,7 +508,8 @@ def load_filter_wheel_connection(configuration, is_synthetic=False):
         )
 
     elif device_type == "ASI":
-        # Communication vis the Tiger Controller.
+        # Communication via the Tiger Controller.
+        # Device connection provided by the stage object, which is then passed to the filter_wheel object.
         return []
 
     elif device_type.lower() == "syntheticfilterwheel" or device_type.lower() == "synthetic":

--- a/src/aslm/model/device_startup_functions.py
+++ b/src/aslm/model/device_startup_functions.py
@@ -287,19 +287,23 @@ def load_stages(configuration, is_synthetic=False):
             )
 
         elif stage_type == "ASI" and platform.system() == "Windows":
-            from aslm.model.devices.stages.stage_asi import build_ASI_Stage_connection
-            from aslm.model.devices.APIs.asi.asi_tiger_controller import TigerException
+            filter_wheel = configuration["configuration"]["hardware"]["filter_wheel"]['type']
+            if filter_wheel == "ASI":
+                stage_devices.append("shared device")
+            else:
+                from aslm.model.devices.stages.stage_asi import build_ASI_Stage_connection
+                from aslm.model.devices.APIs.asi.asi_tiger_controller import TigerException
 
-            stage_devices.append(
-                auto_redial(
-                    build_ASI_Stage_connection,
-                    (
-                        stage_config["port"],
-                        stage_config["baudrate"],
-                    ),
-                    exception=TigerException,
+                stage_devices.append(
+                    auto_redial(
+                        build_ASI_Stage_connection,
+                        (
+                            stage_config["port"],
+                            stage_config["baudrate"],
+                        ),
+                        exception=TigerException,
+                    )
                 )
-            )
 
         elif stage_type == "GalvoNIStage" and platform.system() == "Windows":
             stage_devices.append(DummyDeviceConnection())
@@ -508,9 +512,13 @@ def load_filter_wheel_connection(configuration, is_synthetic=False):
         )
 
     elif device_type == "ASI":
-        # Communication via the Tiger Controller.
-        # Device connection provided by the stage object, which is then passed to the filter_wheel object.
-        return []
+        from aslm.model.devices.filter_wheel.filter_wheel_asi import build_filter_wheel_connection
+        tiger_controller = auto_redial(
+            build_filter_wheel_connection,
+            (device_info["port"], device_info["baudrate"], 0.25),
+            exception=Exception,
+        )
+        return tiger_controller
 
     elif device_type.lower() == "syntheticfilterwheel" or device_type.lower() == "synthetic":
         return DummyDeviceConnection()

--- a/src/aslm/model/device_startup_functions.py
+++ b/src/aslm/model/device_startup_functions.py
@@ -183,12 +183,12 @@ def start_camera(microscope_name, device_connection, configuration, is_synthetic
 
     if cam_type == "HamamatsuOrca":
         from aslm.model.devices.camera.camera_hamamatsu import HamamatsuOrca
-
         return HamamatsuOrca(microscope_name, device_connection, configuration)
+
     elif cam_type.lower() == "syntheticcamera" or cam_type.lower() == "synthetic":
         from aslm.model.devices.camera.camera_synthetic import SyntheticCamera
-
         return SyntheticCamera(microscope_name, device_connection, configuration)
+
     else:
         device_not_found(microscope_name, "camera", cam_type)
 
@@ -519,6 +519,9 @@ def load_filter_wheel_connection(configuration, is_synthetic=False):
             (device_info["port"], device_info["baudrate"], 0.25),
             exception=Exception,
         )
+    elif device_type == "ASI":
+        # Communication vis the Tiger Controller.
+        pass
     elif (
         device_type.lower() == "syntheticfilterwheel"
         or device_type.lower() == "synthetic"
@@ -566,11 +569,12 @@ def start_filter_wheel(
         ]["hardware"]["type"]
 
     if device_type == "SutterFilterWheel":
-        from aslm.model.devices.filter_wheel.filter_wheel_sutter import (
-            SutterFilterWheel,
-        )
-
+        from aslm.model.devices.filter_wheel.filter_wheel_sutter import SutterFilterWheel
         return SutterFilterWheel(microscope_name, device_connection, configuration)
+
+    elif device_type == "ASI":
+        from aslm.model.devices.filter_wheel.filter_wheel_asi import ASIFilterWheel
+        return ASIFilterWheel(microscope_name, device_connection, configuration)
 
     elif (
         device_type.lower() == "syntheticfilterwheel"

--- a/src/aslm/model/devices/filter_wheel/filter_wheel_asi.py
+++ b/src/aslm/model/devices/filter_wheel/filter_wheel_asi.py
@@ -1,0 +1,221 @@
+# Copyright (c) 2021-2022  The University of Texas Southwestern Medical Center.
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted for academic and research use only (subject to the
+# limitations in the disclaimer below) provided that the following conditions are met:
+
+#      * Redistributions of source code must retain the above copyright notice,
+#      this list of conditions and the following disclaimer.
+
+#      * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+
+#      * Neither the name of the copyright holders nor the names of its
+#      contributors may be used to endorse or promote products derived from this
+#      software without specific prior written permission.
+
+# NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE GRANTED BY
+# THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+# CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+# PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+# BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+# IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+
+#  Standard Library Imports
+import logging
+import time
+
+# Third Party Imports
+import numpy as np
+import serial
+
+# Local Imports
+from aslm.model.devices.filter_wheel.filter_wheel_base import FilterWheelBase
+
+# Logger Setup
+p = __name__.split(".")[1]
+logger = logging.getLogger(p)
+
+
+def build_filter_wheel_connection(comport, baudrate, timeout=0.25):
+    """Build SutterFilterWheel Serial Port connection
+    Attributes
+    ----------
+    comport : str
+        Comport for communicating with the filter wheel, e.g., COM1.
+    baudrate : int
+        Baud rate for communicating with the filter wheel, e.g., 9600.
+    """
+    logging.debug(f"SutterFilterWheel - Opening Serial Port {comport}")
+    try:
+        return serial.Serial(comport, baudrate, timeout=0.25)
+    except serial.SerialException:
+        logger.warning("SutterFilterWheel - Could not establish Serial Port Connection")
+        raise UserWarning(
+            "Could not communicate with Sutter Lambda 10-B via COMPORT", comport
+        )
+
+
+class ASIFilterWheel(FilterWheelBase):
+    """ASIFilterWheel Class
+
+    Class for controlling ASI Filter Wheels
+    https://asiimaging.com/docs/fw_1000#fw-1000_ascii_command_set
+
+    """
+
+    def __init__(self, microscope_name, device_connection, configuration):
+        super().__init__(microscope_name, device_connection, configuration)
+        self.serial = device_connection
+
+        self.number_of_filter_wheels = configuration["configuration"]["microscopes"][
+            microscope_name
+        ]["filter_wheel"]["hardware"]["wheel_number"]
+        self.wait_until_done_delay = configuration["configuration"]["microscopes"][
+            microscope_name
+        ]["filter_wheel"]["filter_wheel_delay"]
+        self.wait_until_done = True
+        self.read_on_init = True
+        self.speed = 2
+
+        # Delay in s for the wait until done function
+        self.delay_matrix = np.matrix(
+            [
+                [0, 0.031, 0.051, 0.074, 0.095, 0.115],
+                [0, 0.040, 0.065, 0.095, 0.120, 0.148],
+                [0, 0.044, 0.075, 0.105, 0.136, 0.168],
+                [0, 0.050, 0.088, 0.127, 0.165, 0.205],
+                [0, 0.060, 0.108, 0.156, 0.205, 0.250],
+                [0, 0.068, 0.123, 0.178, 0.235, 0.290],
+                [0, 0.124, 0.235, 0.350, 0.460, 0.580],
+                [0, 0.230, 0.440, 0.650, 0.860, 1.100],
+            ]
+        )
+
+        logger.debug("SutterFilterWheel - Placing device In Online Mode")
+        self.serial.write(bytes.fromhex("ee"))
+        if self.read_on_init:
+            self.read(2)  # class 'bytes'
+            self.init_finished = True
+            logger.debug("SutterFilterWheel - Initialized.")
+        else:
+            self.init_finished = False
+
+        # Set filter to the 0th position by default upon initialization.
+        default_filter = list(self.filter_dictionary.keys())[0]
+        self.set_filter(default_filter)
+        logger.debug("SutterFilterWheel -  Placed in Default Filter Position.")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type, value, traceback):
+        logger.debug("SutterFilterWheel - Closing Device.")
+        self.close()
+
+    def filter_change_delay(self, filter_name):
+        """Calculate duration of time necessary to change filter wheel positions.
+        Identifies the number of positions that must be switched, and then retrieves
+        the duration of time necessary to perform the switch from self.delay_matrix.
+        Detailed information on timing located on page 38:
+        https://www.sutter.com/manuals/LB10-3_OpMan.pdf
+
+        Parameters
+        ----------
+        filter_name : str
+            Name of filter that we want to move to.
+        """
+        # Find the old and new positions, the distance between them, and the
+        # delay necessary.
+        old_position = self.wheel_position
+        self.wheel_position = self.filter_dictionary[filter_name]
+        delta_position = int(abs(old_position - self.wheel_position))
+        self.wait_until_done_delay = self.delay_matrix[self.speed, delta_position]
+
+    def set_filter(self, filter_name, wait_until_done=True):
+        """Change the filter wheel to the filter designated by the filter
+        position argument.
+
+        Parameters
+        ----------
+        filter_name : str
+            Name of filter to move to.
+        wait_until_done : bool
+            Waits duration of time necessary for filter wheel to change positions.
+        """
+        if self.check_if_filter_in_filter_dictionary(filter_name) is True:
+
+            # Calculate the Delay Needed to Change the Positions
+            self.filter_change_delay(filter_name)
+
+            # Make sure you are moving it to a reasonable filter position at a
+            # reasonable speed.
+            assert self.wheel_position in range(10)
+            assert self.speed in range(8)
+
+            # If previously we did not confirm that the initialization was complete,
+            # check now.
+            if not self.init_finished:
+                self.read(2)
+                self.init_finished = True
+                logger.debug("SutterFilterWheel - Initialized.")
+
+            for wheel_idx in range(self.number_of_filter_wheels):
+                """Loop through each filter, and send the binary sequence via serial to
+                move to the desired filter wheel position
+                When number_of_filter_wheels = 1, loop executes once, and only wheel A
+                changes. When number_of_filter_wheels = 2, loop executes twice, with
+                both wheel A and B moving to the same position sequentially
+                Filter Wheel Command Byte Encoding = wheel + (self.speed*16) +
+                position = command byte
+                """
+                logger.debug(f"SutterFilterWheel - Moving to Position {wheel_idx}")
+                output_command = wheel_idx * 128 + self.wheel_position + 16 * self.speed
+                output_command = output_command.to_bytes(1, "little")
+                self.serial.write(output_command)
+
+            #  Wheel Position Change Delay
+            if wait_until_done:
+                time.sleep(self.wait_until_done_delay)
+
+    def read(self, num_bytes):
+        """Reads the specified number of bytes from the serial port.
+
+        Parameters
+        ----------
+        num_bytes : int
+            Number of bytes to read from the serial port.
+        """
+        for i in range(100):
+            num_waiting = self.serial.inWaiting()
+            if num_waiting == num_bytes:
+                break
+            time.sleep(0.02)
+        else:
+            logger.error(
+                "The serial port to the Sutter Lambda 10-B is on, but it isn't "
+                "responding as expected."
+            )
+            raise UserWarning(
+                "The serial port to the Sutter Lambda 10-B is on, but it isn't "
+                "responding as expected."
+            )
+        return self.serial.read(num_bytes)
+
+    def close(self):
+        """Close the SutterFilterWheel serial port.
+
+        Sets the filter wheel to the Empty-Alignment position and then closes the port.
+        """
+        logger.debug("SutterFilterWheel - Closing the Filter Wheel Serial Port")
+        self.set_filter("Empty-Alignment")
+        self.serial.close()

--- a/src/aslm/model/devices/filter_wheel/filter_wheel_asi.py
+++ b/src/aslm/model/devices/filter_wheel/filter_wheel_asi.py
@@ -75,147 +75,25 @@ class ASIFilterWheel(FilterWheelBase):
 
     def __init__(self, microscope_name, device_connection, configuration):
         super().__init__(microscope_name, device_connection, configuration)
-        self.serial = device_connection
 
-        self.number_of_filter_wheels = configuration["configuration"]["microscopes"][
-            microscope_name
-        ]["filter_wheel"]["hardware"]["wheel_number"]
-        self.wait_until_done_delay = configuration["configuration"]["microscopes"][
-            microscope_name
-        ]["filter_wheel"]["filter_wheel_delay"]
-        self.wait_until_done = True
-        self.read_on_init = True
-        self.speed = 2
+        print("ASI Filter wheel launched.")
+        print("Device connection:", device_connection)
 
-        # Delay in s for the wait until done function
-        self.delay_matrix = np.matrix(
-            [
-                [0, 0.031, 0.051, 0.074, 0.095, 0.115],
-                [0, 0.040, 0.065, 0.095, 0.120, 0.148],
-                [0, 0.044, 0.075, 0.105, 0.136, 0.168],
-                [0, 0.050, 0.088, 0.127, 0.165, 0.205],
-                [0, 0.060, 0.108, 0.156, 0.205, 0.250],
-                [0, 0.068, 0.123, 0.178, 0.235, 0.290],
-                [0, 0.124, 0.235, 0.350, 0.460, 0.580],
-                [0, 0.230, 0.440, 0.650, 0.860, 1.100],
-            ]
-        )
-
-        logger.debug("SutterFilterWheel - Placing device In Online Mode")
-        self.serial.write(bytes.fromhex("ee"))
-        if self.read_on_init:
-            self.read(2)  # class 'bytes'
-            self.init_finished = True
-            logger.debug("SutterFilterWheel - Initialized.")
-        else:
-            self.init_finished = False
-
-        # Set filter to the 0th position by default upon initialization.
-        default_filter = list(self.filter_dictionary.keys())[0]
-        self.set_filter(default_filter)
-        logger.debug("SutterFilterWheel -  Placed in Default Filter Position.")
 
     def __enter__(self):
-        return self
+        pass
 
     def __exit__(self, type, value, traceback):
-        logger.debug("SutterFilterWheel - Closing Device.")
-        self.close()
+        pass
 
     def filter_change_delay(self, filter_name):
-        """Calculate duration of time necessary to change filter wheel positions.
-        Identifies the number of positions that must be switched, and then retrieves
-        the duration of time necessary to perform the switch from self.delay_matrix.
-        Detailed information on timing located on page 38:
-        https://www.sutter.com/manuals/LB10-3_OpMan.pdf
-
-        Parameters
-        ----------
-        filter_name : str
-            Name of filter that we want to move to.
-        """
-        # Find the old and new positions, the distance between them, and the
-        # delay necessary.
-        old_position = self.wheel_position
-        self.wheel_position = self.filter_dictionary[filter_name]
-        delta_position = int(abs(old_position - self.wheel_position))
-        self.wait_until_done_delay = self.delay_matrix[self.speed, delta_position]
+        pass
 
     def set_filter(self, filter_name, wait_until_done=True):
-        """Change the filter wheel to the filter designated by the filter
-        position argument.
-
-        Parameters
-        ----------
-        filter_name : str
-            Name of filter to move to.
-        wait_until_done : bool
-            Waits duration of time necessary for filter wheel to change positions.
-        """
-        if self.check_if_filter_in_filter_dictionary(filter_name) is True:
-
-            # Calculate the Delay Needed to Change the Positions
-            self.filter_change_delay(filter_name)
-
-            # Make sure you are moving it to a reasonable filter position at a
-            # reasonable speed.
-            assert self.wheel_position in range(10)
-            assert self.speed in range(8)
-
-            # If previously we did not confirm that the initialization was complete,
-            # check now.
-            if not self.init_finished:
-                self.read(2)
-                self.init_finished = True
-                logger.debug("SutterFilterWheel - Initialized.")
-
-            for wheel_idx in range(self.number_of_filter_wheels):
-                """Loop through each filter, and send the binary sequence via serial to
-                move to the desired filter wheel position
-                When number_of_filter_wheels = 1, loop executes once, and only wheel A
-                changes. When number_of_filter_wheels = 2, loop executes twice, with
-                both wheel A and B moving to the same position sequentially
-                Filter Wheel Command Byte Encoding = wheel + (self.speed*16) +
-                position = command byte
-                """
-                logger.debug(f"SutterFilterWheel - Moving to Position {wheel_idx}")
-                output_command = wheel_idx * 128 + self.wheel_position + 16 * self.speed
-                output_command = output_command.to_bytes(1, "little")
-                self.serial.write(output_command)
-
-            #  Wheel Position Change Delay
-            if wait_until_done:
-                time.sleep(self.wait_until_done_delay)
+        pass
 
     def read(self, num_bytes):
-        """Reads the specified number of bytes from the serial port.
-
-        Parameters
-        ----------
-        num_bytes : int
-            Number of bytes to read from the serial port.
-        """
-        for i in range(100):
-            num_waiting = self.serial.inWaiting()
-            if num_waiting == num_bytes:
-                break
-            time.sleep(0.02)
-        else:
-            logger.error(
-                "The serial port to the Sutter Lambda 10-B is on, but it isn't "
-                "responding as expected."
-            )
-            raise UserWarning(
-                "The serial port to the Sutter Lambda 10-B is on, but it isn't "
-                "responding as expected."
-            )
-        return self.serial.read(num_bytes)
+        pass
 
     def close(self):
-        """Close the SutterFilterWheel serial port.
-
-        Sets the filter wheel to the Empty-Alignment position and then closes the port.
-        """
-        logger.debug("SutterFilterWheel - Closing the Filter Wheel Serial Port")
-        self.set_filter("Empty-Alignment")
-        self.serial.close()
+        pass

--- a/src/aslm/model/devices/filter_wheel/filter_wheel_asi.py
+++ b/src/aslm/model/devices/filter_wheel/filter_wheel_asi.py
@@ -45,7 +45,7 @@ p = __name__.split(".")[1]
 logger = logging.getLogger(p)
 
 
-def build_filter_wheel_connection(comport, baudrate=9600, timeout=0.25):
+def build_filter_wheel_connection(comport, baudrate=115200, timeout=0.25):
     """Build ASIFilterWheel Serial Port connection
     Attributes
     ----------
@@ -59,7 +59,7 @@ def build_filter_wheel_connection(comport, baudrate=9600, timeout=0.25):
     wait_start = time.time()
     timeout_s = timeout / 1000
     while block_flag:
-        tiger_controller = TigerController(comport, baudrate, verbose=True)
+        tiger_controller = TigerController(comport, baudrate, verbose=False)
         tiger_controller.connect_to_serial()
         if tiger_controller.is_open():
             block_flag = False

--- a/src/aslm/model/devices/stages/stage_asi.py
+++ b/src/aslm/model/devices/stages/stage_asi.py
@@ -47,7 +47,7 @@ p = __name__.split(".")[1]
 logger = logging.getLogger(p)
 
 
-def build_ASI_Stage_connection(com_port, baud_rate, timeout=1000):
+def build_ASI_Stage_connection(com_port, baud_rate=115200, timeout=1000):
     """Connect to the ASI Stage
 
     Parameters
@@ -70,7 +70,7 @@ def build_ASI_Stage_connection(com_port, baud_rate, timeout=1000):
     wait_start = time.time()
     timeout_s = timeout / 1000
     while block_flag:
-        asi_stage = TigerController(com_port, baud_rate, verbose=True)
+        asi_stage = TigerController(com_port, baud_rate, verbose=False)
         asi_stage.connect_to_serial()
         if asi_stage.is_open():
             block_flag = False

--- a/src/aslm/model/microscope.py
+++ b/src/aslm/model/microscope.py
@@ -93,7 +93,7 @@ class Microscope:
         self.available_channels = None
         self.number_of_frames = None
         self.central_focus = None
-
+        self.is_synthetic = is_synthetic
         self.laser_wavelength = []
 
         if is_virtual:
@@ -171,6 +171,8 @@ class Microscope:
                     is_list=is_list,
                     device_name_list=device_name_list,
                     device_ref_name=device_ref_name,
+                    device_connection=device_connection,
+                    name=name,
                     i=i,
                 )
 
@@ -583,6 +585,8 @@ class Microscope:
         is_list,
         device_name_list,
         device_ref_name,
+        device_connection,
+        name,
         i,
     ):
         """Load and start devices.
@@ -597,6 +601,10 @@ class Microscope:
             Device name list.
         device_ref_name : str
             Device reference name.
+        device_connection : str
+            Device connection.
+        name : str
+            Name.
         i : int
             Index.
 
@@ -618,14 +626,14 @@ class Microscope:
         if is_list:
             exec(
                 f"self.{device_name}['{device_name_list[i]}'] = "
-                f"start_{device_name}(name, device_connection, configuration, "
-                f"i, is_synthetic)"
+                f"start_{device_name}(name, device_connection, self.configuration, "
+                f"i, self.is_synthetic)"
             )
             if device_name in device_name_list[i]:
                 self.info[device_name_list[i]] = device_ref_name
         else:
             exec(
                 f"self.{device_name} = start_{device_name}(name, "
-                f"device_connection, configuration, is_synthetic)"
+                f"device_connection, self.configuration, self.is_synthetic)"
             )
             self.info[device_name] = device_ref_name

--- a/src/aslm/model/microscope.py
+++ b/src/aslm/model/microscope.py
@@ -109,6 +109,10 @@ class Microscope:
             "lasers": ["wavelength"],
         }
 
+        # TODO: This cannot be pulled into the repo. I need help comping up with a more general way to have
+        # shared devices. 
+        devices_dict['filter_wheel']['ASI'] = devices_dict['stages']['ASI_119060508']
+
         device_name_dict = {"lasers": "wavelength"}
 
         laser_list = self.configuration["configuration"]["microscopes"][
@@ -153,7 +157,6 @@ class Microscope:
                         ref_list = []
 
                 device_ref_name = build_ref_name("_", *ref_list)
-
                 if device_name in devices_dict and device_ref_name in devices_dict[device_name]:
                     device_connection = devices_dict[device_name][device_ref_name]
 
@@ -161,9 +164,11 @@ class Microscope:
                     # TODO: Remove this. We should not have this hardcoded.
                     device_connection = self.daq
 
-                elif device_ref_name.startswith("ASI") and (device_name == "stage" or device_name == "filter_wheel"):
+                elif device_ref_name.startswith("ASI"):
                     # TODO: Using above TODO to model the import of a shared device_connection.
+                    self.tiger_controller = devices_dict["stages"][device_ref_name]
                     device_connection = self.tiger_controller
+                    print("Here")
 
                 # Import start_device classes
                 try:
@@ -200,6 +205,8 @@ class Microscope:
                         else getattr(self, device_name)
                     )
 
+        # ASI
+
         # stages
         stage_devices = self.configuration["configuration"]["microscopes"][
             self.microscope_name
@@ -219,11 +226,6 @@ class Microscope:
             if device_ref_name.startswith("GalvoNIStage"):
                 # TODO: Remove this. We should not have this hardcoded.
                 devices_dict["stages"][device_ref_name] = self.daq
-
-            if device_ref_name.startswith("ASI"):
-                # TODO: Remove this. Whoever did this first shouldn't have hardcoded it.
-                self.tiger_controller = devices_dict["stages"][device_ref_name]
-                devices_dict["filter_wheel"][device_ref_name] = self.tiger_controller
 
             stage = start_stage(
                 microscope_name=self.microscope_name,

--- a/src/aslm/model/microscope.py
+++ b/src/aslm/model/microscope.py
@@ -164,6 +164,9 @@ class Microscope:
                     # all other ASI devices as self.tiger_controller
                     device_connection = devices_dict[device_name][device_ref_name]
                     self.tiger_controller = device_connection
+                elif device_ref_name.startswith("ASI") and self.tiger_controller is not None:
+                    # If subsequent ASI-based tiger controller devices are included.
+                    device_connection = self.tiger_controller
 
                 # LOAD AND START DEVICES
                 self.load_and_start_devices(

--- a/src/aslm/model/microscope.py
+++ b/src/aslm/model/microscope.py
@@ -86,7 +86,7 @@ class Microscope:
         self.lasers = {}
         self.galvo = {}
         self.daq = devices_dict.get("daq", None)
-        self.tiger_controller = devices_dict.get("stages", None)
+        self.tiger_controller = None
         self.info = {}
         self.current_channel = None
         self.channels = None
@@ -109,9 +109,10 @@ class Microscope:
             "lasers": ["wavelength"],
         }
 
-        # TODO: This cannot be pulled into the repo. I need help comping up with a more general way to have
-        # shared devices. 
-        devices_dict['filter_wheel']['ASI'] = devices_dict['stages']['ASI_119060508']
+        # TODO: This cannot be pulled into the repo.
+        #  I need help comping up with a more general way to have
+        # shared devices.
+        # devices_dict['filter_wheel']['ASI'] = devices_dict['stages']['ASI_119060508']
 
         device_name_dict = {"lasers": "wavelength"}
 
@@ -120,35 +121,24 @@ class Microscope:
         ]["lasers"]
         self.laser_wavelength = [laser["wavelength"] for laser in laser_list]
 
-        # load/start all the devices listed in device_ref_dict. e.g., camera, filter_wheel, zoom,...
+        # LOAD/START CAMERAS, FILTER_WHEELS, ZOOM, SHUTTERS, REMOTE_FOCUS_DEVICES,
+        # GALVOS, AND LASERS
         for device_name in device_ref_dict.keys():
             device_connection = None
-            device_config_list = []
-            device_name_list = []
-
-            if type(configuration["configuration"]["microscopes"][name][device_name]) == ListProxy:
-                i = 0
-                for d in configuration["configuration"]["microscopes"][name][device_name]:
-                    device_config_list.append(d)
-                    if device_name in device_name_dict:
-                        device_name_list.append(
-                            build_ref_name("_", d[device_name_dict[device_name]])
-                        )
-
-                    else:
-                        device_name_list.append(build_ref_name("_", device_name, i))
-                    i += 1
-
-                is_list = True
-
-            else:
-                device_config_list.append(configuration["configuration"]["microscopes"][name][device_name])
-                is_list = False
+            (
+                device_config_list,
+                device_name_list,
+                is_list,
+            ) = self.assemble_device_config_lists(
+                device_name=device_name, device_name_dict=device_name_dict
+            )
 
             for i, device in enumerate(device_config_list):
                 device_ref_name = None
                 if "hardware" in device.keys():
-                    ref_list = [device["hardware"][k] for k in device_ref_dict[device_name]]
+                    ref_list = [
+                        device["hardware"][k] for k in device_ref_dict[device_name]
+                    ]
 
                 else:
                     try:
@@ -157,55 +147,42 @@ class Microscope:
                         ref_list = []
 
                 device_ref_name = build_ref_name("_", *ref_list)
-                if device_name in devices_dict and device_ref_name in devices_dict[device_name]:
+                if (
+                    device_name in devices_dict
+                    and device_ref_name in devices_dict[device_name]
+                ):
                     device_connection = devices_dict[device_name][device_ref_name]
 
-                elif device_ref_name.startswith("NI") and (device_name == "galvo" or device_name == "remote_focus_device"):
-                    # TODO: Remove this. We should not have this hardcoded.
+                # SHARED DEVICES
+                elif device_ref_name.startswith("NI") and (
+                    device_name == "galvo" or device_name == "remote_focus_device"
+                ):
                     device_connection = self.daq
 
-                elif device_ref_name.startswith("ASI"):
-                    # TODO: Using above TODO to model the import of a shared device_connection.
-                    self.tiger_controller = devices_dict["stages"][device_ref_name]
-                    device_connection = self.tiger_controller
-                    print("Here")
+                if device_ref_name.startswith("ASI") and self.tiger_controller is None:
+                    # The first ASI instance of a device connection will be passed to
+                    # all other ASI devices as self.tiger_controller
+                    device_connection = devices_dict[device_name][device_ref_name]
+                    self.tiger_controller = device_connection
 
-                # Import start_device classes
-                try:
-                    exec(
-                        f"start_{device_name}=importlib.import_module("
-                        f"'aslm.model.device_startup_functions').start_{device_name}"
-                    )
-                except AttributeError:
-                    print(f"Could not import start_{device_name}")
-                    print(f"Could not load device {device_name}")
-
-                # Start the devices
-                if is_list:
-                    exec(
-                        f"self.{device_name}['{device_name_list[i]}'] = "
-                        f"start_{device_name}(name, device_connection, configuration, "
-                        f"i, is_synthetic)"
-                    )
-                    if device_name in device_name_list[i]:
-                        self.info[device_name_list[i]] = device_ref_name
-                else:
-                    exec(
-                        f"self.{device_name} = start_{device_name}(name, "
-                        f"device_connection, configuration, is_synthetic)"
-                    )
-                    self.info[device_name] = device_ref_name
+                # LOAD AND START DEVICES
+                self.load_and_start_devices(
+                    device_name=device_name,
+                    is_list=is_list,
+                    device_name_list=device_name_list,
+                    device_ref_name=device_ref_name,
+                    i=i,
+                )
 
                 if device_connection is None and device_ref_name is not None:
                     if device_name not in devices_dict:
                         devices_dict[device_name] = {}
+
                     devices_dict[device_name][device_ref_name] = (
                         getattr(self, device_name)[device_name_list[i]]
                         if is_list
                         else getattr(self, device_name)
                     )
-
-        # ASI
 
         # stages
         stage_devices = self.configuration["configuration"]["microscopes"][
@@ -223,9 +200,14 @@ class Microscope:
                 logger.debug("stage has not been loaded!")
                 raise Exception("no stage device!")
 
+            # SHARED DEVICES
             if device_ref_name.startswith("GalvoNIStage"):
-                # TODO: Remove this. We should not have this hardcoded.
                 devices_dict["stages"][device_ref_name] = self.daq
+
+            if device_ref_name.startswith("ASI") and self.tiger_controller is not None:
+                # If the self.tiger_controller is already set, then we can pass it to
+                # other devices that are connected to the same controller.
+                devices_dict["stages"][device_ref_name] = self.tiger_controller
 
             stage = start_stage(
                 microscope_name=self.microscope_name,
@@ -259,12 +241,6 @@ class Microscope:
         Returns
         -------
         None
-
-        Examples
-        --------
-        >>> microscope.update_data_buffer(img_width=512,
-        >>> img_height=512, data_buffer=None, number_of_frames=1)
-
         """
 
         if self.camera.is_acquiring:
@@ -284,11 +260,6 @@ class Microscope:
         Returns
         -------
         None
-
-        Examples
-        --------
-        >>> microscope.move_stage_offset(former_microscope="microscope1")
-
         """
 
         if former_microscope:
@@ -319,11 +290,6 @@ class Microscope:
         Returns
         -------
         None
-
-        Examples
-        --------
-        >>> microscope.prepare_acquisition()
-
         """
         self.current_channel = 0
         self.central_focus = None
@@ -365,10 +331,6 @@ class Microscope:
         Returns
         -------
         None
-
-        Examples
-        --------
-        >>> microscope.end_acquisition()
         """
         self.stop_stage()
         self.daq.stop_acquisition()
@@ -391,11 +353,6 @@ class Microscope:
         -------
         waveform : dict
             Dictionary of all the waveforms.
-
-        Examples
-        --------
-        >>> waveform = microscope.calculate_all_waveform()
-
         """
         readout_time = self.get_readout_time()
         camera_waveform = self.daq.calculate_all_waveforms(
@@ -424,10 +381,6 @@ class Microscope:
         Returns
         -------
         None
-
-        Examples
-        --------
-        >>> microscope.prepare_next_channel()
         """
         curr_channel = self.current_channel
         prefix = "channel_"
@@ -510,11 +463,6 @@ class Microscope:
         -------
         readout_time : float
             Camera readout time in seconds or -1 if not in Normal mode.
-
-        Examples
-        --------
-        >>> readout_time = microscope.get_readout_time()
-
         """
         readout_time = 0
         if (
@@ -537,10 +485,6 @@ class Microscope:
         Returns
         -------
         None
-
-        Examples
-        --------
-        >>> microscope.move_stage({"x_abs": 0, "y_abs": 0, "z_abs": 0, "f_abs": 0})
         """
 
         success = True
@@ -564,10 +508,6 @@ class Microscope:
         Returns
         -------
         None
-
-        Examples
-        --------
-        >>> microscope.stop_stage()
         """
 
         for axis in self.stages:
@@ -584,10 +524,6 @@ class Microscope:
         -------
         stage_position : dict
             Dictionary of stage positions.
-
-        Examples
-        --------
-        >>> stage_position = microscope.get_stage_position()
         """
 
         ret_pos_dict = {}
@@ -596,3 +532,100 @@ class Microscope:
             temp_pos = self.stages[axis].report_position()
             ret_pos_dict[pos_axis] = temp_pos[pos_axis]
         return ret_pos_dict
+
+    def assemble_device_config_lists(self, device_name, device_name_dict):
+        """Assemble device config lists.
+
+        Parameters
+        ----------
+        device_name : str
+            Device name.
+        device_name_dict : dict
+            Device name dictionary.
+
+        Returns
+        -------
+        device_config_list : list
+            Device configuration list.
+        device_name_list : list
+            Device name list.
+        """
+        device_config_list = []
+        device_name_list = []
+
+        devices = self.configuration["configuration"]["microscopes"][
+            self.microscope_name
+        ][device_name]
+
+        if type(devices) == ListProxy:
+            i = 0
+            for d in devices:
+                device_config_list.append(d)
+                if device_name in device_name_dict:
+                    device_name_list.append(
+                        build_ref_name("_", d[device_name_dict[device_name]])
+                    )
+
+                else:
+                    device_name_list.append(build_ref_name("_", device_name, i))
+                i += 1
+            is_list = True
+
+        else:
+            device_config_list.append(devices)
+            is_list = False
+
+        return device_config_list, device_name_list, is_list
+
+    def load_and_start_devices(
+        self,
+        device_name,
+        is_list,
+        device_name_list,
+        device_ref_name,
+        i,
+    ):
+        """Load and start devices.
+
+        Parameters
+        ----------
+        device_name : str
+            Device name.
+        is_list : bool
+            Is list.
+        device_name_list : list
+            Device name list.
+        device_ref_name : str
+            Device reference name.
+        i : int
+            Index.
+
+        Returns
+        -------
+        None
+        """
+        # Import start_device classes
+        try:
+            exec(
+                f"start_{device_name}=importlib.import_module("
+                f"'aslm.model.device_startup_functions').start_{device_name}"
+            )
+        except AttributeError:
+            print(f"Could not import start_{device_name}")
+            print(f"Could not load device {device_name}")
+
+        # Start the devices
+        if is_list:
+            exec(
+                f"self.{device_name}['{device_name_list[i]}'] = "
+                f"start_{device_name}(name, device_connection, configuration, "
+                f"i, is_synthetic)"
+            )
+            if device_name in device_name_list[i]:
+                self.info[device_name_list[i]] = device_ref_name
+        else:
+            exec(
+                f"self.{device_name} = start_{device_name}(name, "
+                f"device_connection, configuration, is_synthetic)"
+            )
+            self.info[device_name] = device_ref_name


### PR DESCRIPTION
Addresses:
#447 - Added functionality to the controller that now overwrites the .config/experiment.yml file upon exit. Thus, when the program is reloaded, it is in the same state that it was exited in. 

#429 - ASI Filter Wheel Commands now added. Only one instance of the device_connection can exist for the ASI Tiger Controller, which controls both the filter wheels, dichroic changers (not yet implemented), and stages.  Cleaned up the Microscope object to make the dictionary parsing and logic slightly more clear (broke it up into a few more sub functions). I believe the logic now makes sense to me, but I will need to make sure that the ASI device_connection gets passed to both the stages and filter wheels in the morning. 

Also, given that I mucked around with the microscope object, which is obviously critical, we should test this on more than one microscope.