### PR TITLE
DAQ Hardware Documentation and DAQ_NI Update

### DIFF
--- a/docs/source/supported_hardware.rst
+++ b/docs/source/supported_hardware.rst
@@ -51,6 +51,11 @@ PXI-6259
 The PXI-6259 can create one software-timed analog task per channel. As such, the
 galvo/remote focus/lasers can be attached to any of the analog output ports.
 
+PXI-6723
+""""""""""
+- Connect the ``master_trigger_out_line`` to the ``trigger_source`` with a direct wire, commonly ``PXI6723/port0/line1`` and ``/PXI6723/PFI0``. With an SCB-68A breakout box, connect pin 17 directly to pin 11.
+- Connect the ``camera_trigger_out_line`` to the ``Ext. Trigger`` on the camera using the ``CTR0Out`` pin. With an SCB-68A breakout box, the positive lead is pin 2, the ground is pin 36.
+
 
 Cameras
 ----------

--- a/src/aslm/model/devices/daq/daq_ni.py
+++ b/src/aslm/model/devices/daq/daq_ni.py
@@ -241,7 +241,9 @@ class NIDAQ(DAQBase):
             Channel key for analog output.
         """
         n_samples = list(set([v["samples"] for v in self.analog_outputs.values()]))
-        if len(n_samples) > 1:
+        if len(n_samples) == 0:
+            return
+        elif len(n_samples) > 1:
             logger.debug(
                 "NI DAQ - Different number of samples provided for each analog"
                 "channel. Defaulting to the minimum number of samples provided."


### PR DESCRIPTION
The DAQ interface was throwing an error because n_samples == 0, and it did not know how to handle this condition. This arose because we had multiple digital signals, but no analog outputs configured. Software had not been tested under this condition.