### PR TITLE
Make tests/BDV match model data_buffer order

### DIFF
--- a/src/aslm/model/data_sources/bdv_data_source.py
+++ b/src/aslm/model/data_sources/bdv_data_source.py
@@ -47,7 +47,7 @@ from multiprocessing.managers import DictProxy
 class BigDataViewerDataSource(DataSource):
     def __init__(self, file_name: str = None, mode: str = "w") -> None:
         self._resolutions = np.array(
-            [[1, 1, 1], [2, 2, 2], [4, 4, 4], [8, 8, 8]], dtype=int
+            [[1, 1, 1], [2, 2, 1], [4, 4, 1], [8, 8, 1]], dtype=int
         )
         self._subdivisions = None
         self._shapes = None
@@ -148,7 +148,7 @@ class BigDataViewerDataSource(DataSource):
                 zs = np.minimum(
                     z // dz, self.shapes[i, 0] - 1
                 )  # TODO: Is this necessary?
-                self.image[dataset_name][zs, ...] = data[::dx, ::dy].T
+                self.image[dataset_name][zs, ...] = data[::dx, ::dy]
                 if (i == 0) and len(kw) > 0:
                     self._views.append(kw)
         self._current_frame += 1

--- a/test/model/data_sources/test_bdv_data_source.py
+++ b/test/model/data_sources/test_bdv_data_source.py
@@ -10,8 +10,9 @@ from aslm.tools.file_functions import delete_folder
 @pytest.mark.parametrize("per_stack", [True, False])
 @pytest.mark.parametrize("z_stack", [True, False])
 @pytest.mark.parametrize("stop_early", [True, False])
+@pytest.mark.parametrize("size", [(1024, 2048), (2048, 1024), (2048, 2048)])
 @pytest.mark.parametrize("ext", ["h5", "n5"])
-def test_bdv_write(multiposition, per_stack, z_stack, stop_early, ext):
+def test_bdv_write(multiposition, per_stack, z_stack, stop_early, size, ext):
     from aslm.model.dummy import DummyModel
     from aslm.model.data_sources.bdv_data_source import BigDataViewerDataSource
 
@@ -24,6 +25,13 @@ def test_bdv_write(multiposition, per_stack, z_stack, stop_early, ext):
     model = DummyModel()
     z_steps = np.random.randint(1, 3)
     timepoints = np.random.randint(1, 3)
+
+    x_size, y_size = size
+    model.configuration["experiment"]["CameraParameters"]["x_pixels"] = x_size
+    model.configuration["experiment"]["CameraParameters"]["y_pixels"] = y_size
+    model.img_width = x_size
+    model.img_height = y_size
+
     model.configuration["experiment"]["MicroscopeState"]["image_mode"] = (
         "z-stack" if z_stack else "single"
     )
@@ -52,7 +60,7 @@ def test_bdv_write(multiposition, per_stack, z_stack, stop_early, ext):
         f"t: {ds.shape_t} positions: {ds.positions} per_stack: {ds.metadata.per_stack}"
     )
     # TODO: Why does 2**16 make ImageJ crash??? But 2**8 works???
-    data = (np.random.rand(n_images, ds.shape_x, ds.shape_y) * 2**8).astype("uint16")
+    data = (np.random.rand(n_images, ds.shape_y, ds.shape_x) * 2**8).astype("uint16")
     data_positions = (np.random.rand(n_images, 5) * 50e3).astype(float)
     for i in range(n_images):
         ds.write(

--- a/test/model/data_sources/test_tiff_data_source.py
+++ b/test/model/data_sources/test_tiff_data_source.py
@@ -55,7 +55,7 @@ def test_tiff_write_read(is_ome, multiposition, per_stack, z_stack, stop_early):
 
     # Populate one image per channel per timepoint per position
     n_images = ds.shape_c * ds.shape_z * ds.shape_t * ds.positions
-    data = (np.random.rand(n_images, ds.shape_x, ds.shape_y) * 2**16).astype(
+    data = (np.random.rand(n_images, ds.shape_y, ds.shape_x) * 2**16).astype(
         np.uint16
     )
     file_names_raw = []


### PR DESCRIPTION
Closes #544.

Also changes z-subdivision to 1 for OMERO compatibility.