### PR TITLE
Subclass Hamamatsu ORCA-Lightning

### DIFF
--- a/src/aslm/controller/sub_controllers/camera_setting_controller.py
+++ b/src/aslm/controller/sub_controllers/camera_setting_controller.py
@@ -425,7 +425,7 @@ class CameraSettingController(GUIController):
         """Calculate camera readout time.
 
 
-        TODO: Highly specific to Hamamatsu.
+        TODO: Highly specific to Hamamatsu Orca Flash 4.0.
         Should find a way to pass this from the camera to here.
         This should be moved to the camera device/API,
         ideally by calling a command from the camera.

--- a/src/aslm/model/device_startup_functions.py
+++ b/src/aslm/model/device_startup_functions.py
@@ -133,12 +133,13 @@ def load_camera_connection(configuration, camera_id=0, is_synthetic=False):
             "type"
         ]
 
-    if cam_type == "HamamatsuOrca":
+    if cam_type == "HamamatsuOrca" or cam_type == "HamamatsuOrcaLightning":
         # Locally Import Hamamatsu API and Initialize Camera Controller
         HamamatsuController = importlib.import_module(
             "aslm.model.devices.APIs.hamamatsu.HamamatsuAPI"
         )
         return auto_redial(HamamatsuController.DCAM, (camera_id,), exception=Exception)
+    
     elif cam_type.lower() == "syntheticcamera" or cam_type.lower() == "synthetic":
         from aslm.model.devices.camera.camera_synthetic import SyntheticCameraController
 

--- a/src/aslm/model/device_startup_functions.py
+++ b/src/aslm/model/device_startup_functions.py
@@ -183,10 +183,17 @@ def start_camera(microscope_name, device_connection, configuration, is_synthetic
 
     if cam_type == "HamamatsuOrca":
         from aslm.model.devices.camera.camera_hamamatsu import HamamatsuOrca
+
         return HamamatsuOrca(microscope_name, device_connection, configuration)
+
+    elif cam_type == "HamamatsuOrcaLightning":
+        from aslm.model.devices.camera.camera_hamamatsu import HamamatsuOrcaLightning
+
+        return HamamatsuOrcaLightning(microscope_name, device_connection, configuration)
 
     elif cam_type.lower() == "syntheticcamera" or cam_type.lower() == "synthetic":
         from aslm.model.devices.camera.camera_synthetic import SyntheticCamera
+
         return SyntheticCamera(microscope_name, device_connection, configuration)
 
     else:
@@ -287,12 +294,18 @@ def load_stages(configuration, is_synthetic=False):
             )
 
         elif stage_type == "ASI" and platform.system() == "Windows":
-            filter_wheel = configuration["configuration"]["hardware"]["filter_wheel"]['type']
+            filter_wheel = configuration["configuration"]["hardware"]["filter_wheel"][
+                "type"
+            ]
             if filter_wheel == "ASI":
                 stage_devices.append("shared device")
             else:
-                from aslm.model.devices.stages.stage_asi import build_ASI_Stage_connection
-                from aslm.model.devices.APIs.asi.asi_tiger_controller import TigerException
+                from aslm.model.devices.stages.stage_asi import (
+                    build_ASI_Stage_connection,
+                )
+                from aslm.model.devices.APIs.asi.asi_tiger_controller import (
+                    TigerException,
+                )
 
                 stage_devices.append(
                     auto_redial(
@@ -359,30 +372,37 @@ def start_stage(
 
     if device_type == "PI":
         from aslm.model.devices.stages.stage_pi import PIStage
+
         return PIStage(microscope_name, device_connection, configuration, id)
 
     elif device_type == "MP285":
         from aslm.model.devices.stages.stage_sutter import SutterStage
+
         return SutterStage(microscope_name, device_connection, configuration, id)
 
     elif device_type == "Thorlabs":
         from aslm.model.devices.stages.stage_tl_kcube_inertial import TLKIMStage
+
         return TLKIMStage(microscope_name, device_connection, configuration, id)
 
     elif device_type == "MCL":
         from aslm.model.devices.stages.stage_mcl import MCLStage
+
         return MCLStage(microscope_name, device_connection, configuration, id)
 
     elif device_type == "ASI":
         from aslm.model.devices.stages.stage_asi import ASIStage
+
         return ASIStage(microscope_name, device_connection, configuration, id)
 
     elif device_type == "GalvoNIStage":
         from aslm.model.devices.stages.stage_galvo import GalvoNIStage
+
         return GalvoNIStage(microscope_name, device_connection, configuration, id)
 
     elif device_type.lower() == "syntheticstage" or device_type.lower() == "synthetic":
         from aslm.model.devices.stages.stage_synthetic import SyntheticStage
+
         return SyntheticStage(microscope_name, device_connection, configuration, id)
 
     else:
@@ -504,7 +524,10 @@ def load_filter_wheel_connection(configuration, is_synthetic=False):
         device_type = device_info["type"]
 
     if device_type == "SutterFilterWheel":
-        from aslm.model.devices.filter_wheel.filter_wheel_sutter import build_filter_wheel_connection
+        from aslm.model.devices.filter_wheel.filter_wheel_sutter import (
+            build_filter_wheel_connection,
+        )
+
         return auto_redial(
             build_filter_wheel_connection,
             (device_info["port"], device_info["baudrate"], 0.25),
@@ -512,7 +535,10 @@ def load_filter_wheel_connection(configuration, is_synthetic=False):
         )
 
     elif device_type == "ASI":
-        from aslm.model.devices.filter_wheel.filter_wheel_asi import build_filter_wheel_connection
+        from aslm.model.devices.filter_wheel.filter_wheel_asi import (
+            build_filter_wheel_connection,
+        )
+
         tiger_controller = auto_redial(
             build_filter_wheel_connection,
             (device_info["port"], device_info["baudrate"], 0.25),
@@ -520,7 +546,10 @@ def load_filter_wheel_connection(configuration, is_synthetic=False):
         )
         return tiger_controller
 
-    elif device_type.lower() == "syntheticfilterwheel" or device_type.lower() == "synthetic":
+    elif (
+        device_type.lower() == "syntheticfilterwheel"
+        or device_type.lower() == "synthetic"
+    ):
         return DummyDeviceConnection()
 
     else:
@@ -565,11 +594,15 @@ def start_filter_wheel(
         ]["hardware"]["type"]
 
     if device_type == "SutterFilterWheel":
-        from aslm.model.devices.filter_wheel.filter_wheel_sutter import SutterFilterWheel
+        from aslm.model.devices.filter_wheel.filter_wheel_sutter import (
+            SutterFilterWheel,
+        )
+
         return SutterFilterWheel(microscope_name, device_connection, configuration)
 
     elif device_type == "ASI":
         from aslm.model.devices.filter_wheel.filter_wheel_asi import ASIFilterWheel
+
         return ASIFilterWheel(microscope_name, device_connection, configuration)
 
     elif (
@@ -613,10 +646,12 @@ def start_daq(configuration, is_synthetic=False):
 
     if device_type == "NI":
         from aslm.model.devices.daq.daq_ni import NIDAQ
+
         return NIDAQ(configuration)
 
     elif device_type.lower() == "syntheticdaq" or device_type.lower() == "synthetic":
         from aslm.model.devices.daq.daq_synthetic import SyntheticDAQ
+
         return SyntheticDAQ(configuration)
 
     else:

--- a/src/aslm/model/devices/camera/camera_hamamatsu.py
+++ b/src/aslm/model/devices/camera/camera_hamamatsu.py
@@ -46,6 +46,8 @@ logger = logging.getLogger(p)
 class HamamatsuOrca(CameraBase):
     """HamamatsuOrca camera class.
 
+    This is by default for an Orca Flash 4.0.
+
     Parameters
     ----------
     microscope_name : str
@@ -72,9 +74,7 @@ class HamamatsuOrca(CameraBase):
         self.camera_controller.set_property_value(
             "binning", int(self.camera_parameters["binning"][0])
         )
-        self.camera_controller.set_property_value(
-            "readout_speed", self.camera_parameters["readout_speed"]
-        )
+        self.camera_controller.set_property_value("readout_speed", 0x7FFFFFFF)
         self.camera_controller.set_property_value(
             "trigger_active", self.camera_parameters["trigger_active"]
         )
@@ -397,3 +397,45 @@ class HamamatsuOrca(CameraBase):
         # trigger_interval =
         #   self.camera_controller.get_property_value('minimum_trigger_interval')
         return trigger_blank
+
+
+class HamamatsuOrcaLightning(HamamatsuOrca):
+    def __init__(self, microscope_name, device_connection, configuration):
+        CameraBase.__init__(self, microscope_name, device_connection, configuration)
+
+        # Values are pulled from the CameraParameters section of the configuration.yml
+        # file. Exposure time converted here from milliseconds to seconds.
+        self.set_sensor_mode(self.camera_parameters["sensor_mode"])
+
+        self.camera_controller.set_property_value(
+            "defect_correct_mode", self.camera_parameters["defect_correct_mode"]
+        )
+        self.camera_controller.set_property_value(
+            "exposure_time", self.camera_parameters["exposure_time"] / 1000
+        )
+        self.camera_controller.set_property_value(
+            "binning", int(self.camera_parameters["binning"][0])
+        )
+        self.camera_controller.set_property_value(
+            "trigger_active", self.camera_parameters["trigger_active"]
+        )
+        self.camera_controller.set_property_value(
+            "trigger_mode", self.camera_parameters["trigger_mode"]
+        )
+        self.camera_controller.set_property_value(
+            "trigger_polarity", self.camera_parameters["trigger_polarity"]
+        )
+        self.camera_controller.set_property_value(
+            "trigger_source", self.camera_parameters["trigger_source"]
+        )
+
+        logger.info("HamamatsuOrcaLightning Initialized")
+
+    def calculate_light_sheet_exposure_time(
+        self, full_chip_exposure_time, shutter_width
+    ):
+        self.camera_line_interval = (full_chip_exposure_time / 1000) / (
+            (shutter_width + self.y_pixels) / 4 + 6
+        )
+        exposure_time = self.camera_line_interval * (shutter_width / 4) * 1000
+        return exposure_time, self.camera_line_interval


### PR DESCRIPTION
The lightning is sufficiently different to need changes in the light sheet readout parameters.

Here I also incorporate @annie-xd-wang 's solution in de8b3f4514688fe8427c76caf7a1a8269932c6aa / #409 as hardcoded. This may throw a warning in `set_property_value()`, but it effectively always sets the camera to run in its fastest mode. I also kill readout speed in the Lightning `__init__()`, since this property is not used.