### PR TITLE
Change BDV HDF5 extension to H5 to match OME spec

### DIFF
--- a/src/aslm/model/data_sources/__init__.py
+++ b/src/aslm/model/data_sources/__init__.py
@@ -1,4 +1,4 @@
-FILE_TYPES = ["TIFF", "OME-TIFF", "HDF", "N5"]
+FILE_TYPES = ["TIFF", "OME-TIFF", "H5", "N5"]
 
 
 def get_data_source(file_type):
@@ -30,7 +30,7 @@ def get_data_source(file_type):
 
         return ZarrDataSource
 
-    elif (file_type == "HDF") or file_type == ("N5"):
+    elif (file_type == "H5") or file_type == ("N5"):
         from .bdv_data_source import BigDataViewerDataSource
 
         return BigDataViewerDataSource

--- a/src/aslm/model/data_sources/bdv_data_source.py
+++ b/src/aslm/model/data_sources/bdv_data_source.py
@@ -55,9 +55,8 @@ class BigDataViewerDataSource(DataSource):
         self._views = []
         self.__store = None
 
-        # file_name = ".".join(file_name.split(".")[:-1]) + ".hdf"
         self.__file_type = os.path.splitext(os.path.basename(file_name))[-1][1:].lower()
-        if self.__file_type not in ["hdf", "n5"]:
+        if self.__file_type not in ["h5", "n5"]:
             raise ValueError(f"Unknown file type {self.__file_type}.")
         super().__init__(file_name, mode)
 
@@ -110,12 +109,12 @@ class BigDataViewerDataSource(DataSource):
             self._current_frame, self.metadata.per_stack
         )  # find current channel
         if (z == 0) and (c == 0) and (t == 0) and (p == 0):
-            if self.__file_type == "hdf":
+            if self.__file_type == "h5":
                 self._setup_h5()
             elif self.__file_type == "n5":
                 self._setup_n5()
 
-        if self.__file_type == "hdf":
+        if self.__file_type == "h5":
             time_group_name = f"t{t:05}"
             setup_group_name = f"s{(c*self.positions+p):02}"
             ds_name = "/".join([time_group_name, setup_group_name, "???", "cells"])
@@ -144,7 +143,7 @@ class BigDataViewerDataSource(DataSource):
 
     def read(self) -> None:
         self.mode = "r"
-        if self.__file_type == "hdf":
+        if self.__file_type == "h5":
             self.image = h5py.File(self.file_name, "r")
         elif self.__file_type == "n5":
             self.image = zarr.N5Store(self.file_name)
@@ -215,7 +214,7 @@ class BigDataViewerDataSource(DataSource):
         if self._write_mode:
             self._current_frame = 0
             self._views = []
-            if self.__file_type == "hdf":
+            if self.__file_type == "h5":
                 self._setup_h5()
             elif self.__file_type == "n5":
                 self._setup_n5()

--- a/src/aslm/model/metadata_sources/bdv_metadata.py
+++ b/src/aslm/model/metadata_sources/bdv_metadata.py
@@ -60,7 +60,7 @@ class BigDataViewerMetadata(XMLMetadata):
         bdv_dict["SequenceDescription"] = {}
 
         ext = os.path.basename(file_name).split(".")[-1]
-        if ext == "hdf":
+        if ext == "h5":
             """
             <ImageLoader format="bdv.hdf5">
                 <hdf5 type="relative">dataset.h5</hdf5>

--- a/test/model/data_sources/test_bdv_data_source.py
+++ b/test/model/data_sources/test_bdv_data_source.py
@@ -10,7 +10,7 @@ from aslm.tools.file_functions import delete_folder
 @pytest.mark.parametrize("per_stack", [True, False])
 @pytest.mark.parametrize("z_stack", [True, False])
 @pytest.mark.parametrize("stop_early", [True, False])
-@pytest.mark.parametrize("ext", ["hdf", "n5"])
+@pytest.mark.parametrize("ext", ["h5", "n5"])
 def test_bdv_write(multiposition, per_stack, z_stack, stop_early, ext):
     from aslm.model.dummy import DummyModel
     from aslm.model.data_sources.bdv_data_source import BigDataViewerDataSource


### PR DESCRIPTION
Enables BDV HDF files to be imported via Bio-Formats (e.g. Fiji, Plugins > Bio-Formats > Bio-Formats Importer).