### PR TITLE
Smoothing low samples

### DIFF
--- a/src/aslm/model/waveforms.py
+++ b/src/aslm/model/waveforms.py
@@ -389,6 +389,9 @@ def smooth_waveform(waveform, percent_smoothing=10):
     """
     waveform_length = np.size(waveform)
     window_length = int(np.floor(waveform_length * percent_smoothing / 100))
+    if window_length == 0:
+        # cannot smooth
+        return waveform
     waveform_padded = np.pad(waveform, int(window_length // 2), mode="edge")
     smoothed_waveform = (
         np.convolve(waveform_padded, np.ones(window_length), "valid") / window_length

--- a/test/model/test_waveforms.py
+++ b/test/model/test_waveforms.py
@@ -208,3 +208,10 @@ class TestWaveforms(unittest.TestCase):
         waveform = waveforms.remote_focus_ramp()
         smoothed_waveform = waveforms.smooth_waveform(waveform, 10)
         self.assertEqual(np.size(smoothed_waveform), np.size(waveform))
+
+    def test_smoothing_low_sampling(self):
+        waveform_smoothing_pct = 10
+        waveform = waveforms.remote_focus_ramp(sample_rate=16)
+        smoothed_waveform = waveforms.smooth_waveform(waveform, waveform_smoothing_pct)
+        assert(len(waveform) < waveform_smoothing_pct)
+        np.testing.assert_array_equal(waveform, smoothed_waveform)

--- a/test/model/test_waveforms.py
+++ b/test/model/test_waveforms.py
@@ -215,3 +215,7 @@ class TestWaveforms(unittest.TestCase):
         smoothed_waveform = waveforms.smooth_waveform(waveform, waveform_smoothing_pct)
         assert(len(waveform)*waveform_smoothing_pct/100 < 1)
         np.testing.assert_array_equal(waveform, smoothed_waveform)
+
+        waveform = waveforms.remote_focus_ramp(sample_rate=1000)
+        smoothed_waveform = waveforms.smooth_waveform(waveform, waveform_smoothing_pct)
+        assert waveform.shape == smoothed_waveform.shape

--- a/test/model/test_waveforms.py
+++ b/test/model/test_waveforms.py
@@ -213,5 +213,5 @@ class TestWaveforms(unittest.TestCase):
         waveform_smoothing_pct = 10
         waveform = waveforms.remote_focus_ramp(sample_rate=16)
         smoothed_waveform = waveforms.smooth_waveform(waveform, waveform_smoothing_pct)
-        assert(len(waveform) < waveform_smoothing_pct)
+        assert(len(waveform)*waveform_smoothing_pct/100 < 1)
         np.testing.assert_array_equal(waveform, smoothed_waveform)


### PR DESCRIPTION
In the event we subsample so that the waveform is so short the smoothing window is <1 sample, return the original sample.