### PR TITLE
Fix stage hot key with flip flags

### DIFF
--- a/src/aslm/controller/sub_controllers/keystroke_controller.py
+++ b/src/aslm/controller/sub_controllers/keystroke_controller.py
@@ -97,10 +97,10 @@ class KeystrokeController(GUIController):
         )
 
         """Keystrokes for Main Window"""
-        self.main_view.bind("w", self.stage_controller.stage_key_press)
-        self.main_view.bind("s", self.stage_controller.stage_key_press)
-        self.main_view.bind("a", self.stage_controller.stage_key_press)
-        self.main_view.bind("d", self.stage_controller.stage_key_press)
+        # self.main_view.bind("w", self.stage_controller.stage_key_press)
+        # self.main_view.bind("s", self.stage_controller.stage_key_press)
+        # self.main_view.bind("a", self.stage_controller.stage_key_press)
+        # self.main_view.bind("d", self.stage_controller.stage_key_press)
         self.main_view.bind("<Control-KeyRelease-j>", self.stage_controller.joystick_button_handler)
         self.main_view.bind("<Control-Key-1>", self.switch_tab)
         self.main_view.bind("<Control-Key-2>", self.switch_tab)

--- a/src/aslm/controller/sub_controllers/stage_controller.py
+++ b/src/aslm/controller/sub_controllers/stage_controller.py
@@ -188,29 +188,16 @@ class StageController(GUIController):
         """
         if event.state != 0:
             return
-        char = event.char.lower()
-        current_position = self.get_position()
-        if current_position is None:
-            return
-        xy_increment = self.widget_vals["xy_step"].get()
         if not self.joystick_is_on:
+            char = event.char.lower()
             if char == "w":
-                current_position["y"] += xy_increment * (
-                    -1 if self.flip_flags["y"] else 1
-                )
+                self.up_btn_handler("y")()
             elif char == "a":
-                current_position["x"] -= xy_increment * (
-                    -1 if self.flip_flags["x"] else 1
-                )
+                self.down_btn_handler("x")()
             elif char == "s":
-                current_position["y"] -= xy_increment * (
-                    -1 if self.flip_flags["y"] else 1
-                )
+                self.down_btn_handler("y")()
             elif char == "d":
-                current_position["x"] += xy_increment * (
-                    -1 if self.flip_flags["x"] else 1
-                )
-        self.set_position(current_position)
+                self.up_btn_handler("x")()
 
     def initialize(self):
         """Initialize the Stage limits of steps and positions

--- a/src/aslm/controller/sub_controllers/stage_controller.py
+++ b/src/aslm/controller/sub_controllers/stage_controller.py
@@ -195,13 +195,21 @@ class StageController(GUIController):
         xy_increment = self.widget_vals["xy_step"].get()
         if not self.joystick_is_on:
             if char == "w":
-                current_position["y"] += xy_increment
+                current_position["y"] += xy_increment * (
+                    -1 if self.flip_flags["y"] else 1
+                )
             elif char == "a":
-                current_position["x"] -= xy_increment
+                current_position["x"] -= xy_increment * (
+                    -1 if self.flip_flags["x"] else 1
+                )
             elif char == "s":
-                current_position["y"] -= xy_increment
+                current_position["y"] -= xy_increment * (
+                    -1 if self.flip_flags["y"] else 1
+                )
             elif char == "d":
-                current_position["x"] += xy_increment
+                current_position["x"] += xy_increment * (
+                    -1 if self.flip_flags["x"] else 1
+                )
         self.set_position(current_position)
 
     def initialize(self):

--- a/test/controller/sub_controllers/test_stage_controller.py
+++ b/test/controller/sub_controllers/test_stage_controller.py
@@ -55,8 +55,23 @@ def stage_controller(dummy_controller):
         dummy_controller,
     )
 
-
-def test_stage_key_press(stage_controller):
+@pytest.mark.parametrize(
+    "flip_x, flip_y",
+    [
+        (False, False),
+        (True, False),
+        (True, True),
+        (False, True),
+        (True, True)
+    ],
+)
+def test_stage_key_press(stage_controller, flip_x, flip_y):
+    microscope_name = stage_controller.parent_controller.configuration_controller.microscope_name
+    stage_config = stage_controller.parent_controller.configuration["configuration"]["microscopes"][microscope_name]["stage"]
+    stage_config["flip_x"] = flip_x
+    stage_config["flip_y"] = flip_y
+    stage_controller.initialize()
+    flip_flags = stage_controller.parent_controller.configuration_controller.stage_flip_flags
     x = round(np.random.random(), 1)
     y = round(np.random.random(), 1)
     increment = round(np.random.random(), 1)
@@ -73,8 +88,8 @@ def test_stage_key_press(stage_controller):
         event.char = char
         # <a> instead of <Control+a>
         event.state = 0
-        x += xs
-        y += ys
+        x += xs * (-1 if flip_x else 1)
+        y += ys * (-1 if flip_y else 1)
         stage_controller.stage_key_press(event)
         stage_controller.get_position.assert_called_once()
         stage_controller.set_position.assert_called_with({"x": x, "y": y})
@@ -82,6 +97,8 @@ def test_stage_key_press(stage_controller):
         stage_controller.set_position.reset_mock()
         stage_controller.widget_vals["xy_step"].get.reset_mock()
 
+    stage_config["flip_x"] = False
+    stage_config["flip_y"] = False
 
 def test_set_position(stage_controller):
 

--- a/test/controller/sub_controllers/test_stage_controller.py
+++ b/test/controller/sub_controllers/test_stage_controller.py
@@ -75,10 +75,14 @@ def test_stage_key_press(stage_controller, flip_x, flip_y):
     x = round(np.random.random(), 1)
     y = round(np.random.random(), 1)
     increment = round(np.random.random(), 1)
-    stage_controller.get_position = MagicMock(return_value={"x": x, "y": y})
-    stage_controller.set_position = MagicMock()
     stage_controller.widget_vals["xy_step"].get = MagicMock(return_value=increment)
+    stage_controller.widget_vals["x"].get = MagicMock(return_value=x)
+    stage_controller.widget_vals["x"].set = MagicMock()
+    stage_controller.widget_vals["y"].get = MagicMock(return_value=y)
+    stage_controller.widget_vals["y"].set = MagicMock()
     event = MagicMock()
+
+    axes_map = {"w": "y", "a": "x", "s": "y", "d": "x"}
 
     for char, xs, ys in zip(
         ["w", "a", "s", "d"],
@@ -88,13 +92,15 @@ def test_stage_key_press(stage_controller, flip_x, flip_y):
         event.char = char
         # <a> instead of <Control+a>
         event.state = 0
-        x += xs * (-1 if flip_x else 1)
-        y += ys * (-1 if flip_y else 1)
+        axis = axes_map[char]
+        if axis == "x":
+            temp = x + xs * (-1 if flip_x else 1)
+        else:
+            temp = y + ys * (-1 if flip_y else 1)
         stage_controller.stage_key_press(event)
-        stage_controller.get_position.assert_called_once()
-        stage_controller.set_position.assert_called_with({"x": x, "y": y})
-        stage_controller.get_position.reset_mock()
-        stage_controller.set_position.reset_mock()
+        stage_controller.widget_vals[axis].set.assert_called_once_with(temp)
+        stage_controller.widget_vals[axis].set.reset_mock()
+        stage_controller.widget_vals[axis].get.reset_mock()
         stage_controller.widget_vals["xy_step"].get.reset_mock()
 
     stage_config["flip_x"] = False


### PR DESCRIPTION
Fixed the bug: stage hotkeys were triggered twice.
Fixed the bug: stage hotkeys didn't work with the stage limits flag.
Fixed the bug: stage hotkeys didn't work with the flip flags.