### PR TITLE
Add proper sweep_time calc to smoothing

### DIFF
--- a/src/aslm/model/devices/galvo/galvo_ni.py
+++ b/src/aslm/model/devices/galvo/galvo_ni.py
@@ -74,7 +74,7 @@ class GalvoNI(GalvoBase):
         Initialize the NI DAQ task for the galvo
     __del__()
         Deletes the task.
-    adjust(readout_time)
+    adjust(exposure_times, sweep_times)
         Adjust the galvo to the readout time
     prepare_task(channel_key)
         Prepare the task for the given channel
@@ -88,7 +88,7 @@ class GalvoNI(GalvoBase):
     Examples
     --------
     >>> galvo = GalvoNI(microscope_name, device_connection, configuration, galvo_id=0)
-    >>> galvo.adjust(readout_time)
+    >>> galvo.adjust(exposure_times, sweep_times)
     >>> galvo.prepare_task(channel_key)
     >>> galvo.start_task()
     >>> galvo.stop_task(force=False)
@@ -158,13 +158,15 @@ class GalvoNI(GalvoBase):
         self.stop_task()
         self.close_task()
 
-    def adjust(self, readout_time):
+    def adjust(self, exposure_times, sweep_times):
         """Adjust the galvo to the readout time
 
         Parameters
         ----------
-        readout_time : float
-            The readout time in seconds
+        exposure_times : dict
+            Dictionary of exposure times for each selected channel
+        sweep_times : dict
+            Dictionary of sweep times for each selected channel
 
         Returns
         -------
@@ -172,9 +174,9 @@ class GalvoNI(GalvoBase):
 
         Examples
         --------
-        >>> galvo.adjust(readout_time)
+        >>> galvo.adjust(exposure_times, sweep_times)
         """
-        waveform_dict = super().adjust(readout_time)
+        waveform_dict = super().adjust(exposure_times, sweep_times)
 
         self.daq.analog_outputs[self.device_config["hardware"]["channel"]] = {
             "sample_rate": self.sample_rate,
@@ -261,6 +263,6 @@ class GalvoNI(GalvoBase):
         --------
         >>> galvo.close_task()
         """
-        
+
         # self.task.close()
         pass

--- a/src/aslm/model/devices/remote_focus/remote_focus_base.py
+++ b/src/aslm/model/devices/remote_focus/remote_focus_base.py
@@ -147,6 +147,15 @@ class RemoteFocusBase:
             self.microscope_name
         ]["daq"]["sample_rate"]
 
+        duty_cycle_wait_duration = (
+            float(
+                self.configuration["waveform_constants"]
+                .get("other_constants", {})
+                .get("remote_focus_settle_duration", 0)
+            )
+            / 1000
+        )
+
         for channel_key in microscope_state["channels"].keys():
             # channel includes 'is_selected', 'laser', 'filter', 'camera_exposure'...
             channel = microscope_state["channels"][channel_key]
@@ -169,7 +178,7 @@ class RemoteFocusBase:
                     ][channel["laser"]].get("percent_smoothing", 0.0)
                 )
                 if ps > 0:
-                    self.sweep_time = (1 - ps / 100) * self.sweep_time
+                    self.sweep_time = (self.sweep_time - duty_cycle_wait_duration) / (1 + ps / 100) + duty_cycle_wait_duration
 
                 # Remote Focus Parameters
                 temp = waveform_constants["remote_focus_constants"][imaging_mode][zoom][

--- a/src/aslm/model/devices/remote_focus/remote_focus_ni.py
+++ b/src/aslm/model/devices/remote_focus/remote_focus_ni.py
@@ -80,7 +80,7 @@ class RemoteFocusNI(RemoteFocusBase):
         Initialize the task.
     __del__()
         Delete the task.
-    adjust(readout_time)
+    adjust(exposure_times, sweep_times)
         Adjust the waveform.
     prepare_task(channel_key)
         Prepare the task.
@@ -146,15 +146,17 @@ class RemoteFocusNI(RemoteFocusBase):
         self.stop_task()
         self.close_task()
 
-    def adjust(self, readout_time, offset=None):
+    def adjust(self, exposure_times, sweep_times, offset=None):
         """Adjust the waveform.
 
         This method adjusts the waveform.
 
         Parameters
         ----------
-        readout_time : float
-            The readout time.
+        exposure_times : dict
+            Dictionary of exposure times for each selected channel
+        sweep_times : dict
+            Dictionary of sweep times for each selected channel
 
         Returns
         -------
@@ -162,9 +164,9 @@ class RemoteFocusNI(RemoteFocusBase):
 
         Examples
         --------
-        >>> self.adjust(readout_time)
+        >>> self.adjust(exposure_times, sweep_times)
         """
-        waveform_dict = super().adjust(readout_time, offset)
+        waveform_dict = super().adjust(exposure_times, sweep_times, offset)
 
         self.daq.analog_outputs[self.device_config["hardware"]["channel"]] = {
             "sample_rate": self.sample_rate,
@@ -174,9 +176,9 @@ class RemoteFocusNI(RemoteFocusBase):
         }
 
         return waveform_dict
-    
-    def move(self, readout_time, offset=None):
-        self.adjust(readout_time, offset)
+
+    def move(self, exposure_times, sweep_times, offset=None):
+        self.adjust(exposure_times, sweep_times, offset)
         self.daq.update_analog_task(self.board_name)
 
     def prepare_task(self, channel_key):

--- a/test/model/devices/daq/test_daq_base.py
+++ b/test/model/devices/daq/test_daq_base.py
@@ -3,7 +3,7 @@ def test_initialize_daq():
     from aslm.model.dummy import DummyModel
 
     model = DummyModel()
-    daq = DAQBase(model.configuration)
+    DAQBase(model.configuration)
 
 
 def test_calculate_all_waveforms():
@@ -14,21 +14,24 @@ def test_calculate_all_waveforms():
 
     model = DummyModel()
     daq = DAQBase(model.configuration)
-    microscope_name = model.configuration["experiment"]["MicroscopeState"][
-        "microscope_name"
-    ]
-    waveform_dict = daq.calculate_all_waveforms(microscope_name, np.random.rand())
+    microscope_state = model.configuration["experiment"]["MicroscopeState"]
+    microscope_name = microscope_state["microscope_name"]
+    exposure_times = {
+        k: v["camera_exposure_time"] / 1000
+        for k, v in microscope_state["channels"].items()
+    }
+    sweep_times = {
+        k: 2 * v["camera_exposure_time"] / 1000
+        for k, v in microscope_state["channels"].items()
+    }
+    waveform_dict = daq.calculate_all_waveforms(
+        microscope_name, exposure_times, sweep_times
+    )
 
     for k, v in waveform_dict.items():
-        try:
-            channel = model.configuration["experiment"]["MicroscopeState"]["channels"][
-                k
-            ]
-            if not channel["is_selected"]:
-                continue
-            exposure_time = channel["camera_exposure_time"] / 1000
-            print(k, channel["is_selected"], np.sum(v > 0), exposure_time)
-            assert np.sum(v > 0) == daq.sample_rate * exposure_time
-        except KeyError:
-            # The channel doesn't exist. Points to an issue in how waveform dict is created.
+        channel = microscope_state["channels"][k]
+        if not channel["is_selected"]:
             continue
+        exposure_time = channel["camera_exposure_time"] / 1000
+        print(k, channel["is_selected"], np.sum(v > 0), exposure_time)
+        assert np.sum(v > 0) == daq.sample_rate * exposure_time

--- a/test/model/devices/remote_focus/test_remote_focus_base.py
+++ b/test/model/devices/remote_focus/test_remote_focus_base.py
@@ -2,8 +2,8 @@
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without
-# modification, are permitted for academic and research use only (subject to the limitations in the disclaimer below)
-# provided that the following conditions are met:
+# modification, are permitted for academic and research use only (subject to the
+# limitations in the disclaimer below) provided that the following conditions are met:
 
 #      * Redistributions of source code must retain the above copyright notice,
 #      this list of conditions and the following disclaimer.
@@ -50,7 +50,6 @@ def test_remote_focus_base_init():
 
 
 def test_remote_focus_base_adjust():
-    import random
 
     from aslm.model.devices.remote_focus.remote_focus_base import RemoteFocusBase
     from aslm.model.dummy import DummyModel
@@ -59,9 +58,19 @@ def test_remote_focus_base_adjust():
     microscope_name = model.configuration["experiment"]["MicroscopeState"][
         "microscope_name"
     ]
+    microscope_state = model.configuration["experiment"]["MicroscopeState"]
     rf = RemoteFocusBase(microscope_name, None, model.configuration)
 
-    waveform_dict = rf.adjust(random.random())
+    exposure_times = {
+        k: v["camera_exposure_time"] / 1000
+        for k, v in microscope_state["channels"].items()
+    }
+    sweep_times = {
+        k: 2 * v["camera_exposure_time"] / 1000
+        for k, v in microscope_state["channels"].items()
+    }
+
+    waveform_dict = rf.adjust(exposure_times, sweep_times)
 
     for k, v in waveform_dict.items():
         try:
@@ -73,7 +82,8 @@ def test_remote_focus_base_adjust():
             assert np.all(v <= rf.remote_focus_max_voltage)
             assert np.all(v >= rf.remote_focus_min_voltage)
         except KeyError:
-            # The channel doesn't exist. Points to an issue in how waveform dict is created.
+            # The channel doesn't exist. Points to an issue in how waveform dict
+            # is created.
             continue
 
 

--- a/test/model/test_waveforms.py
+++ b/test/model/test_waveforms.py
@@ -225,5 +225,20 @@ class TestWaveforms(unittest.TestCase):
         waveform_smoothing_pct = 10
         waveform = waveforms.remote_focus_ramp(sample_rate=16)
         smoothed_waveform = waveforms.smooth_waveform(waveform, waveform_smoothing_pct)
-        assert(len(waveform)*waveform_smoothing_pct/100 < 1)
+        assert len(waveform) * waveform_smoothing_pct / 100 < 1
         np.testing.assert_array_equal(waveform, smoothed_waveform)
+
+    def test_camera_exposure(self):
+        sr, st, ex, cd = 100000, 0.5, 0.4, 10
+        v = waveforms.camera_exposure(
+            sample_rate=sr, sweep_time=st, exposure=ex, camera_delay=cd
+        )
+        assert np.sum(v > 0) == sr * ex
+
+    def test_camera_exposure_short(self):
+        """In the event the camera delay + exposure_time > sweep time..."""
+        sr, st, ex, cd = 100000, 0.4, 0.4, 10
+        v = waveforms.camera_exposure(
+            sample_rate=sr, sweep_time=st, exposure=ex, camera_delay=cd
+        )
+        assert np.sum(v > 0) == (1 - cd / 100) * sr * ex


### PR DESCRIPTION
Finishes #506. Moves sweep time calculation into single spot in `microscope.py`. Makes sure the waveforms all properly adjust on change of percent smoothing of remote focus ramp.