### PR TITLE
Reflect multiposition state changes in experiment config in controller

### DIFF
--- a/src/aslm/controller/controller.py
+++ b/src/aslm/controller/controller.py
@@ -986,7 +986,8 @@ class Controller:
                     table=self.view.settings.multiposition_tab.multipoint_list.get_table(),
                     pos=value,
                 )
-                self.view.settings.channels_tab.multipoint_frame.on_off.set(True)
+                self.channels_tab_controller.is_multiposition_val.set(True)
+                self.channels_tab_controller.toggle_multiposition()
 
             elif event == "ilastik_mask":
                 # Display the ilastik mask

--- a/src/aslm/controller/sub_controllers/channels_tab_controller.py
+++ b/src/aslm/controller/sub_controllers/channels_tab_controller.py
@@ -324,6 +324,10 @@ class ChannelsTabController(GUIController):
         self.set_info(self.conpro_acq_vals, self.microscope_state_dict)
         self.set_info(self.timepoint_vals, self.microscope_state_dict)
 
+        # check configuration for multiposition settings
+        self.is_multiposition_val.set(self.microscope_state_dict["is_multiposition"])
+        self.toggle_multiposition()
+
         # validate
         self.view.stack_timepoint_frame.stack_pause_spinbox.validate()
         self.view.stack_timepoint_frame.exp_time_spinbox.validate()

--- a/src/aslm/model/devices/APIs/sutter/MP285.py
+++ b/src/aslm/model/devices/APIs/sutter/MP285.py
@@ -193,7 +193,7 @@ class MP285:
             else:
                 # print(f"Ah hell: {position_information}")
                 raise UserWarning(
-                    "Encountered response {position_information}. "
+                    f"Encountered response {position_information}. "
                     "You probably need to power cycle the stage."
                 )
         self.safe_to_write.set()
@@ -274,7 +274,7 @@ class MP285:
                 self.flush_buffers()
                 # print(f"Uh oh: {response}")
                 raise UserWarning(
-                    "Encountered response {response}. "
+                    f"Encountered response {response}. "
                     "You probably need to power cycle the stage."
                 )
 


### PR DESCRIPTION
This addresses a long-standing issue @AdvancedImagingUTSW pointed out, which is that the `is_multiposition` flag can be set to `True` without this being reflected in the GUI. The multiposition state that is pulled from the `experiment.yml` is now properly displayed in the GUI so the user sees the true state. We also update the multiposition table population to properly update the experimental state (previously it only updated the GUI state).