### PR TITLE
Add debug to VolumeSearch and stabilize camera/stage orientation

### DIFF
--- a/src/aslm/model/analysis/boundary_detect.py
+++ b/src/aslm/model/analysis/boundary_detect.py
@@ -37,7 +37,7 @@ from skimage.transform import downscale_local_mean
 import numpy as np
 import numpy.typing as npt
 
-from aslm.model.analysis.camera import compute_signal_to_noise
+# from aslm.model.analysis.camera import compute_signal_to_noise
 
 
 def has_tissue(
@@ -76,18 +76,18 @@ def has_tissue(
     ysl = slice(y * width, (y + 1) * width)
 
     # Decide tissue is present by hard SNR threshold
-    if offset is not None and variance is not None:
-        threshold_value = 2  # snr threshold
-        snr = compute_signal_to_noise(
-            image_data[xsl, ysl], offset[xsl, ysl], variance[xsl, ysl]
-        )
-        return (
-            np.sum(snr > threshold_value) / np.prod(snr.shape) > 0.0625
-        )  # at least 6.25% of pixels have to be above this value
+    # if offset is not None and variance is not None:
+    #     threshold_value = 2  # snr threshold
+    #     snr = compute_signal_to_noise(
+    #         image_data[xsl, ysl], offset[xsl, ysl], variance[xsl, ysl]
+    #     )
+    #     return (
+    #         np.sum(snr > threshold_value) / np.prod(snr.shape) > 0.0625
+    #     )  # at least 6.25% of pixels have to be above this value
 
     # Decide tissue is present by hard pixel count threshold
-    threshold_value = 1000
-    return np.any(image_data[xsl, ysl] > threshold_value)
+    # threshold_value = 1000
+    return np.any(image_data[xsl, ysl] > np.mean(image_data))
 
 
 def find_tissue_boundary_2d(

--- a/src/aslm/model/features/volume_search.py
+++ b/src/aslm/model/features/volume_search.py
@@ -323,11 +323,13 @@ class VolumeSearch:
                             int(
                                 item[0] * self.target_grid_pixels * (1 - self.overlap)
                                 + self.target_grid_pixels
-                            ),
+                            )
+                            - 1,
                             int(
                                 item[1] * self.target_grid_pixels * (1 - self.overlap)
                                 + self.target_grid_pixels
-                            ),
+                            )
+                            - 1,
                         )
             self.model.event_queue.put(("multiposition", positions))
             if self.debug:

--- a/src/aslm/model/features/volume_search.py
+++ b/src/aslm/model/features/volume_search.py
@@ -318,8 +318,8 @@ class VolumeSearch:
                             self.volumes_selected[z_index],
                             item[0] * self.target_grid_pixels,
                             item[1] * self.target_grid_pixels,
-                            (item[0] + 1) * self.target_grid_pixels,
-                            (item[1] + 1) * self.target_grid_pixels,
+                            (item[0] + 1) * self.target_grid_pixels - 1,
+                            (item[1] + 1) * self.target_grid_pixels - 1,
                         )
             self.model.event_queue.put(("multiposition", positions))
             if self.debug:

--- a/src/aslm/model/features/volume_search.py
+++ b/src/aslm/model/features/volume_search.py
@@ -316,10 +316,20 @@ class VolumeSearch:
                     for item in path:
                         self.volumes_selected[z_index] = draw_box(
                             self.volumes_selected[z_index],
-                            item[0] * self.target_grid_pixels,
-                            item[1] * self.target_grid_pixels,
-                            (item[0] + 1) * self.target_grid_pixels - 1,
-                            (item[1] + 1) * self.target_grid_pixels - 1,
+                            int(item[0] * self.target_grid_pixels * (1 - self.overlap)),
+                            int(item[1] * self.target_grid_pixels * (1 - self.overlap)),
+                            int(
+                                (item[0] + 1)
+                                * self.target_grid_pixels
+                                * (1 - self.overlap)
+                                - 1
+                            ),
+                            int(
+                                (item[1] + 1)
+                                * self.target_grid_pixels
+                                * (1 - self.overlap)
+                                - 1
+                            ),
                         )
             self.model.event_queue.put(("multiposition", positions))
             if self.debug:

--- a/src/aslm/model/features/volume_search.py
+++ b/src/aslm/model/features/volume_search.py
@@ -321,16 +321,12 @@ class VolumeSearch:
                             int(item[0] * self.target_grid_pixels * (1 - self.overlap)),
                             int(item[1] * self.target_grid_pixels * (1 - self.overlap)),
                             int(
-                                (item[0] + 1)
-                                * self.target_grid_pixels
-                                * (1 - self.overlap)
-                                - 1
+                                item[0] * self.target_grid_pixels * (1 - self.overlap)
+                                + self.target_grid_pixels
                             ),
                             int(
-                                (item[1] + 1)
-                                * self.target_grid_pixels
-                                * (1 - self.overlap)
-                                - 1
+                                item[1] * self.target_grid_pixels * (1 - self.overlap)
+                                + self.target_grid_pixels
                             ),
                         )
             self.model.event_queue.put(("multiposition", positions))

--- a/src/aslm/model/features/volume_search.py
+++ b/src/aslm/model/features/volume_search.py
@@ -95,8 +95,10 @@ class VolumeSearch:
         self.f_offset = 0
         self.curr_z_index = 0
 
-        self.sinx = -1 if flipx else 1
-        self.siny = -1 if flipy else 1
+        # By default an increase in x/y stage position corresponds
+        # to a sample moving down/right into the field of view
+        self.sinx = 1 if flipx else -1
+        self.siny = 1 if flipy else -1
 
         self.overlap = max(0, min(overlap, 0.999))
 
@@ -230,14 +232,14 @@ class VolumeSearch:
                 ]["stage"][t]
             )
 
-        # Add to this the offset between
+        # Set this to the upper left corner of the image
         self.offset[0] += (
             self.model.configuration["experiment"]["StageParameters"]["x"]
-            - (img_width - self.target_grid_pixels) // 2 * curr_pixel_size
+            - self.sinx * (img_width - self.target_grid_pixels) // 2 * curr_pixel_size
         )
         self.offset[1] += (
             self.model.configuration["experiment"]["StageParameters"]["y"]
-            - (img_width - self.target_grid_pixels) // 2 * curr_pixel_size
+            - self.siny * (img_width - self.target_grid_pixels) // 2 * curr_pixel_size
         )
         self.offset[2] += self.z_pos
         self.offset[3] += self.model.configuration["experiment"]["StageParameters"][

--- a/src/aslm/model/model.py
+++ b/src/aslm/model/model.py
@@ -212,7 +212,7 @@ class Model:
             [
                 {
                     "name": VolumeSearch,
-                    "args": ("Nanoscale", "N/A", False, False, 0.1),
+                    "args": ("Nanoscale", "N/A", True, False, 0.1),
                 }
             ]
         )


### PR DESCRIPTION
The crux of the issue came down to the orientation of the stage movement w.r.t. camera orientation. To address this, I have implemented the rule: By default, an increase in x/y stage position corresponds to a sample moving down/right (to a higher pixel index) into the camera's field of view. This can be changed on a per microscope basis by passing `flipx` and `flipy` flags. Currently this is only implemented for `VolumeSearch`, but it seems reasonable to extend this to other features and maybe even make it a microscope property.