### PR TITLE
Introduce new tiling wizard and controller

### DIFF
--- a/src/aslm/controller/sub_controllers/channels_tab_controller.py
+++ b/src/aslm/controller/sub_controllers/channels_tab_controller.py
@@ -45,12 +45,12 @@ from aslm.controller.sub_controllers.gui_controller import GUIController
 from aslm.controller.sub_controllers.channel_setting_controller import (
     ChannelSettingController,
 )
-from aslm.controller.sub_controllers.tiling_wizard_controller import (
+from aslm.controller.sub_controllers.tiling_wizard_controller2 import (
     TilingWizardController,
 )
 
 # View Imports that are not called on startup
-from aslm.view.popups.tiling_wizard_popup import TilingWizardPopup
+from aslm.view.popups.tiling_wizard_popup2 import TilingWizardPopup
 
 # Logger Setup
 p = __name__.split(".")[1]
@@ -535,7 +535,9 @@ class ChannelsTabController(GUIController):
         except tk._tkinter.TclError:
             self.microscope_state_dict["start_focus"] = 0
         try:
-            self.microscope_state_dict["end_focus"] = self.stack_acq_vals["end_focus"].get()
+            self.microscope_state_dict["end_focus"] = self.stack_acq_vals[
+                "end_focus"
+            ].get()
         except tk._tkinter.TclError:
             self.microscope_state_dict["end_focus"] = 0
         self.microscope_state_dict["stack_z_origin"] = self.z_origin

--- a/src/aslm/controller/sub_controllers/tiling_wizard_controller2.py
+++ b/src/aslm/controller/sub_controllers/tiling_wizard_controller2.py
@@ -61,75 +61,35 @@ class TilingWizardController(GUIController):
     values for the respective axis when pressed and display in popup
     Number of images we need to acquire with our desired
     percent overlap is calculated and then displayed in third column
-
-
-    Parameters
-    ----------
-    view : object
-        GUI element containing widgets and variables to control.
-        Likely tk.Toplevel-derived. In this case tiling_wizard_popup.py
-    parent_controller : channels_tab_controller
-        The controller that creates the popup/this controller.
-
-    Attributes
-    ----------
-    widgets : dict
-        Dictionary of widgets in the view
-    buttons : dict
-        Dictionary of buttons in the view
-    variables : dict
-        Dictionary of variables in the view
-    _axes : list
-        List of axes to iterate over
-    _percent_overlap : float
-        Percent overlap of tiles
-    _fov : dict
-        Dictionary of fov values for each axis
-    cam_settings_widgets : dict
-        Dictionary of widgets in the camera settings tab
-    stack_acq_widgets : dict
-        Dictionary of widgets in the stack acquisition tab
-    stage_position_vars : dict
-        Dictionary of variables in the stage control tab
-    multipoint_table : ttk.Treeview
-        Treeview of multipoint table in the multipoint tab
-
-    Methods
-    -------
-    calculate_distance()
-        Calculate the distance between start and end positions for each axis
-    calculate_tiles()
-        Calculate the number of tiles for each axis
-    update_table()
-        Update the multipoint table with the new tiling parameters
-    update_fov()
-        Update the fov values when the user changes the camera settings
-    position_handler()
-        Handler for the set start/end position buttons
-    set_table()
-        Set the multipoint table to the tiling parameters
-    showup()
-        Show the popup
-    update_overlap()
-        Update the percent overlap when the user changes the value
-    update_total_tiles()
-        Update the total number of tiles when the user changes the value
-
     """
 
     def __init__(self, view, parent_controller):
+        """Initialize Tiling Wizard Controller
+
+        Parameters
+        ----------
+        view : object
+            GUI element containing widgets and variables to control.
+            Likely tk.Toplevel-derived. In this case tiling_wizard_popup.py
+        parent_controller : channels_tab_controller
+            The controller that creates the popup/this controller.
+
+        """
         super().__init__(view, parent_controller)
 
         # Getting widgets and buttons and vars of widgets
+        #: dict: Dictionary of widgets in the view
         self.widgets = self.view.get_widgets()
+        #: dict: Dictionary of buttons in the view
         self.buttons = self.view.get_buttons()
+        #: dict: Dictionary of variables in the view
         self.variables = self.view.get_variables()
-
+        #: int: Default percent overlap between tiles
         self._percent_overlap = 10.0  # default to 10% overlap
 
         # Init widgets to zero
+        #: list: List of axes to iterate over
         self._axes = ["x", "y", "z", "f"]
-        # self._fov = dict([(ax, 0.0) for ax in self._axes])
         self.variables["percent_overlap"].set(self._percent_overlap)
         self.variables["total_tiles"].set(1)
         for ax in self._axes:
@@ -185,8 +145,6 @@ class TilingWizardController(GUIController):
         )
 
         # Calculate distances
-        # TODO: For reasons that make no sense to me at all,
-        #  these can't go in a for ax in self._axes loop?
         self.variables["x_start"].trace_add(
             "write", lambda *args: self.calculate_distance("x")
         )
@@ -236,8 +194,6 @@ class TilingWizardController(GUIController):
         self.variables["f_end"].trace_add("write", lambda *args: self.update_fov("f"))
 
         # Calculating Number of Tiles traces
-        # TODO: For reasons that make no sense to me at all,
-        #  these can't go in a for ax in self._axes loop?
         self.variables["x_dist"].trace_add(
             "write", lambda *args: self.calculate_tiles("x")
         )
@@ -290,15 +246,6 @@ class TilingWizardController(GUIController):
         pandas dataframe which is then set as the new table data.
         The table is then redrawn.
 
-        Parameters
-        ----------
-        self : object
-            Tiling Wizard Controller instance
-
-        Returns
-        -------
-        None
-
         Examples
         --------
         >>> self.set_table()
@@ -336,6 +283,20 @@ class TilingWizardController(GUIController):
 
         # for consistency, always go from low to high
         def sort_vars(a, b):
+            """Sort two variables from low to high
+
+            Parameters
+            ----------
+            a : float
+                First variable
+            b : float
+                Second variable
+
+            Returns
+            -------
+            a, b : float
+                Sorted variables
+            """
             if a > b:
                 return b, a
             return a, b
@@ -390,15 +351,6 @@ class TilingWizardController(GUIController):
         Sums the tiles for each axis in the tiling wizard.
         Will update when any axis has a tile amount change.
 
-        Parameters
-        ----------
-        self : object
-            Tiling Wizard Controller instance
-
-        Returns
-        -------
-        None
-
         Examples
         --------
         >>> self.update_total_tiles()
@@ -420,14 +372,8 @@ class TilingWizardController(GUIController):
 
         Parameters
         ----------
-        self : object
-            Tiling Wizard Controller instance
         axis : str
             x, y, z, f axis of stage to calculate.
-
-        Returns
-        -------
-        None
 
         Examples
         --------
@@ -475,14 +421,8 @@ class TilingWizardController(GUIController):
 
         Parameters
         ----------
-        self : object
-            Tiling Wizard Controller instance
         axis : str
             x, y, z axis of stage to calculate
-
-        Returns
-        -------
-        None
 
         Examples
         --------
@@ -500,15 +440,6 @@ class TilingWizardController(GUIController):
         Updates percent overlay when a user changes the widget in the popup.
         This value is used for backend calculations.
         The number of tiles will then be recalculated
-
-        Parameters
-        ----------
-        self : object
-            Tiling Wizard Controller instance
-
-        Returns
-        -------
-        None
 
         Examples
         --------
@@ -530,8 +461,6 @@ class TilingWizardController(GUIController):
 
         Parameters
         ----------
-        self : object
-            Tiling Wizard Controller instance
         axis : str
             x, y, z, f axis that corresponds to stage axis
         start_end : str
@@ -563,14 +492,8 @@ class TilingWizardController(GUIController):
 
         Parameters
         ----------
-        self : object
-            Tiling Wizard Controller instance
-        ax : str
+        axis : str
             Axis
-
-        Returns
-        -------
-        None
 
         Examples
         --------
@@ -614,16 +537,7 @@ class TilingWizardController(GUIController):
     def showup(self):
         """Show the tiling wizard
 
-        Brings popup window to front
-
-        Parameters
-        ----------
-        self : object
-            Tiling Wizard Controller instance
-
-        Returns
-        -------
-        None
+        Brings popup window to front of screen
 
         Examples
         --------

--- a/src/aslm/controller/sub_controllers/tiling_wizard_controller2.py
+++ b/src/aslm/controller/sub_controllers/tiling_wizard_controller2.py
@@ -1,0 +1,568 @@
+# Copyright (c) 2021-2022  The University of Texas Southwestern Medical Center.
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted for academic and research use only
+# (subject to the limitations in the disclaimer below)
+# provided that the following conditions are met:
+
+#      * Redistributions of source code must retain the above copyright notice,
+#      this list of conditions and the following disclaimer.
+
+#      * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+
+#      * Neither the name of the copyright holders nor the names of its
+#      contributors may be used to endorse or promote products derived from this
+#      software without specific prior written permission.
+
+# NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE GRANTED BY
+# THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+# CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+# PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+# BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+# IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+
+# Standard Library Imports
+import logging
+
+# Third Party Imports
+
+# Local Imports
+from aslm.tools.multipos_table_tools import (
+    sign,
+    compute_tiles_from_bounding_box,
+    calc_num_tiles,
+    update_table,
+)
+from aslm.controller.sub_controllers.gui_controller import GUIController
+from aslm.tools.common_functions import combine_funcs
+
+# Logger Setup
+p = __name__.split(".")[1]
+logger = logging.getLogger(p)
+
+
+class TilingWizardController(GUIController):
+    """Tiling Wizard Controller
+
+    Controller for tiling wizard parameters.
+    Gathers the FOV from the camera settings tab and will
+    update when user changes this value.
+    Set start/end position buttons will grab the stage
+    values for the respective axis when pressed and display in popup
+    Number of images we need to acquire with our desired
+    percent overlap is calculated and then displayed in third column
+
+
+    Parameters
+    ----------
+    view : object
+        GUI element containing widgets and variables to control.
+        Likely tk.Toplevel-derived. In this case tiling_wizard_popup.py
+    parent_controller : channels_tab_controller
+        The controller that creates the popup/this controller.
+
+    Attributes
+    ----------
+    widgets : dict
+        Dictionary of widgets in the view
+    buttons : dict
+        Dictionary of buttons in the view
+    variables : dict
+        Dictionary of variables in the view
+    _axes : list
+        List of axes to iterate over
+    _percent_overlap : float
+        Percent overlap of tiles
+    _fov : dict
+        Dictionary of fov values for each axis
+    cam_settings_widgets : dict
+        Dictionary of widgets in the camera settings tab
+    stack_acq_widgets : dict
+        Dictionary of widgets in the stack acquisition tab
+    stage_position_vars : dict
+        Dictionary of variables in the stage control tab
+    multipoint_table : ttk.Treeview
+        Treeview of multipoint table in the multipoint tab
+
+    Methods
+    -------
+    calculate_distance()
+        Calculate the distance between start and end positions for each axis
+    calculate_tiles()
+        Calculate the number of tiles for each axis
+    update_table()
+        Update the multipoint table with the new tiling parameters
+    update_fov()
+        Update the fov values when the user changes the camera settings
+    position_handler()
+        Handler for the set start/end position buttons
+    set_table()
+        Set the multipoint table to the tiling parameters
+    showup()
+        Show the popup
+    update_overlay()
+        Update the percent overlap when the user changes the value
+    update_total_tiles()
+        Update the total number of tiles when the user changes the value
+
+    """
+
+    def __init__(self, view, parent_controller):
+        super().__init__(view, parent_controller)
+
+        # Getting widgets and buttons and vars of widgets
+        self.widgets = self.view.get_widgets()
+        self.buttons = self.view.get_buttons()
+        self.variables = self.view.get_variables()
+
+        # Init widgets to zero
+        self._axes = ["x", "y", "z", "f"]
+        self._percent_overlap = 0.0
+        self._fov = dict([(ax, 0.0) for ax in self._axes])
+        self.variables["percent_overlap"].set(0.0)
+        self.variables["total_tiles"].set(1)
+
+        for ax in self._axes:
+            self.variables[f"{ax}_start"].set(0.0)
+            self.variables[f"{ax}_end"].set(0.0)
+            self.variables[f"{ax}_dist"].set(0.0)
+            self.variables[f"{ax}_tiles"].set(1)
+
+        # Ref to widgets in other views
+        # (Camera Settings, Stage Control Positions, Stack Acq Settings)
+        main_view = (
+            self.parent_controller.parent_controller.view
+        )  # channels_tab_controller -> aslm_controller -> view
+        self.cam_settings_widgets = (
+            main_view.settings.camera_settings_tab.camera_roi.get_widgets()
+        )
+        self.stack_acq_widgets = (
+            main_view.settings.channels_tab.stack_acq_frame.get_widgets()
+        )
+        self.stage_position_vars = (
+            main_view.settings.stage_control_tab.position_frame.get_variables()
+        )
+        self.multipoint_table = (
+            main_view.settings.multiposition_tab.multipoint_list.get_table()
+        )
+
+        # Setting/Tracing Percent Overlay
+        # Overlay change is also handled in update_overlay
+        self.variables["percent_overlap"].trace_add(
+            "write", lambda *args: self.update_overlay()
+        )
+
+        # Trace cam_settings FOV to catch user changes
+        # FOV change handled in update_fov
+        self.cam_settings_widgets["FOV_X"].get_variable().trace_add(
+            "write", lambda *args: self.update_fov()
+        )
+        self.cam_settings_widgets["FOV_Y"].get_variable().trace_add(
+            "write", lambda *args: self.update_fov()
+        )
+        self.stack_acq_widgets["abs_z_start"].get_variable().trace_add(
+            "write", lambda *args: self.update_fov()
+        )
+        self.stack_acq_widgets["abs_z_end"].get_variable().trace_add(
+            "write", lambda *args: self.update_fov()
+        )
+
+        # Calculate distances
+        # TODO: For reasons that make no sense to me at all,
+        #  these can't go in a for ax in self._axes loop?
+        self.variables["x_start"].trace_add(
+            "write", lambda *args: self.calculate_distance("x")
+        )
+        self.variables["x_end"].trace_add(
+            "write", lambda *args: self.calculate_distance("x")
+        )
+        self.variables["y_start"].trace_add(
+            "write", lambda *args: self.calculate_distance("y")
+        )
+        self.variables["y_end"].trace_add(
+            "write", lambda *args: self.calculate_distance("y")
+        )
+        self.variables["z_start"].trace_add(
+            "write", lambda *args: self.calculate_distance("z")
+        )
+        self.variables["z_end"].trace_add(
+            "write", lambda *args: self.calculate_distance("z")
+        )
+
+        self.variables["x_start"].trace_add("write", lambda *args: self.update_fov())
+        self.variables["x_end"].trace_add("write", lambda *args: self.update_fov())
+        self.variables["y_start"].trace_add("write", lambda *args: self.update_fov())
+        self.variables["y_end"].trace_add("write", lambda *args: self.update_fov())
+        self.variables["z_start"].trace_add("write", lambda *args: self.update_fov())
+        self.variables["z_end"].trace_add("write", lambda *args: self.update_fov())
+        self.variables["f_start"].trace_add("write", lambda *args: self.update_fov())
+        self.variables["f_end"].trace_add("write", lambda *args: self.update_fov())
+
+        # Calculating Number of Tiles traces
+        # TODO: For reasons that make no sense to me at all,
+        #  these can't go in a for ax in self._axes loop?
+        self.variables["x_dist"].trace_add(
+            "write", lambda *args: self.calculate_tiles("x")
+        )
+        self.variables["y_dist"].trace_add(
+            "write", lambda *args: self.calculate_tiles("y")
+        )
+        self.variables["z_dist"].trace_add(
+            "write", lambda *args: self.calculate_tiles("z")
+        )
+        self.variables["f_dist"].trace_add(
+            "write", lambda *args: self.calculate_tiles("f")
+        )
+
+        # Populate Table trace
+        self.buttons["set_table"].configure(command=self.set_table)
+
+        for ax in self._axes:
+            # Start/End buttons
+            self.buttons[f"{ax}_start"].configure(
+                command=self.position_handler(ax, "start")
+            )
+            self.buttons[f"{ax}_end"].configure(
+                command=self.position_handler(ax, "end")
+            )
+
+            # Calculating total tile traces
+            self.variables[f"{ax}_tiles"].trace_add(
+                "write", lambda *args: self.update_total_tiles()
+            )
+
+        # Update widgets to current values in other views
+        self.update_fov()
+
+        # Properly Closing Popup with parent controller
+        self.view.popup.protocol(
+            "WM_DELETE_WINDOW",
+            combine_funcs(
+                self.view.popup.dismiss,
+                lambda: delattr(self.parent_controller, "tiling_wizard_controller"),
+            ),
+        )
+
+    def set_table(self):
+        """Set the multipoint table to the values in the tiling wizard
+
+        Sets multiposition table with values from tiling wizard after
+        populate Multiposition Table button is pressed
+        Compute grid will return a list of all position combinations.
+        This list is then converted to a
+        pandas dataframe which is then set as the new table data.
+        The table is then redrawn.
+
+        Parameters
+        ----------
+        self : object
+            Tiling Wizard Controller instance
+
+        Returns
+        -------
+        None
+
+        Examples
+        --------
+        >>> self.set_table()
+        """
+
+        x_start = float(self.variables["x_start"].get())
+        x_stop = float(self.variables["x_end"].get())
+        x_tiles = int(self.variables["x_tiles"].get())
+
+        y_start = float(self.variables["y_start"].get())
+        y_stop = float(self.variables["y_end"].get())
+        y_tiles = int(self.variables["y_tiles"].get())
+
+        # shift z by coordinate origin of local z-stack
+        z_start = float(self.variables["z_start"].get()) - float(
+            self.stack_acq_widgets["start_position"].get()
+        )
+        z_stop = float(self.variables["z_end"].get()) - float(
+            self.stack_acq_widgets["end_position"].get()
+        )
+        z_tiles = int(self.variables["z_tiles"].get())
+
+        # Default to fixed theta
+        r_start = self.stage_position_vars["theta"].get()
+        r_stop = self.stage_position_vars["theta"].get()
+        r_tiles = 1
+
+        f_start = float(self.variables["f_start"].get()) - float(
+            self.stack_acq_widgets["start_focus"].get()
+        )
+        f_stop = float(self.variables["f_end"].get()) - float(
+            self.stack_acq_widgets["end_focus"].get()
+        )
+        f_tiles = int(self.variables["f_tiles"].get())
+
+        # for consistency, always go from low to high
+        def sort_vars(a, b):
+            if a > b:
+                return b, a
+            return a, b
+
+        x_start, x_stop = sort_vars(x_start, x_stop)
+        y_start, y_stop = sort_vars(y_start, y_stop)
+        z_start, z_stop = sort_vars(z_start, z_stop)
+        r_start, r_stop = sort_vars(r_start, r_stop)
+        f_start, f_stop = sort_vars(f_start, f_stop)
+
+        ov = float(self._percent_overlap) / 100
+        table_values = compute_tiles_from_bounding_box(
+            x_start,
+            x_tiles,
+            self.variables["x_fov"].get(),
+            ov,
+            y_start,
+            y_tiles,
+            self.variables["y_fov"].get(),
+            ov,
+            z_start,
+            z_tiles,
+            self.variables["z_fov"].get(),
+            ov,
+            r_start,
+            r_tiles,
+            0,
+            ov,
+            f_start,
+            f_tiles,
+            self.variables["f_fov"].get(),
+            ov,
+        )
+
+        update_table(self.multipoint_table, table_values)
+
+    def update_total_tiles(self):
+        """Update the total number of tiles in the tiling wizard
+
+        Sums the tiles for each axis in the tiling wizard.
+        Will update when any axis has a tile amount change.
+
+        Parameters
+        ----------
+        self : object
+            Tiling Wizard Controller instance
+
+        Returns
+        -------
+        None
+
+        Examples
+        --------
+        >>> self.update_total_tiles()
+        """
+
+        total_tiles = 1
+        for ax in self._axes:
+            total_tiles *= float(self.variables[f"{ax}_tiles"].get())
+
+        self.variables["total_tiles"].set(total_tiles)
+
+    def calculate_tiles(self, axis=None):
+        """Calculate the number of tiles for a given axis
+
+        Calculates the number of tiles of the acquisition for
+        each axis or an individual axis
+        Num of Tiles = dist - (overlay * FOV)  /  FOV * (1 - overlay)
+        (D-OF)/(F-OF) = N
+
+        Parameters
+        ----------
+        self : object
+            Tiling Wizard Controller instance
+        axis : str
+            x, y, z, f axis of stage to calculate.
+
+        Returns
+        -------
+        None
+
+        Examples
+        --------
+        >>> self.calculate_tiles()
+        """
+
+        if axis not in self._axes + [None]:
+            logger.warning(f"Unknown axis {axis}, skipping calculate_tiles().")
+            return
+
+        if axis is not None:
+            if not isinstance(axis, list):
+                axis = [axis]
+        else:
+            axis = self._axes
+
+        overlay = float(self._percent_overlap) / 100
+
+        for ax in axis:
+            dist = abs(float(self.variables[f"{ax}_dist"].get()))  # um
+            fov = abs(float(self._fov[ax]))  # um
+
+            num_tiles = calc_num_tiles(dist, overlay, fov)
+
+            self.variables[f"{ax}_tiles"].set(num_tiles)
+
+    def calculate_distance(self, axis):
+        """Calculate the distance for a given axis
+
+        This function will calculate the distance for a given
+        axis of the stage when the start or end position is changed
+        via the Set buttons
+
+        Parameters
+        ----------
+        self : object
+            Tiling Wizard Controller instance
+        axis : str
+            x, y, z axis of stage to calculate
+
+        Returns
+        -------
+        None
+
+        Examples
+        --------
+        >>> self.calculate_distance()
+        """
+
+        start = float(self.variables[axis + "_start"].get())
+        end = float(self.variables[axis + "_end"].get())
+        dist = abs(end - start)
+        self.variables[axis + "_dist"].set(dist)
+
+    def update_overlay(self):
+        """Update the overlay percentage for the tiling wizard
+
+        Updates percent overlay when a user changes the widget in the popup.
+        This value is used for backend calculations.
+        The number of tiles will then be recalculated
+
+        Parameters
+        ----------
+        self : object
+            Tiling Wizard Controller instance
+
+        Returns
+        -------
+        None
+
+        Examples
+        --------
+        >>> self.update_overlay()
+        """
+
+        try:
+            self._percent_overlap = float(self.variables["percent_overlap"].get())
+            self.calculate_tiles()
+        except ValueError:
+            # most likely an empty string was passed
+            pass
+
+    def position_handler(self, axis, start_end):
+        """Set the start or end position for a given axis
+
+        When the Set [axis] Start/End button is pressed then the
+        stage position is polled from the stage controller
+
+        Parameters
+        ----------
+        self : object
+            Tiling Wizard Controller instance
+        axis : str
+            x, y, z, f axis that corresponds to stage axis
+        start_end : str
+            start or end will signify which spinbox gets updated upon button press
+
+        Returns
+        -------
+        handler : func
+            Function for setting positional spinbox based on parameters passed in
+
+        Examples
+        --------
+        >>> self.position_handler()
+        """
+
+        def handler():
+            pos = self.stage_position_vars[axis].get()
+            self.widgets[axis + "_" + start_end].widget.set(pos)
+            # if axis == "z":
+            #     setattr(self, f"_f_{start_end}", self.stage_position_vars["f"].get())
+
+        return handler
+
+    def update_fov(self):
+        """Update the FOV for the tiling wizard
+
+        Grabs the updated FOV if changed by user,
+        will recalculate num of tiles for each axis after
+
+        Parameters
+        ----------
+        self : object
+            Tiling Wizard Controller instance
+
+        Returns
+        -------
+        None
+
+        Examples
+        --------
+        >>> self.update_fov()
+        """
+
+        # Calculate signed fov
+        x = float(self.cam_settings_widgets["FOV_X"].get()) * sign(
+            float(self.variables["x_end"].get())
+            - float(self.variables["x_start"].get())
+        )
+        y = float(self.cam_settings_widgets["FOV_Y"].get()) * sign(
+            float(self.variables["y_end"].get())
+            - float(self.variables["y_start"].get())
+        )
+        z = float(self.stack_acq_widgets["end_position"].get()) - float(
+            self.stack_acq_widgets["start_position"].get()
+        )
+        f = float(self.stack_acq_widgets["end_focus"].get()) - float(
+            self.stack_acq_widgets["start_focus"].get()
+        )
+
+        for ax in self._axes:
+            self._fov[ax] = locals().get(ax)
+            self.variables[f"{ax}_fov"].set(abs(self._fov[ax]))
+
+        self.calculate_tiles()
+
+    def showup(self):
+        """Show the tiling wizard
+
+        Brings popup window to front
+
+        Parameters
+        ----------
+        self : object
+            Tiling Wizard Controller instance
+
+        Returns
+        -------
+        None
+
+        Examples
+        --------
+        >>> self.showup()
+        """
+        self.view.popup.deiconify()
+        self.view.popup.attributes("-topmost", 1)

--- a/src/aslm/controller/sub_controllers/tiling_wizard_controller2.py
+++ b/src/aslm/controller/sub_controllers/tiling_wizard_controller2.py
@@ -199,7 +199,14 @@ class TilingWizardController(GUIController):
         self.variables["z_end"].trace_add(
             "write", lambda *args: self.calculate_distance("z")
         )
+        self.variables["f_start"].trace_add(
+            "write", lambda *args: self.calculate_distance("f")
+        )
+        self.variables["f_end"].trace_add(
+            "write", lambda *args: self.calculate_distance("f")
+        )
 
+        # Bind FOV changes
         self.variables["x_fov"].trace_add(
             "write", lambda *args: self.calculate_tiles("x")
         )

--- a/src/aslm/controller/sub_controllers/tiling_wizard_controller2.py
+++ b/src/aslm/controller/sub_controllers/tiling_wizard_controller2.py
@@ -125,17 +125,18 @@ class TilingWizardController(GUIController):
         self.buttons = self.view.get_buttons()
         self.variables = self.view.get_variables()
 
+        self._percent_overlap = 10.0  # default to 10% overlap
+
         # Init widgets to zero
         self._axes = ["x", "y", "z", "f"]
-        self._percent_overlap = 10.0
-        self._fov = dict([(ax, 0.0) for ax in self._axes])
+        # self._fov = dict([(ax, 0.0) for ax in self._axes])
         self.variables["percent_overlap"].set(self._percent_overlap)
         self.variables["total_tiles"].set(1)
-
         for ax in self._axes:
             self.variables[f"{ax}_start"].set(0.0)
             self.variables[f"{ax}_end"].set(0.0)
             self.variables[f"{ax}_dist"].set(0.0)
+            self.variables[f"{ax}_fov"].set(0.0)
             self.variables[f"{ax}_tiles"].set(1)
 
         # Ref to widgets in other views
@@ -197,6 +198,19 @@ class TilingWizardController(GUIController):
         )
         self.variables["z_end"].trace_add(
             "write", lambda *args: self.calculate_distance("z")
+        )
+
+        self.variables["x_fov"].trace_add(
+            "write", lambda *args: self.calculate_tiles("x")
+        )
+        self.variables["y_fov"].trace_add(
+            "write", lambda *args: self.calculate_tiles("y")
+        )
+        self.variables["z_fov"].trace_add(
+            "write", lambda *args: self.calculate_tiles("z")
+        )
+        self.variables["f_fov"].trace_add(
+            "write", lambda *args: self.calculate_tiles("f")
         )
 
         self.variables["x_start"].trace_add("write", lambda *args: self.update_fov())
@@ -409,7 +423,7 @@ class TilingWizardController(GUIController):
 
         for ax in axis:
             dist = abs(float(self.variables[f"{ax}_dist"].get()))  # um
-            fov = abs(float(self._fov[ax]))  # um
+            fov = abs(float(self.variables[f"{ax}_fov"].get()))  # um
 
             if ax.lower() == "x" or ax.lower() == "y":
                 # + fov because distance is center of the fov to center of the fov
@@ -547,8 +561,10 @@ class TilingWizardController(GUIController):
         )
 
         for ax in self._axes:
-            self._fov[ax] = locals().get(ax)
-            self.variables[f"{ax}_fov"].set(abs(self._fov[ax]))
+            # self._fov[ax] = locals().get(ax)
+            self.variables[f"{ax}_fov"].set(
+                abs(locals().get(ax))
+            )  # abs(self._fov[ax]))
 
         self.calculate_tiles()
 

--- a/src/aslm/controller/sub_controllers/tiling_wizard_controller2.py
+++ b/src/aslm/controller/sub_controllers/tiling_wizard_controller2.py
@@ -372,6 +372,18 @@ class TilingWizardController(GUIController):
 
         update_table(self.multipoint_table, table_values)
 
+        # If we have additional axes, create self.d{axis} for each
+        # additional axis, to ensure we keep track of the step size
+        config = self.parent_controller.parent_controller.configuration
+        microscope_name = config["experiment"]["MicroscopeState"]["microscope_name"]
+        scope = config["configuration"]["microscopes"][microscope_name]
+        coupled_axes = scope["stage"].get("coupled_axes", None)
+        if coupled_axes is not None:
+            for follower in coupled_axes.values():
+                config["experiment"]["MicroscopeState"][
+                    f"{follower.lower()}_step_size"
+                ] = self.variables[f"{follower.lower()}_fov"].get()
+
     def update_total_tiles(self):
         """Update the total number of tiles in the tiling wizard
 

--- a/src/aslm/controller/sub_controllers/tiling_wizard_controller2.py
+++ b/src/aslm/controller/sub_controllers/tiling_wizard_controller2.py
@@ -423,7 +423,10 @@ class TilingWizardController(GUIController):
         """
 
         if axis not in self._axes + [None]:
-            logger.warning(f"Unknown axis {axis}, skipping calculate_tiles().")
+            logger.warning(
+                f"Controller - Tiling Wizard - Unknown axis {axis}, "
+                "skipping calculate_tiles()."
+            )
             return
 
         if axis is not None:
@@ -435,18 +438,21 @@ class TilingWizardController(GUIController):
         overlay = float(self._percent_overlap) / 100
 
         for ax in axis:
-            dist = abs(float(self.variables[f"{ax}_dist"].get()))  # um
-            fov = abs(float(self.variables[f"{ax}_fov"].get()))  # um
+            try:
+                dist = abs(float(self.variables[f"{ax}_dist"].get()))  # um
+                fov = abs(float(self.variables[f"{ax}_fov"].get()))  # um
 
-            if ax.lower() == "x" or ax.lower() == "y":
-                # + fov because distance is center of the fov to center of the fov
-                # and so we are covering a distance that is 2 * 1/2 * fov
-                # larger than dist
-                dist += fov
+                if ax.lower() == "x" or ax.lower() == "y":
+                    # + fov because distance is center of the fov to center of the fov
+                    # and so we are covering a distance that is 2 * 1/2 * fov
+                    # larger than dist
+                    dist += fov
 
-            num_tiles = calc_num_tiles(dist, overlay, fov)
+                num_tiles = calc_num_tiles(dist, overlay, fov)
 
-            self.variables[f"{ax}_tiles"].set(num_tiles)
+                self.variables[f"{ax}_tiles"].set(num_tiles)
+            except ValueError as e:
+                logger.warning(f"Controller - Tiling Wizard - {e}")
 
     def calculate_distance(self, axis):
         """Calculate the distance for a given axis

--- a/src/aslm/controller/sub_controllers/tiling_wizard_controller2.py
+++ b/src/aslm/controller/sub_controllers/tiling_wizard_controller2.py
@@ -323,15 +323,15 @@ class TilingWizardController(GUIController):
         table_values = compute_tiles_from_bounding_box(
             x_start,
             x_tiles,
-            self.variables["x_fov"].get(),
+            float(self.variables["x_fov"].get()),
             ov,
             y_start,
             y_tiles,
-            self.variables["y_fov"].get(),
+            float(self.variables["y_fov"].get()),
             ov,
             z_start,
             z_tiles,
-            self.variables["z_fov"].get(),
+            float(self.variables["z_fov"].get()),
             ov,
             r_start,
             r_tiles,
@@ -339,7 +339,7 @@ class TilingWizardController(GUIController):
             ov,
             f_start,
             f_tiles,
-            self.variables["f_fov"].get(),
+            float(self.variables["f_fov"].get()),
             ov,
         )
 
@@ -411,7 +411,10 @@ class TilingWizardController(GUIController):
             dist = abs(float(self.variables[f"{ax}_dist"].get()))  # um
             fov = abs(float(self._fov[ax]))  # um
 
-            num_tiles = calc_num_tiles(dist, overlay, fov)
+            # + fov because distance is center of the fov to center of the fov
+            # and so we are covering a distance that is 2 * 1/2 * fov
+            # larger than dist
+            num_tiles = calc_num_tiles(dist + fov, overlay, fov)
 
             self.variables[f"{ax}_tiles"].set(num_tiles)
 

--- a/src/aslm/controller/sub_controllers/tiling_wizard_controller2.py
+++ b/src/aslm/controller/sub_controllers/tiling_wizard_controller2.py
@@ -166,10 +166,10 @@ class TilingWizardController(GUIController):
         # Trace cam_settings FOV to catch user changes
         # FOV change handled in update_fov
         self.cam_settings_widgets["FOV_X"].get_variable().trace_add(
-            "write", lambda *args: self.update_fov("x")
+            "write", lambda *args: self.update_fov("y")
         )
         self.cam_settings_widgets["FOV_Y"].get_variable().trace_add(
-            "write", lambda *args: self.update_fov("y")
+            "write", lambda *args: self.update_fov("x")
         )
         self.stack_acq_widgets["abs_z_start"].get_variable().trace_add(
             "write", lambda *args: self.update_fov("z")
@@ -584,13 +584,13 @@ class TilingWizardController(GUIController):
 
         for ax in axis:
             # Calculate signed fov
-            if ax == "x":
-                x = float(self.cam_settings_widgets["FOV_X"].get()) * sign(
+            if ax == "y":
+                y = float(self.cam_settings_widgets["FOV_X"].get()) * sign(
                     float(self.variables["x_end"].get())
                     - float(self.variables["x_start"].get())
                 )
-            elif ax == "y":
-                y = float(self.cam_settings_widgets["FOV_Y"].get()) * sign(
+            elif ax == "x":
+                x = float(self.cam_settings_widgets["FOV_Y"].get()) * sign(
                     float(self.variables["y_end"].get())
                     - float(self.variables["y_start"].get())
                 )

--- a/src/aslm/controller/sub_controllers/tiling_wizard_controller2.py
+++ b/src/aslm/controller/sub_controllers/tiling_wizard_controller2.py
@@ -127,9 +127,9 @@ class TilingWizardController(GUIController):
 
         # Init widgets to zero
         self._axes = ["x", "y", "z", "f"]
-        self._percent_overlap = 0.0
+        self._percent_overlap = 10.0
         self._fov = dict([(ax, 0.0) for ax in self._axes])
-        self.variables["percent_overlap"].set(0.0)
+        self.variables["percent_overlap"].set(self._percent_overlap)
         self.variables["total_tiles"].set(1)
 
         for ax in self._axes:
@@ -411,10 +411,13 @@ class TilingWizardController(GUIController):
             dist = abs(float(self.variables[f"{ax}_dist"].get()))  # um
             fov = abs(float(self._fov[ax]))  # um
 
-            # + fov because distance is center of the fov to center of the fov
-            # and so we are covering a distance that is 2 * 1/2 * fov
-            # larger than dist
-            num_tiles = calc_num_tiles(dist + fov, overlay, fov)
+            if ax.lower() == "x" or ax.lower() == "y":
+                # + fov because distance is center of the fov to center of the fov
+                # and so we are covering a distance that is 2 * 1/2 * fov
+                # larger than dist
+                dist += fov
+
+            num_tiles = calc_num_tiles(dist, overlay, fov)
 
             self.variables[f"{ax}_tiles"].set(num_tiles)
 

--- a/src/aslm/controller/sub_controllers/tiling_wizard_controller2.py
+++ b/src/aslm/controller/sub_controllers/tiling_wizard_controller2.py
@@ -110,7 +110,7 @@ class TilingWizardController(GUIController):
         Set the multipoint table to the tiling parameters
     showup()
         Show the popup
-    update_overlay()
+    update_overlap()
         Update the percent overlap when the user changes the value
     update_total_tiles()
         Update the total number of tiles when the user changes the value
@@ -158,9 +158,9 @@ class TilingWizardController(GUIController):
         )
 
         # Setting/Tracing Percent Overlay
-        # Overlay change is also handled in update_overlay
+        # Overlay change is also handled in update_overlap
         self.variables["percent_overlap"].trace_add(
-            "write", lambda *args: self.update_overlay()
+            "write", lambda *args: self.update_overlap()
         )
 
         # Trace cam_settings FOV to catch user changes
@@ -482,7 +482,7 @@ class TilingWizardController(GUIController):
         dist = abs(end - start)
         self.variables[axis + "_dist"].set(dist)
 
-    def update_overlay(self):
+    def update_overlap(self):
         """Update the overlay percentage for the tiling wizard
 
         Updates percent overlay when a user changes the widget in the popup.
@@ -500,7 +500,7 @@ class TilingWizardController(GUIController):
 
         Examples
         --------
-        >>> self.update_overlay()
+        >>> self.update_overlap()
         """
 
         try:

--- a/src/aslm/model/metadata_sources/bdv_metadata.py
+++ b/src/aslm/model/metadata_sources/bdv_metadata.py
@@ -30,6 +30,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 #  Standard Imports
+import sys
 import os
 from typing import Optional, Union
 import xml.etree.ElementTree as ET
@@ -199,19 +200,23 @@ class BigDataViewerMetadata(XMLMetadata):
         # Set the transform positions
         xp, yp, zp = x / self.dx, y / self.dy, z / self.dz
 
+
         # Allow additional axes (e.g. f) to couple onto existing axes (e.g. z)
         # if they are both moving along the same physical dimension
         if self._coupled_axes is not None:
-            for leader, follower in self._coupled_axes:
+            for leader, follower in self._coupled_axes.items():
                 if leader.lower() not in "xyz":
                     print(
                         f"Unrecognized coupled axis {leader}. "
                         "Not gonna do anything with this."
                     )
                     continue
-                locals()[f"{leader.lower()}p"] += locals()[
-                    f"{follower.lower()}"
-                ] / getattr(self, f"d{follower.lower()}")
+                elif leader.lower() == "x":
+                    xp += float(locals()[f"{follower.lower()}"]) / self.dx
+                elif leader.lower() == "y":
+                    yp += float(locals()[f"{follower.lower()}"]) / self.dy
+                elif leader.lower() == "z":
+                    zp += float(locals()[f"{follower.lower()}"]) / self.dz
 
         # Translation into pixels
         arr[:, 3] = [yp, xp, zp]

--- a/src/aslm/model/metadata_sources/metadata.py
+++ b/src/aslm/model/metadata_sources/metadata.py
@@ -99,19 +99,16 @@ class Metadata:
             self.set_stack_order_from_configuration_experiment()
 
     def set_shape_from_configuration_experiment(self) -> None:
-        zoom = self.configuration["experiment"]["MicroscopeState"]["zoom"]
+        state = self.configuration["experiment"]["MicroscopeState"]
+        zoom = state["zoom"]
         pixel_size = float(
             self.configuration["configuration"]["microscopes"][self.active_microscope][
                 "zoom"
             ]["pixel_size"][zoom]
         )
         self.dx, self.dy = pixel_size, pixel_size
-        self.dz = float(
-            abs(self.configuration["experiment"]["MicroscopeState"]["step_size"])
-        )
-        self.dt = float(
-            self.configuration["experiment"]["MicroscopeState"]["timepoint_interval"]
-        )
+        self.dz = float(abs(state["step_size"]))
+        self.dt = float(state["timepoint_interval"])
 
         self.shape_x = int(
             self.configuration["experiment"]["CameraParameters"]["x_pixels"]
@@ -120,46 +117,21 @@ class Metadata:
             self.configuration["experiment"]["CameraParameters"]["y_pixels"]
         )
         if (
-            (
-                self.configuration["experiment"]["MicroscopeState"]["image_mode"]
-                == "z-stack"
-            )
-            or (
-                self.configuration["experiment"]["MicroscopeState"]["image_mode"]
-                == "ConstantVelocityAcquisition"
-            )
-            or (
-                self.configuration["experiment"]["MicroscopeState"]["image_mode"]
-                == "customized"
-            )
+            (state["image_mode"] == "z-stack")
+            or (state["image_mode"] == "ConstantVelocityAcquisition")
+            or (state["image_mode"] == "customized")
         ):
-            self.shape_z = int(
-                self.configuration["experiment"]["MicroscopeState"]["number_z_steps"]
-            )
-        elif (
-            self.configuration["experiment"]["MicroscopeState"]["image_mode"]
-            == "confocal-projection"
-        ):
-            self.shape_z = int(
-                self.configuration["experiment"]["MicroscopeState"]["n_plane"]
-            )
+            self.shape_z = int(state["number_z_steps"])
+        elif state["image_mode"] == "confocal-projection":
+            self.shape_z = int(state["n_plane"])
         else:
             self.shape_z = 1
-        self.shape_t = int(
-            self.configuration["experiment"]["MicroscopeState"]["timepoints"]
-        )
+        self.shape_t = int(state["timepoints"])
         self.shape_c = sum(
-            [
-                v["is_selected"] is True
-                for k, v in self.configuration["experiment"]["MicroscopeState"][
-                    "channels"
-                ].items()
-            ]
+            [v["is_selected"] is True for k, v in state["channels"].items()]
         )
 
-        self._multiposition = self.configuration["experiment"]["MicroscopeState"][
-            "is_multiposition"
-        ]
+        self._multiposition = state["is_multiposition"]
 
         if bool(self._multiposition):
             self.positions = len(self.configuration["experiment"]["MultiPositions"])
@@ -173,16 +145,13 @@ class Metadata:
         # )
 
     def set_stack_order_from_configuration_experiment(self) -> None:
+        state = self.configuration["experiment"]["MicroscopeState"]
         self._per_stack = (
-            self.configuration["experiment"]["MicroscopeState"]["stack_cycling_mode"]
-            == "per_stack"
-            and self.configuration["experiment"]["MicroscopeState"]["image_mode"]
-            == "z-stack"
+            state["stack_cycling_mode"] == "per_stack"
+            and state["image_mode"] == "z-stack"
         ) or (
-            self.configuration["experiment"]["MicroscopeState"]["conpro_cycling_mode"]
-            == "per_stack"
-            and self.configuration["experiment"]["MicroscopeState"]["image_mode"]
-            == "confocal-projection"
+            state["conpro_cycling_mode"] == "per_stack"
+            and state["image_mode"] == "confocal-projection"
         )
 
     @property

--- a/src/aslm/model/metadata_sources/ome_tiff_metadata.py
+++ b/src/aslm/model/metadata_sources/ome_tiff_metadata.py
@@ -180,9 +180,9 @@ class OMETIFFMetadata(XMLMetadata):
                 # if they are both moving along the same physical dimension
                 if self._coupled_axes is not None:
                     for leader, follower in self._coupled_axes:
-                        view[leader] += view[follower] / getattr(
+                        view[leader] += view[follower] / float(getattr(
                             self, f"d{follower.lower()}"
-                        )
+                        ))
 
                 d = {
                     "DeltaT": dt,

--- a/src/aslm/model/metadata_sources/ome_tiff_metadata.py
+++ b/src/aslm/model/metadata_sources/ome_tiff_metadata.py
@@ -174,14 +174,24 @@ class OMETIFFMetadata(XMLMetadata):
             ome_dict["Image"]["Pixels"]["Plane"] = []
             for i in range(self.shape_c):
                 view_idx = i * self.shape_z
+                view = views[view_idx]
+                x, y, z = view["x"], view["y"], view["z"]
+                # Allow additional axes (e.g. f) to couple onto existing axes (e.g. z)
+                # if they are both moving along the same physical dimension
+                if self._coupled_axes is not None:
+                    for leader, follower in self._coupled_axes:
+                        view[leader] += view[follower] / getattr(
+                            self, f"d{follower.lower()}"
+                        )
+
                 d = {
                     "DeltaT": dt,
                     "TheT": "0",
                     "TheC": str(i),
                     "TheZ": "0",
-                    "PositionX": views[view_idx]["x"],
-                    "PositionY": views[view_idx]["y"],
-                    "PositionZ": views[view_idx]["z"],
+                    "PositionX": x,
+                    "PositionY": y,
+                    "PositionZ": z,
                 }
                 ome_dict["Image"]["Pixels"]["Plane"].append(d)
 

--- a/src/aslm/tools/multipos_table_tools.py
+++ b/src/aslm/tools/multipos_table_tools.py
@@ -202,7 +202,7 @@ def calc_num_tiles(dist, overlap, roi_length):
     else:
         ov = overlap * roi_length  # True overlap in distance units
         num_tiles = ceil(
-            dist / (roi_length - ov)
+            (dist - ov) / (roi_length - ov)
         )  # ceil(abs(dist - ov) / abs(roi_length - ov))
 
     return int(num_tiles)

--- a/src/aslm/tools/multipos_table_tools.py
+++ b/src/aslm/tools/multipos_table_tools.py
@@ -73,12 +73,10 @@ def compute_tiles_from_bounding_box(
     f_tiles,
     f_length,
     f_overlap,
+    f_track_with_z=False,
 ):
     """Create a grid of ROIs to image based on start position, number of tiles, and
     signed FOV length in each dimension.
-
-    Focus currently tracks with z, since focus is z-dependent.
-    TODO: Change this behavior? Make it a flag?
 
     Parameters
     ----------
@@ -122,6 +120,8 @@ def compute_tiles_from_bounding_box(
         Signed length of the FOV along focus dimension.
     f_overlap : float
         Fractional overlap of ROIs along focus dimension.
+    f_track_with_z : bool
+        Make focus track with z/assume focus is z-dependent.
 
     Returns
     -------
@@ -142,9 +142,6 @@ def compute_tiles_from_bounding_box(
     z_step = z_length * (1 - z_overlap)
     theta_step = theta_length * (1 - theta_overlap)
     f_step = f_length * (1 - f_overlap)
-    # Although we assume focus FOVs have no thickness, we include
-    # overlap to adjust for z-ramping. We have no excuse for the
-    # theta overlap.
 
     # grid out each dimension starting from (x_start, y_start, z_start) in steps
     def dim_vector(start, n_tiles, step):
@@ -158,19 +155,22 @@ def compute_tiles_from_bounding_box(
     thetas = dim_vector(
         theta_start, theta_tiles, theta_step
     )  # we assume theta FOVs have no thickness
-    fs = dim_vector(f_start, f_tiles, f_step)  # we assume focus FOVs have no thickness
+    fs = dim_vector(f_start, f_tiles, f_step)
 
-    # grid out the 4D space...
-    x, y, z, t = np.meshgrid(xs, ys, zs, thetas)
+    if f_track_with_z:
+        # grid out the 4D space...
+        x, y, z, t = np.meshgrid(xs, ys, zs, thetas)
 
-    # we need to make f vary the same as z, for now, since focus changes with z
-    lz = len(z.ravel())
-    f = np.repeat(fs, np.ceil(lz / len(fs)))[
-        :lz
-    ]  # This only works if len(fs) = len(zs)
-    # TODO: Don't clip f. Practically fine for now.
+        # we need to make f vary the same as z, for now, since focus changes with z
+        lz = len(z.ravel())
+        f = np.repeat(fs, np.ceil(lz / len(fs)))[
+            :lz
+        ]  # This only works if len(fs) = len(zs)
+        # TODO: Don't clip f. Practically fine for now.
+    else:
+        x, y, z, t, f = np.meshgrid(xs, ys, zs, thetas, fs)
 
-    return np.vstack([x.ravel(), y.ravel(), z.ravel(), t.ravel(), f]).T
+    return np.vstack([x.ravel(), y.ravel(), z.ravel(), t.ravel(), f.ravel()]).T
 
 
 def calc_num_tiles(dist, overlap, roi_length):

--- a/src/aslm/tools/multipos_table_tools.py
+++ b/src/aslm/tools/multipos_table_tools.py
@@ -201,7 +201,9 @@ def calc_num_tiles(dist, overlap, roi_length):
         num_tiles = 1
     else:
         ov = overlap * roi_length  # True overlap in distance units
-        num_tiles = ceil(abs(dist - ov) / abs(roi_length - ov))
+        num_tiles = ceil(
+            dist / (roi_length - ov)
+        )  # ceil(abs(dist - ov) / abs(roi_length - ov))
 
     return int(num_tiles)
 

--- a/src/aslm/view/custom_widgets/validation.py
+++ b/src/aslm/view/custom_widgets/validation.py
@@ -1107,13 +1107,12 @@ class ValidatedSpinbox(ValidatedMixin, ttk.Spinbox):
         max_val = self.cget("to")
         min_val = self.cget("from")
         try:
-            max_val = round(Decimal(max_val), 16)
-            min_val = round(Decimal(min_val), 16)
+            max_val = Decimal(max_val)
+            min_val = Decimal(min_val)
         except InvalidOperation:
-            print(
-                f"Either min_val or max_val couldn't be cast to a Decimal. "
-                f"min_val: {min_val} max_val: {max_val}"
-            )
+            err_str = f"Either {min_val} or {max_val} couldn't be cast to a Decimal."
+            logger.warning(err_str)
+            print(err_str)
 
         # Check for error upon leaving widget
         if value.strip() == "" and self.required:

--- a/src/aslm/view/popups/tiling_wizard_popup2.py
+++ b/src/aslm/view/popups/tiling_wizard_popup2.py
@@ -47,38 +47,21 @@ logger = logging.getLogger(p)
 
 
 class TilingWizardPopup:
-    """Popup for tiling parameters in View.
-
-    Parameters
-    ----------
-    root : object
-        GUI root
-    *args : object
-        Arguments
-    **kwargs : object
-        Keyword arguments
-
-    Attributes
-    ----------
-    popup : object
-        Popup window
-    inputs : dict
-        Dictionary of inputs
-    buttons : dict
-        Dictionary of buttons
-
-    Methods
-    -------
-    get_variables()
-        Returns the variables
-    get_buttons()
-        Returns the buttons
-    get_widgets()
-        Returns the widgets
-
-    """
+    """Popup for tiling parameters in View."""
 
     def __init__(self, root, *args, **kwargs):
+        """Initialize the popup
+
+        Parameters
+        ----------
+        root : tk.Tk
+            The root Tk instance
+        *args
+            Variable length argument list.
+        **kwargs
+            Arbitrary keyword arguments.
+        """
+        #: tk.TopLevel: The popup window
         self.popup = PopUp(
             root,
             "Multi-Position Tiling Wizard",
@@ -101,9 +84,10 @@ class TilingWizardPopup:
             self.popup.content_frame.columnconfigure(col, pad=5, weight=1)
         for row in range(nrow):
             self.popup.content_frame.rowconfigure(row, pad=5, weight=1)
-
-        self.inputs = {}  # The GUI elements used for input, mostly ttk.Frames
-        self.buttons = {}  # Action buttons for the inputs, a dictionary of ttk.Buttons
+        #: dict: The GUI elements used for input, mostly ttk.Frames
+        self.inputs = {}
+        #: dict: The GUI elements used for buttons, mostly ttk.Buttons
+        self.buttons = {}
 
         # Add one row per axis
         for row, ax in enumerate(axes):
@@ -238,10 +222,6 @@ class TilingWizardPopup:
         This function returns a dictionary of all the variables that are tied to each
         widget name. The key is the widget name, value is the variable associated.
 
-        Parameters
-        ----------
-        None
-
         Returns
         -------
         variables : dict
@@ -255,10 +235,6 @@ class TilingWizardPopup:
         This function returns the dictionary that holds the input widgets.
         The key is the widget name, value is the LabelInput class that has all the data.
 
-        Parameters
-        ----------
-        None
-
         Returns
         -------
         self.inputs : dict
@@ -271,10 +247,6 @@ class TilingWizardPopup:
 
         This function returns the dictionary that holds the buttons.
         The key is the button name, value is the button.
-
-        Parameters
-        ----------
-        None
 
         Returns
         -------

--- a/src/aslm/view/popups/tiling_wizard_popup2.py
+++ b/src/aslm/view/popups/tiling_wizard_popup2.py
@@ -1,0 +1,284 @@
+# Copyright (c) 2021-2022  The University of Texas Southwestern Medical Center.
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted for academic and research use only (subject to the
+# limitations in the disclaimer below) provided that the following conditions are met:
+
+#      * Redistributions of source code must retain the above copyright notice,
+#      this list of conditions and the following disclaimer.
+
+#      * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+
+#      * Neither the name of the copyright holders nor the names of its
+#      contributors may be used to endorse or promote products derived from this
+#      software without specific prior written permission.
+
+# NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE GRANTED BY
+# THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+# CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+# PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+# BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+# IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# Standard Library Imports
+import logging
+import tkinter as tk
+from tkinter import ttk
+
+# Third Party Imports
+
+# Local Imports
+from aslm.view.custom_widgets.popup import PopUp
+from aslm.view.custom_widgets.LabelInputWidgetFactory import LabelInput
+from aslm.view.custom_widgets.validation import ValidatedSpinbox, ValidatedEntry
+
+# Logging Setup
+p = __name__.split(".")[1]
+logger = logging.getLogger(p)
+
+
+class TilingWizardPopup:
+    """Popup for tiling parameters in View.
+
+    Parameters
+    ----------
+    root : object
+        GUI root
+    *args : object
+        Arguments
+    **kwargs : object
+        Keyword arguments
+
+    Attributes
+    ----------
+    popup : object
+        Popup window
+    inputs : dict
+        Dictionary of inputs
+    buttons : dict
+        Dictionary of buttons
+
+    Methods
+    -------
+    get_variables()
+        Returns the variables
+    get_buttons()
+        Returns the buttons
+    get_widgets()
+        Returns the widgets
+
+    """
+
+    def __init__(self, root, *args, **kwargs):
+        self.popup = PopUp(
+            root,
+            "Multi-Position Tiling Wizard",
+            "800x250+10+10",
+            top=False,
+            transient=False,
+        )
+
+        # Grab the axes we want to grid out. Optionally,
+        # we can pass these in the kwargs
+        axes = list(kwargs.get("axes", "XYZF"))
+
+        nrow = len(axes) + 2  # +2 for percent overlay, total number of tiles, populate
+        # <set x-start> [x-start] <set-x-end> [x-end]
+        # [x-distance] [x-fov-width] [x-tiles]
+        ncol = 7
+
+        # Set up the grid on the popup's frame
+        for col in range(ncol):
+            self.popup.content_frame.columnconfigure(col, pad=5, weight=1)
+        for row in range(nrow):
+            self.popup.content_frame.rowconfigure(row, pad=5, weight=1)
+
+        self.inputs = {}  # The GUI elements used for input, mostly ttk.Frames
+        self.buttons = {}  # Action buttons for the inputs, a dictionary of ttk.Buttons
+
+        # Add one row per axis
+        for row, ax in enumerate(axes):
+            # Set start position
+            start_var = f"{ax.lower()}_start"
+            self.buttons[start_var] = ttk.Button(
+                self.popup.content_frame, text=f"Set {ax.upper()} Start"
+            )
+            self.buttons[start_var].grid(
+                row=row, column=0, sticky=tk.NSEW, padx=(5, 0), pady=(5, 0)
+            )
+            self.inputs[start_var] = LabelInput(
+                parent=self.popup.content_frame,
+                input_class=ValidatedSpinbox,
+                input_var=tk.StringVar(),
+                input_args={"width": 5},
+            )
+            self.inputs[start_var].grid(
+                row=row, column=1, sticky=tk.NSEW, pady=(5, 0), padx=(5, 0)
+            )
+            self.inputs[start_var].widget.state(["disabled"])
+
+            # Set end position
+            end_var = f"{ax.lower()}_end"
+            self.buttons[end_var] = ttk.Button(
+                self.popup.content_frame, text=f"Set {ax.upper()} End"
+            )
+            self.buttons[end_var].grid(
+                row=row, column=2, sticky=tk.NSEW, padx=(5, 0), pady=(5, 0)
+            )
+            self.inputs[end_var] = LabelInput(
+                parent=self.popup.content_frame,
+                input_class=ValidatedSpinbox,
+                input_var=tk.StringVar(),
+                input_args={"width": 5},
+            )
+            self.inputs[end_var].grid(
+                row=row, column=3, sticky=tk.NSEW, pady=(5, 0), padx=(5, 0)
+            )
+            self.inputs[end_var].widget.state(["disabled"])
+
+            # Distance between start and end of this axis
+            dist_var = f"{ax.lower()}_dist"
+            self.inputs[dist_var] = LabelInput(
+                parent=self.popup.content_frame,
+                label=f"{ax.upper()} Distance",
+                input_class=ValidatedEntry,
+                input_var=tk.StringVar(),
+                input_args={"width": 5},
+            )
+            self.inputs[dist_var].grid(
+                row=row, column=4, sticky=tk.NSEW, pady=(5, 0), padx=(5, 0)
+            )
+            self.inputs[dist_var].widget.state(["disabled"])
+
+            # FOV width for this particular axis (e.g. for X it is the number
+            # of vertical pixels on the camera multipled by the effective
+            # pixel size)
+            fov_var = f"{ax.lower()}_fov"
+            self.inputs[fov_var] = LabelInput(
+                parent=self.popup.content_frame,
+                label=f"{ax.upper()} FOV Dist",
+                input_class=ValidatedSpinbox,
+                input_var=tk.StringVar(),
+                input_args={
+                    "width": 5,
+                    "from_": "-Infinity",
+                    "to": "Infinity",
+                    "increment": 100.0,
+                },
+            )
+            self.inputs[fov_var].grid(
+                row=row, column=5, sticky=tk.NSEW, pady=(5, 0), padx=(5, 0)
+            )
+            # self.inputs[fov_var].widget.state(["disabled"])
+
+            # Number of tiles, roughly ceil((ax_end - ax_start) / fov_width)
+            # (not accounting for percent overlap)
+            tiles_var = f"{ax.lower()}_tiles"
+            self.inputs[tiles_var] = LabelInput(
+                parent=self.popup.content_frame,
+                label="Num. Tiles",
+                input_class=ValidatedEntry,
+                input_var=tk.StringVar(),
+                input_args={"width": 5},
+            )
+            self.inputs[tiles_var].grid(
+                row=row, column=6, sticky=tk.NSEW, pady=(5, 0), padx=(5, 0)
+            )
+            self.inputs[tiles_var].widget.state(["disabled"])
+
+        # In the final row, add percent overlap, total number of tiles, populate button
+        self.inputs["percent_overlap"] = LabelInput(
+            parent=self.popup.content_frame,
+            label="% Overlap",
+            input_class=ValidatedSpinbox,
+            input_var=tk.StringVar(),
+            input_args={"width": 5, "increment": 5, "from_": 0, "to": 100},
+        )
+        self.inputs["percent_overlap"].grid(
+            row=len(axes), column=5, sticky=tk.NSEW, padx=(5, 0), pady=(5, 0)
+        )
+
+        self.inputs["total_tiles"] = LabelInput(
+            parent=self.popup.content_frame,
+            label="Total Tiles",
+            input_class=ValidatedEntry,
+            input_var=tk.StringVar(),
+            input_args={"width": 5},
+        )
+        self.inputs["total_tiles"].widget.state(["disabled"])
+        self.inputs["total_tiles"].grid(
+            row=len(axes), column=6, sticky=tk.NSEW, padx=(5, 0), pady=(5, 0)
+        )
+
+        self.buttons["set_table"] = ttk.Button(
+            self.popup.content_frame, text="Populate Multi-Position Table"
+        )
+        self.buttons["set_table"].grid(
+            row=len(axes) + 1,
+            column=5,
+            columnspan=2,
+            sticky=tk.NE,
+            padx=(0, 5),
+            pady=(5, 0),
+        )
+
+    # Getters
+    def get_variables(self):
+        """Get the variables tied to the widgets
+
+        This function returns a dictionary of all the variables that are tied to each
+        widget name. The key is the widget name, value is the variable associated.
+
+        Parameters
+        ----------
+        None
+
+        Returns
+        -------
+        variables : dict
+            A dictionary of all the variables that are tied to each widget name.
+        """
+        return {key: widget.get_variable() for key, widget in self.inputs.items()}
+
+    def get_widgets(self):
+        """Get the widgets
+
+        This function returns the dictionary that holds the input widgets.
+        The key is the widget name, value is the LabelInput class that has all the data.
+
+        Parameters
+        ----------
+        None
+
+        Returns
+        -------
+        self.inputs : dict
+            A dictionary of all the widgets that are tied to each widget name.
+        """
+        return self.inputs
+
+    def get_buttons(self):
+        """Get the buttons
+
+        This function returns the dictionary that holds the buttons.
+        The key is the button name, value is the button.
+
+        Parameters
+        ----------
+        None
+
+        Returns
+        -------
+        self.buttons : dict
+            A dictionary of all the buttons that are tied to each button name.
+        """
+        return self.buttons

--- a/test/controller/sub_controllers/test_tiling_wizard_controller.py
+++ b/test/controller/sub_controllers/test_tiling_wizard_controller.py
@@ -1,0 +1,70 @@
+import random
+import pytest
+
+
+@pytest.fixture(scope="module")
+def tiling_wizard_controller(dummy_view, dummy_controller):
+    from aslm.view.popups.tiling_wizard_popup2 import TilingWizardPopup
+    from aslm.controller.sub_controllers.tiling_wizard_controller2 import (
+        TilingWizardController,
+    )
+
+    tiling_wizard = TilingWizardPopup(dummy_view)
+
+    class SubController:
+        def __init__(self):
+            self.parent_controller = dummy_controller
+
+    return TilingWizardController(tiling_wizard, SubController())
+
+
+def test_update_total_tiles(tiling_wizard_controller):
+    tiling_wizard_controller.update_total_tiles()
+
+    assert True
+
+
+@pytest.mark.parametrize("axis", ["x", "y", "z", "f"])
+def test_calculate_tiles(tiling_wizard_controller, axis):
+    from aslm.tools.multipos_table_tools import calc_num_tiles
+
+    ov, dist, fov = random.random(), random.random() * 100, random.random() * 10
+    tiling_wizard_controller._percent_overlap = ov * 100
+    tiling_wizard_controller.variables[f"{axis}_dist"].set(dist)
+    tiling_wizard_controller._fov[axis] = fov
+    tiling_wizard_controller.calculate_tiles(axis)
+
+    assert int(
+        tiling_wizard_controller.variables[f"{axis}_tiles"].get()
+    ) == calc_num_tiles(dist, ov, fov)
+
+
+@pytest.mark.parametrize("axis", ["x", "y", "z", "f"])
+def test_calculate_distance(tiling_wizard_controller, axis):
+    start, end = random.random() * 10, random.random() * 100
+    tiling_wizard_controller.variables[axis + "_start"].set(start)
+    tiling_wizard_controller.variables[axis + "_end"].set(end)
+    tiling_wizard_controller.calculate_distance(axis)
+    assert float(tiling_wizard_controller.variables[axis + "_dist"].get()) == abs(
+        start - end
+    )
+
+
+def test_update_overlay(tiling_wizard_controller):
+    tiling_wizard_controller.variables["percent_overlap"].set("")
+    tiling_wizard_controller.update_overlay()
+    tiling_wizard_controller.variables["percent_overlap"].set("10")
+    tiling_wizard_controller.update_overlay()
+
+    assert True
+
+
+def test_update_fov(tiling_wizard_controller):
+    tiling_wizard_controller.update_fov()
+
+
+# def test_set_table(tiling_wizard_controller):
+#     print(tiling_wizard_controller.cam_settings_widgets["FOV_X"].get())
+#     tiling_wizard_controller.set_table()
+
+#     assert True

--- a/test/controller/sub_controllers/test_tiling_wizard_controller.py
+++ b/test/controller/sub_controllers/test_tiling_wizard_controller.py
@@ -60,12 +60,13 @@ def test_traces(tiling_wizard_controller):
     assert_one_trace(
         tiling_wizard_controller.stack_acq_widgets["abs_z_end"].get_variable()
     )
-    assert_one_trace(
-        tiling_wizard_controller.stack_acq_widgets["start_focus"].get_variable()
-    )
-    assert_one_trace(
-        tiling_wizard_controller.stack_acq_widgets["end_focus"].get_variable()
-    )
+    # Channels tab controller binds these a bunch
+    # assert_one_trace(
+    #     tiling_wizard_controller.stack_acq_widgets["start_focus"].get_variable()
+    # )
+    # assert_one_trace(
+    #     tiling_wizard_controller.stack_acq_widgets["end_focus"].get_variable()
+    # )
 
 
 def test_update_total_tiles(tiling_wizard_controller):

--- a/test/controller/sub_controllers/test_tiling_wizard_controller.py
+++ b/test/controller/sub_controllers/test_tiling_wizard_controller.py
@@ -118,7 +118,7 @@ def test_update_fov(tiling_wizard_controller, axis):
     import random
     from aslm.tools.multipos_table_tools import sign
 
-    if axis == "x":
+    if axis == "y":
         tiling_wizard_controller.cam_settings_widgets["FOV_X"].set(
             int(random.random() * 1000)
         )
@@ -130,7 +130,7 @@ def test_update_fov(tiling_wizard_controller, axis):
             float(tiling_wizard_controller.variables["x_end"].get())
             - float(tiling_wizard_controller.variables["x_start"].get())
         )
-    elif axis == "y":
+    elif axis == "x":
         tiling_wizard_controller.cam_settings_widgets["FOV_Y"].set(
             int(random.random() * 1000)
         )

--- a/test/controller/sub_controllers/test_tiling_wizard_controller.py
+++ b/test/controller/sub_controllers/test_tiling_wizard_controller.py
@@ -53,21 +53,112 @@ def test_calculate_distance(tiling_wizard_controller, axis):
     )
 
 
-def test_update_overlay(tiling_wizard_controller):
+def test_update_overlap(tiling_wizard_controller):
     tiling_wizard_controller.variables["percent_overlap"].set("")
-    tiling_wizard_controller.update_overlay()
+    tiling_wizard_controller.update_overlap()
     tiling_wizard_controller.variables["percent_overlap"].set("10")
-    tiling_wizard_controller.update_overlay()
+    tiling_wizard_controller.update_overlap()
 
     assert True
 
 
-def test_update_fov(tiling_wizard_controller):
-    tiling_wizard_controller.update_fov()
+@pytest.mark.parametrize("axis", ["x", "y", "z", "f"])
+def test_update_fov(tiling_wizard_controller, axis):
+    import random
+    from aslm.tools.multipos_table_tools import sign
+
+    if axis == "x":
+        tiling_wizard_controller.cam_settings_widgets["FOV_X"].set(
+            int(random.random() * 1000)
+        )
+        tiling_wizard_controller.variables["x_start"].set(random.random() * 10)
+        tiling_wizard_controller.variables["x_end"].set(random.random() * 1000)
+        var = float(
+            tiling_wizard_controller.cam_settings_widgets["FOV_X"].get()
+        ) * sign(
+            float(tiling_wizard_controller.variables["x_end"].get())
+            - float(tiling_wizard_controller.variables["x_start"].get())
+        )
+    elif axis == "y":
+        tiling_wizard_controller.cam_settings_widgets["FOV_Y"].set(
+            int(random.random() * 1000)
+        )
+        tiling_wizard_controller.variables["y_start"].set(random.random() * 10)
+        tiling_wizard_controller.variables["y_end"].set(random.random() * 1000)
+        var = float(
+            tiling_wizard_controller.cam_settings_widgets["FOV_Y"].get()
+        ) * sign(
+            float(tiling_wizard_controller.variables["y_end"].get())
+            - float(tiling_wizard_controller.variables["y_start"].get())
+        )
+    elif axis == "z":
+        tiling_wizard_controller.stack_acq_widgets["start_position"].set(
+            random.random() * 10
+        )
+        tiling_wizard_controller.stack_acq_widgets["end_position"].set(
+            random.random() * 1000
+        )
+        var = float(
+            tiling_wizard_controller.stack_acq_widgets["end_position"].get()
+        ) - float(tiling_wizard_controller.stack_acq_widgets["start_position"].get())
+    elif axis == "f":
+        tiling_wizard_controller.stack_acq_widgets["start_focus"].set(
+            random.random() * 10
+        )
+        tiling_wizard_controller.stack_acq_widgets["end_focus"].set(
+            random.random() * 1000
+        )
+        var = float(
+            tiling_wizard_controller.stack_acq_widgets["end_focus"].get()
+        ) - float(tiling_wizard_controller.stack_acq_widgets["start_focus"].get())
+    tiling_wizard_controller.update_fov(axis)
+
+    assert float(tiling_wizard_controller.variables[f"{axis}_fov"].get()) == var
 
 
 def test_set_table(tiling_wizard_controller):
-    # print(tiling_wizard_controller.cam_settings_widgets["FOV_X"].get())
+    # from aslm.tools.multipos_table_tools import compute_tiles_from_bounding_box
     tiling_wizard_controller.set_table()
 
-    assert True
+    x_start = float(tiling_wizard_controller.variables["x_start"].get())
+    x_stop = float(tiling_wizard_controller.variables["x_end"].get())
+
+    y_start = float(tiling_wizard_controller.variables["y_start"].get())
+    y_stop = float(tiling_wizard_controller.variables["y_end"].get())
+
+    # shift z by coordinate origin of local z-stack
+    z_start = float(tiling_wizard_controller.variables["z_start"].get()) - float(
+        tiling_wizard_controller.stack_acq_widgets["start_position"].get()
+    )
+    z_stop = float(tiling_wizard_controller.variables["z_end"].get()) - float(
+        tiling_wizard_controller.stack_acq_widgets["end_position"].get()
+    )
+
+    # Default to fixed theta
+    r_start = tiling_wizard_controller.stage_position_vars["theta"].get()
+    r_stop = tiling_wizard_controller.stage_position_vars["theta"].get()
+
+    f_start = float(tiling_wizard_controller.variables["f_start"].get()) - float(
+        tiling_wizard_controller.stack_acq_widgets["start_focus"].get()
+    )
+    f_stop = float(tiling_wizard_controller.variables["f_end"].get()) - float(
+        tiling_wizard_controller.stack_acq_widgets["end_focus"].get()
+    )
+
+    # for consistency, always go from low to high
+    def sort_vars(a, b):
+        if a > b:
+            return b, a
+        return a, b
+
+    x_start, x_stop = sort_vars(x_start, x_stop)
+    y_start, y_stop = sort_vars(y_start, y_stop)
+    z_start, z_stop = sort_vars(z_start, z_stop)
+    r_start, r_stop = sort_vars(r_start, r_stop)
+    f_start, f_stop = sort_vars(f_start, f_stop)
+
+    assert tiling_wizard_controller.multipoint_table.model.df["X"].min() == x_start
+    assert tiling_wizard_controller.multipoint_table.model.df["Y"].min() == y_start
+    assert tiling_wizard_controller.multipoint_table.model.df["Z"].min() == z_start
+    assert tiling_wizard_controller.multipoint_table.model.df["R"].min() == r_start
+    assert tiling_wizard_controller.multipoint_table.model.df["F"].min() == f_start

--- a/test/controller/sub_controllers/test_tiling_wizard_controller.py
+++ b/test/controller/sub_controllers/test_tiling_wizard_controller.py
@@ -31,8 +31,11 @@ def test_calculate_tiles(tiling_wizard_controller, axis):
     ov, dist, fov = random.random(), random.random() * 100, random.random() * 10
     tiling_wizard_controller._percent_overlap = ov * 100
     tiling_wizard_controller.variables[f"{axis}_dist"].set(dist)
-    tiling_wizard_controller._fov[axis] = fov
+    tiling_wizard_controller.variables[f"{axis}_fov"].set(fov)
     tiling_wizard_controller.calculate_tiles(axis)
+
+    if axis == "x" or axis == "y":
+        dist += fov
 
     assert int(
         tiling_wizard_controller.variables[f"{axis}_tiles"].get()
@@ -63,8 +66,8 @@ def test_update_fov(tiling_wizard_controller):
     tiling_wizard_controller.update_fov()
 
 
-# def test_set_table(tiling_wizard_controller):
-#     print(tiling_wizard_controller.cam_settings_widgets["FOV_X"].get())
-#     tiling_wizard_controller.set_table()
+def test_set_table(tiling_wizard_controller):
+    # print(tiling_wizard_controller.cam_settings_widgets["FOV_X"].get())
+    tiling_wizard_controller.set_table()
 
-#     assert True
+    assert True

--- a/test/tools/test_multipos_table_tools.py
+++ b/test/tools/test_multipos_table_tools.py
@@ -191,7 +191,9 @@ def test_calc_num_tiles(dist, overlap, roi_length):
     # overlap = .75
     # roi_length = 525
     expected_num_tiles = ceil(
-        abs(dist - overlap * roi_length) / abs(roi_length - overlap * roi_length)
+        # abs(dist - overlap * roi_length) / abs(roi_length - overlap * roi_length)
+        dist
+        / (roi_length - overlap * roi_length)
     )
 
     result = calc_num_tiles(dist, overlap, roi_length)

--- a/test/tools/test_multipos_table_tools.py
+++ b/test/tools/test_multipos_table_tools.py
@@ -82,6 +82,7 @@ def listize(x):
 @pytest.mark.parametrize("f_tiles", listize(np.random.randint(0, 5)))
 @pytest.mark.parametrize("f_length", listize(np.random.rand() * 1000))
 @pytest.mark.parametrize("f_overlap", listize(np.random.rand()))
+@pytest.mark.parametrize("f_track_with_z", [True, False])
 def test_compute_tiles_from_bounding_box(
     x_start,
     x_tiles,
@@ -103,6 +104,7 @@ def test_compute_tiles_from_bounding_box(
     f_tiles,
     f_length,
     f_overlap,
+    f_track_with_z,
 ):
     from aslm.tools.multipos_table_tools import compute_tiles_from_bounding_box
 
@@ -127,6 +129,7 @@ def test_compute_tiles_from_bounding_box(
         f_tiles,
         f_length,
         f_overlap,
+        f_track_with_z,
     )
 
     x_tiles = 1 if x_tiles <= 0 else x_tiles
@@ -151,7 +154,10 @@ def test_compute_tiles_from_bounding_box(
     assert tiles[-1, 1] == y_max
     assert tiles[-1, 2] == z_max
     assert tiles[-1, 3] == theta_max
-    assert tiles[-1, 4] <= f_max  # Due to clipping. TODO: Fix
+    if f_track_with_z:
+        assert tiles[-1, 4] <= f_max  # Due to clipping. TODO: Fix
+    else:
+        assert tiles[-1, 4] == f_max
 
     # check bounding box
     assert np.min(tiles[:, 0]) == x_start
@@ -163,10 +169,16 @@ def test_compute_tiles_from_bounding_box(
     assert np.min(tiles[:, 3]) == theta_start
     assert np.max(tiles[:, 3]) == theta_max
     assert np.min(tiles[:, 4]) == f_start
-    assert np.max(tiles[:, 4]) <= f_max  # Due to clipping. TODO: Fix
+    if f_track_with_z:
+        assert np.max(tiles[:, 4]) <= f_max  # Due to clipping. TODO: Fix
+    else:
+        assert np.max(tiles[:, 4]) == f_max
 
-    # check length
-    assert len(tiles) == x_tiles * y_tiles * z_tiles * theta_tiles
+    if f_track_with_z:
+        # check length
+        assert len(tiles) == x_tiles * y_tiles * z_tiles * theta_tiles
+    else:
+        assert len(tiles) == x_tiles * y_tiles * z_tiles * theta_tiles * f_tiles
 
 
 @pytest.mark.parametrize("dist", listize(np.random.rand(3) * 1000))

--- a/test/tools/test_multipos_table_tools.py
+++ b/test/tools/test_multipos_table_tools.py
@@ -192,7 +192,7 @@ def test_calc_num_tiles(dist, overlap, roi_length):
     # roi_length = 525
     expected_num_tiles = ceil(
         # abs(dist - overlap * roi_length) / abs(roi_length - overlap * roi_length)
-        dist
+        (dist - overlap * roi_length)
         / (roi_length - overlap * roi_length)
     )
 


### PR DESCRIPTION
This is designed to allow for tiling along X, Y, Z and F. The goal is to image a full tissue on the ctASLM v1/v2, where there is both a z-stacking stage (Z) and a sample scanning stage in the z-direction (F).

This works, but in order for BDV to display this as a contiguous tile, we will need to add Z and F together in the affine transform matrix for just these two microscopes. 

Also closes #628.