### PR TITLE
Remove self.is_acquiring from Hamamatsu API.

### DIFF
--- a/src/aslm/model/devices/APIs/hamamatsu/HamamatsuAPI.py
+++ b/src/aslm/model/devices/APIs/hamamatsu/HamamatsuAPI.py
@@ -718,8 +718,6 @@ class DCAM:
         self.max_image_width = self.get_property_value("image_width")
         self.max_image_height = self.get_property_value("image_height")
 
-        self.is_acquiring = False
-
         self._serial_number = self.get_string_value(
             c_int32(int("0x04000102", 0))
         ).strip("S/N: ")
@@ -1114,8 +1112,6 @@ class DCAM:
         if self.__result(dcambuf_attach(self.__hdcam, attach_param)):
             self.pre_frame_count = 0
             self.pre_index = 0
-            # start capture
-            self.is_acquiring = True
             return self.__result(dcamcap_start(self.__hdcam, DCAMCAP_START_SEQUENCE))
         return False
 
@@ -1125,8 +1121,6 @@ class DCAM:
         """
         # stop capture
         dcamcap_stop(self.__hdcam)
-
-        self.is_acquiring = False
 
         # detach buffer
         return self.__result(dcambuf_release(self.__hdcam, DCAMBUF_ATTACHKIND_FRAME))

--- a/src/aslm/model/devices/camera/camera_synthetic.py
+++ b/src/aslm/model/devices/camera/camera_synthetic.py
@@ -183,7 +183,6 @@ class SyntheticCamera(CameraBase):
         """
         self.pre_frame_idx = 0
         self.current_frame_idx = 0
-        self.camera_controller.is_acquiring = False
         self.is_acquiring = False
 
     def load_images(self, filenames=None, ds=None):

--- a/test/model/devices/APIs/hamamatsu/test_hamamatsu_api.py
+++ b/test/model/devices/APIs/hamamatsu/test_hamamatsu_api.py
@@ -50,7 +50,7 @@ def open_camera():
         except:
             continue
     yield camera
-    if camera != None:
+    if camera is not None:
         assert camReg.numCameras == 1
         camera.dev_close()
         assert camReg.numCameras == 0
@@ -61,7 +61,7 @@ class TestHamamatsuAPI:
     @pytest.fixture(autouse=True)
     def _prepare_camera(self, open_camera):
         self.camera = open_camera
-        assert self.camera != None
+        assert self.camera is not None
 
     def test_get_and_set_property_value(self):
         # set property
@@ -144,14 +144,12 @@ class TestHamamatsuAPI:
 
         # attach a buffer without detach a buffer
         r = self.camera.start_acquisition(data_buffer, number_of_frames)
-        assert r == True, "attach the buffer correctly!"
+        assert r is True, "attach the buffer correctly!"
         r = self.camera.start_acquisition(data_buffer, number_of_frames)
         # Confirmed that we can't attach a new buffer before detaching one
-        assert r == False, "attach the buffer correctly!"
+        assert r is False, "attach the buffer correctly!"
 
         self.camera.start_acquisition(data_buffer, number_of_frames)
-
-        assert self.camera.is_acquiring == True, "camera should start acquiring data!"
 
         readout_time = self.camera.get_property_value("readout_time")
 
@@ -167,7 +165,6 @@ class TestHamamatsuAPI:
             assert len(frames) == trigger_num, "can not get all the frames back!"
 
         self.camera.stop_acquisition()
-        assert self.camera.is_acquiring == False, "camera should stop acquiring data!"
 
         # detach a detached buffer
         self.camera.stop_acquisition()

--- a/test/model/devices/camera/test_camera_synthetic.py
+++ b/test/model/devices/camera/test_camera_synthetic.py
@@ -183,7 +183,7 @@ class TestSyntheticCamera:
 
         self.synthetic_camera.close_image_series()
         assert (
-            self.synthetic_camera.is_acquiring == False
+            self.synthetic_camera.is_acquiring is False
         ), "is_acquiring should be False"
 
     def test_synthetic_get_camera_minimum_wating_time(self):


### PR DESCRIPTION
self.is_acquiring was already defined in the camera parent class (camera_base.py).

Deleted self.is_acquiring from the API and the test class for testing the API.

There was some potential for confusion as both the API and the device classes had self.is_aquiring flags.