### PR TITLE
Fix Tiger Controller

### DIFF
--- a/src/aslm/model/devices/APIs/asi/asi_tiger_controller.py
+++ b/src/aslm/model/devices/APIs/asi/asi_tiger_controller.py
@@ -195,10 +195,10 @@ class TigerController:
         """Return the position of the stage in ASI units (tenths of microns)."""
         self.send_command(f"WHERE {axis}\r")
         response = self.read_response()
-        try:
-            pos = int(response.split(" ")[1])
-        except:
-            pos = float('Inf')
+        # try:
+        pos = float(response.split(" ")[1])
+        # except:
+        #     pos = float('Inf')
         return pos
 
     def get_axis_position_um(self, axis: str) -> float:

--- a/src/aslm/model/devices/filter_wheel/filter_wheel_asi.py
+++ b/src/aslm/model/devices/filter_wheel/filter_wheel_asi.py
@@ -55,20 +55,10 @@ def build_filter_wheel_connection(comport, baudrate=115200, timeout=0.25):
         Baud rate for communicating with the filter wheel, e.g., 9600.
     """
     # wait until ASI device is ready
-    block_flag = True
-    wait_start = time.time()
-    timeout_s = timeout / 1000
-    while block_flag:
-        tiger_controller = TigerController(comport, baudrate, verbose=False)
-        tiger_controller.connect_to_serial()
-        if tiger_controller.is_open():
-            block_flag = False
-        else:
-            print("Trying to connect to the Tiger Controller again")
-            elapsed = time.time()
-            if (elapsed - wait_start) > timeout_s:
-                break
-            time.sleep(0.1)
+    tiger_controller = TigerController(comport, baudrate)
+    tiger_controller.connect_to_serial()
+    if not tiger_controller.is_open():
+        raise Exception("ASI stage connection failed.")
     return tiger_controller
 
 

--- a/src/aslm/model/devices/stages/stage_asi.py
+++ b/src/aslm/model/devices/stages/stage_asi.py
@@ -232,7 +232,7 @@ class ASIStage(StageBase):
             # for axis, pos in zip(list(self.axes_mapping.keys()), positions):
             for axis, asi_axis in self.axes_mapping.items():
                 pos = self.tiger_controller.get_axis_position(asi_axis)
-                print(f"ASI axis {asi_axis} = {pos}")
+                # print(f"ASI axis {asi_axis} = {pos}")
                 setattr(self, f"{axis}_pos", float(pos) / 10.0)
         except TigerException as e:
             print("Failed to report ASI Stage Position")


### PR DESCRIPTION
Fix issue related to https://asiimaging.com/docs/products/serial_commands#commandwhere_w. Namely, the `WHERE` command always returns axes positions in the order of the underlying hardware, regardless of the order axes are queried. Querying a single axis at a time fixes this issue.

Lots of code cleanup in the process of getting to this answer.