### PR TITLE
Force ASI axes to uppercase

### DIFF
--- a/test/model/devices/stages/test_stage_asi.py
+++ b/test/model/devices/stages/test_stage_asi.py
@@ -220,7 +220,7 @@ class TestStageASI:
             assert len(stage.axes_mapping) <= len(stage.axes)
         else:
             for i, axis in enumerate(axes):
-                assert stage.axes_mapping[axis] == axes_mapping[i]
+                assert stage.axes_mapping[axis] == axes_mapping[i].upper()
 
         assert stage.stage_limits is True
 
@@ -239,6 +239,7 @@ class TestStageASI:
             (["f", "z"], ["M", "X"]),
             (["x", "y", "z"], ["Y", "X", "M"]),
             (["x", "y", "z", "f"], ["X", "M", "Y", "Z"]),
+            (["x", "y", "z", "f"], ["x", "M", "y", "Z"]),
         ],
     )
     def test_report_position(self, axes, axes_mapping):
@@ -288,6 +289,7 @@ class TestStageASI:
             (["f", "z"], ["M", "X"]),
             (["x", "y", "z"], ["Y", "X", "M"]),
             (["x", "y", "z", "f"], ["X", "M", "Y", "Z"]),
+            (["x", "y", "z", "f"], ["x", "M", "y", "Z"]),
         ],
     )
     def test_move_axis_absolute(self, axes, axes_mapping):
@@ -314,6 +316,7 @@ class TestStageASI:
             (["f", "z"], ["M", "X"]),
             (["x", "y", "z"], ["Y", "X", "M"]),
             (["x", "y", "z", "f"], ["X", "M", "Y", "Z"]),
+            (["x", "y", "z", "f"], ["x", "M", "y", "Z"]),
         ],
     )
     def test_move_absolute(self, axes, axes_mapping):

--- a/test/model/devices/stages/test_stage_asi.py
+++ b/test/model/devices/stages/test_stage_asi.py
@@ -189,6 +189,7 @@ class TestStageASI:
             (["f", "z"], ["M", "X"]),
             (["x", "y", "z"], ["Y", "X", "M"]),
             (["x", "y", "z", "f"], ["X", "M", "Y", "Z"]),
+            (["x", "y", "z", "f"], ["x", "M", "y", "Z"]),
         ],
     )
     def test_initialize_stage(self, axes, axes_mapping):


### PR DESCRIPTION
Closes #641. The problem is in `get_position()` in  `asi_tiger_controller.py`:

```
axes_seq = list(
    filter(
        lambda axis: axis if axis in axes else False,
        self.default_axes_sequence,
    )
)
```

`self.default_axes_sequence` is all upper case when it is pulled from the stage, so the lower case values aren't passed and no position is reported. However, just fixing this without forcing `asi_axes` to upper case in `stage_asi.py` results in key errors. Easiest to just force the axes all to upper case when they are read in.