### PR TITLE
Remove extraneous messages printed on the command line at launch

### DIFF
--- a/src/aslm/_commit.py
+++ b/src/aslm/_commit.py
@@ -32,6 +32,7 @@
 
 
 # Standard Library Imports
+import os
 import subprocess
 
 # Third Party Imports
@@ -40,8 +41,22 @@ import subprocess
 
 
 def get_git_revision_hash() -> str:
-    print("before subprocess")
-    return subprocess.check_output(["git", "rev-parse", "HEAD"]).decode("ascii").strip()
+    """
+    TODO: This should not be dynamic. A packaged version will still have an
+    associated commit, but won't be an active git repo. The hash should be
+    stored in a file like in __version__ and bumped with each commit.
+    """
+    # print("before subprocess")
+    # we don't want to move the user, so we'll return to the directory
+    working_directory = os.getcwd()
+    # we need to check for the git commit inside of the cloned git folder,
+    # should this have been derived from a git commit
+    file_directory = os.path.abspath(os.path.dirname(__file__))
+    os.chdir(file_directory)
+    # call the hash
+    hash = subprocess.check_output(["git", "rev-parse", "HEAD"]).decode("ascii").strip()
+    os.chdir(working_directory)  # restore directory
+    return hash
 
 
 try:

--- a/src/aslm/model/devices/APIs/hamamatsu/HamamatsuAPI.py
+++ b/src/aslm/model/devices/APIs/hamamatsu/HamamatsuAPI.py
@@ -721,7 +721,7 @@ class camReg(object):
             cls.numCameras = 0
 
         cls.numCameras += 1
-        print(f"Number of cameras is {cls.numCameras}")
+        # print(f"Number of cameras is {cls.numCameras}")
 
     @classmethod
     def unregCamera(cls):
@@ -750,7 +750,7 @@ class DCAM:
             "subarray_vsize"
         )
 
-        print(f"steps {self.step_image_height} {self.step_image_width}")
+        # print(f"steps {self.step_image_height} {self.step_image_width}")
 
         self._serial_number = self.get_string_value(
             c_int32(int("0x04000102", 0))
@@ -821,9 +821,9 @@ class DCAM:
             False:  if dcamdev_open() returned DCAMERR except SUCCESS.  lasterr()
                     returns the DCAMERR value.
         """
-        print("Opening Camera")
+        # print("Opening Camera")
         if self.__hdcam:
-            print("Camera already open")
+            # print("Camera already open")
             return self.__result(
                 DCAMERR.ALREADYOPENED
             )  # instance is already opened. New Error.
@@ -840,8 +840,8 @@ class DCAM:
         if ret is False:
             print("Camera dev_open failed")
             return False
-        else:
-            print("Camera Open")
+        # else:
+        #     print("Camera Open")
 
         self.__hdcam = c_void_p(paramopen.hdcam)
 


### PR DESCRIPTION
Comment a couple of print statements in the camera and fix the git hash call.