### PR TITLE
BDV tile fix

### DIFF
--- a/src/aslm/model/data_sources/bdv_data_source.py
+++ b/src/aslm/model/data_sources/bdv_data_source.py
@@ -128,8 +128,7 @@ class BigDataViewerDataSource(DataSource):
         c, z, t, p = self._cztp_indices(
             self._current_frame, self.metadata.per_stack
         )  # find current channel
-        if (z == 0) and (c == 0) and ((t >= self.shape_t) or (p >= self.positions)):
-            self.close()
+
         if not (z or c or t or p):
             self.setup()
 

--- a/src/aslm/model/metadata_sources/bdv_metadata.py
+++ b/src/aslm/model/metadata_sources/bdv_metadata.py
@@ -196,7 +196,7 @@ class BigDataViewerMetadata(XMLMetadata):
         arr = np.eye(3, 4)
 
         # Translation into pixels
-        arr[:, 3] = [x / self.dx, y / self.dy, z / self.dz]
+        arr[:, 3] = [y / self.dy, x / self.dx, z / self.dz]
 
         # Rotation (theta pivots in the xz plane, about the y axis)
         # sin_theta, cos_theta = np.sin(theta), np.cos(theta)

--- a/test/model/metadata_sources/test_bdv_metadata.py
+++ b/test/model/metadata_sources/test_bdv_metadata.py
@@ -1,14 +1,17 @@
 import os
 import numpy as np
 
+import pytest
 
-def test_bdv_metadata():
+
+@pytest.mark.parametrize("ext", ["h5", "n5", "tiff"])
+def test_bdv_metadata(ext):
     from aslm.model.metadata_sources.bdv_metadata import BigDataViewerMetadata
 
     md = BigDataViewerMetadata()
 
     views = []
-    for idx in range(10):
+    for _ in range(10):
         views.append(
             {
                 "x": np.random.randint(-1000, 1000),
@@ -25,6 +28,6 @@ def test_bdv_metadata():
         assert arr[1, 3] == view["x"] / md.dx
         assert arr[2, 3] == view["z"] / md.dz
 
-    md.write_xml("test_bdv.xml", views)
+    md.write_xml(f"test_bdv.{ext}", views)
 
     os.remove("test_bdv.xml")

--- a/test/model/metadata_sources/test_bdv_metadata.py
+++ b/test/model/metadata_sources/test_bdv_metadata.py
@@ -1,7 +1,8 @@
 import os
+import numpy as np
 
 
-def test_bdv_metadata(dummy_model):
+def test_bdv_metadata():
     from aslm.model.metadata_sources.bdv_metadata import BigDataViewerMetadata
 
     md = BigDataViewerMetadata()
@@ -10,13 +11,19 @@ def test_bdv_metadata(dummy_model):
     for idx in range(10):
         views.append(
             {
-                "x": dummy_model.data_buffer_positions[idx][0],
-                "y": dummy_model.data_buffer_positions[idx][1],
-                "z": dummy_model.data_buffer_positions[idx][2],
-                "theta": dummy_model.data_buffer_positions[idx][3],
-                "f": dummy_model.data_buffer_positions[idx][4],
+                "x": np.random.randint(-1000, 1000),
+                "y": np.random.randint(-1000, 1000),
+                "z": np.random.randint(-1000, 1000),
+                "theta": np.random.randint(-1000, 1000),
+                "f": np.random.randint(-1000, 1000),
             }
         )
+
+    for view in views:
+        arr = md.stage_positions_to_affine_matrix(**view)
+        assert arr[0, 3] == view["y"] / md.dy
+        assert arr[1, 3] == view["x"] / md.dx
+        assert arr[2, 3] == view["z"] / md.dz
 
     md.write_xml("test_bdv.xml", views)
 


### PR DESCRIPTION
Closes #597. The removal of `.T` in #594 resulted in a switch in image orientation that needed to be reflected in the affine transform matrix of the metadata.

![image](https://github.com/TheDeanLab/ASLM/assets/1263313/10c3f9ba-c05a-40d0-b5a7-3749908cd925)
