### PR TITLE
called feature controller after sloppy stop to trigger clean up in constant velocity acquisition

### DIFF
--- a/src/aslm/controller/controller.py
+++ b/src/aslm/controller/controller.py
@@ -445,7 +445,7 @@ class Controller:
         if mode == "stop":
             # GUI Failsafe
             self.acquire_bar_controller.stop_acquire()
-            self.menu_controller.feature_id_val.set(0)
+            # self.menu_controller.feature_id_val.set(0)
 
     def execute(self, command, *args):
         """Functions listens to the Sub_Gui_Controllers.
@@ -701,6 +701,7 @@ class Controller:
 
             # self.model.run_command('stop')
             self.sloppy_stop()
+            self.menu_controller.feature_id_val.set(0)
 
             # clear show_img_pipe
             while self.show_img_pipe.poll():
@@ -712,6 +713,7 @@ class Controller:
             """Exit the program."""
             # Save current GUI settings to .ASLM/config/experiment.yml file.
             self.sloppy_stop()
+            # self.menu_controller.feature_id_val.set(0)
 
             self.update_experiment_setting()
             file_directory = os.path.join(get_aslm_path(), "config")


### PR DESCRIPTION
called feature controller after sloppy stop to call container before features. This makes it possible to trigger clean up in constant velocity acquisition and for other features to be used after constant velocity acquisition without hanging. This was tested on Jinlong's setup.