### PR TITLE
Adding few more menu items.

### DIFF
--- a/src/aslm/controller/sub_controllers/menu_controller.py
+++ b/src/aslm/controller/sub_controllers/menu_controller.py
@@ -490,14 +490,15 @@ class MenuController(GUIController):
         path : str
             Path to folder.
         """
-        if platform.system() == "Darwin":  # macOS
-            subprocess.check_call(["open", "--", path])
-
-        elif platform.system() == "Windows":  # Windows
-            subprocess.check_call(["explorer", path])
-
-        else:
-            print("Unsupported platform.")
+        try:
+            if platform.system() == "Darwin":  # macOS
+                subprocess.check_call(["open", "--", path])
+            elif platform.system() == "Windows":  # Windows
+                subprocess.check_call(["explorer", path])
+            else:
+                print("Unsupported platform.")
+        except subprocess.CalledProcessError:
+            pass
 
     def open_log_files(self):
         path = os.path.join(get_aslm_path(), "logs")

--- a/src/aslm/controller/sub_controllers/menu_controller.py
+++ b/src/aslm/controller/sub_controllers/menu_controller.py
@@ -36,6 +36,7 @@ import platform
 import os
 import tkinter as tk
 from tkinter import messagebox
+import subprocess
 
 # Third Party Imports
 
@@ -169,6 +170,15 @@ class MenuController(GUIController):
                 "Unload Images": [
                     "standard",
                     lambda: self.parent_controller.model.load_images(None),
+                    None,
+                    None,
+                    None,
+                ],
+                "add_separator_1": [None, None, None, None, None],
+                "Open Log Files": ["standard", self.open_log_files, None, None, None],
+                "Open Configuration Files": [
+                    "standard",
+                    self.open_configuration_files,
                     None,
                     None,
                     None,
@@ -471,6 +481,31 @@ class MenuController(GUIController):
             )
             self.feature_list_names.append(feature["feature_list_name"])
             self.feature_list_count += 1
+
+    def open_folder(self, path):
+        """Open folder in file explorer.
+
+        Parameters
+        ----------
+        path : str
+            Path to folder.
+        """
+        if platform.system() == "Darwin":  # macOS
+            subprocess.check_call(["open", "--", path])
+
+        elif platform.system() == "Windows":  # Windows
+            subprocess.check_call(["explorer", path])
+
+        else:
+            print("Unsupported platform.")
+
+    def open_log_files(self):
+        path = os.path.join(get_aslm_path(), "logs")
+        self.open_folder(path)
+
+    def open_configuration_files(self):
+        path = os.path.join(get_aslm_path(), "config")
+        self.open_folder(path)
 
     def populate_menu(self, menu_dict):
         """Populate the menus from a dictionary.

--- a/test/controller/sub_controllers/test_menu_controller.py
+++ b/test/controller/sub_controllers/test_menu_controller.py
@@ -32,7 +32,7 @@
 
 # Standard Library Imports
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 import tkinter as tk
 
 # Third Party Imports
@@ -206,3 +206,34 @@ class TestMenuController(unittest.TestCase):
                 self.menu_controller.parent_controller.view.settings.index("current")
                 == i - 1
             )
+
+    @patch("src.aslm.controller.sub_controllers.menu_controller.platform.system")
+    @patch("src.aslm.controller.sub_controllers.menu_controller.subprocess.check_call")
+    def test_open_folder(self, mock_check_call, mock_system):
+        mock_system.return_value = "Darwin"
+        self.menu_controller.open_folder("test_path")
+        mock_check_call.assert_called_once_with(["open", "--", "test_path"])
+
+        mock_check_call.reset_mock()
+        mock_system.return_value = "Windows"
+        self.menu_controller.open_folder("test_path")
+        mock_check_call.assert_called_once_with(["explorer", "test_path"])
+
+        mock_check_call.reset_mock()
+        mock_system.return_value = "Linux"
+        self.menu_controller.open_folder("test_path")
+        self.assertEqual(mock_check_call.call_count, 0)
+
+    @patch("src.aslm.controller.sub_controllers.menu_controller.os.path.join")
+    def test_open_log_files(self, mock_join):
+        with patch.object(self.menu_controller, "open_folder") as mock_open_folder:
+            mock_join.return_value = "joined_path"
+            self.menu_controller.open_log_files()
+            mock_open_folder.assert_called_once_with("joined_path")
+
+    @patch("src.aslm.controller.sub_controllers.menu_controller.os.path.join")
+    def test_open_configuration_files(self, mock_join):
+        with patch.object(self.menu_controller, "open_folder") as mock_open_folder:
+            mock_join.return_value = "joined_path"
+            self.menu_controller.open_configuration_files()
+            mock_open_folder.assert_called_once_with("joined_path")


### PR DESCRIPTION
Idea is that I want to make it as easy as possible for new users to access the logs, and these files (as well as the configuration file) are somewhat hidden to the uninitiated. So, now they can call a menu item to pull it up. That way, when they have an issue, they can also submit the logs. Needs to be tested on a Windows machine...