### PR TITLE
Move the Dummy Model to Tests

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -48,7 +48,7 @@ def dummy_model():
     DummyModel
         Dummy model for testing.
     """
-    from navigate.model.dummy import DummyModel
+    from test.model.dummy import DummyModel
 
     model = DummyModel()
     return model
@@ -89,7 +89,7 @@ def dummy_controller(dummy_view):
     DummyController
         Dummy controller for testing.
     """
-    from navigate.model.dummy import DummyController
+    from test.model.dummy import DummyController
 
     controller = DummyController(dummy_view)
     return controller

--- a/test/model/data_sources/test_bdv_data_source.py
+++ b/test/model/data_sources/test_bdv_data_source.py
@@ -30,7 +30,7 @@ def recurse_dtype(group):
 @pytest.mark.parametrize("size", [(1024, 2048), (2048, 1024), (2048, 2048)])
 @pytest.mark.parametrize("ext", ["h5", "n5"])
 def test_bdv_write(multiposition, per_stack, z_stack, stop_early, size, ext):
-    from navigate.model.dummy import DummyModel
+    from test.model.dummy import DummyModel
     from navigate.model.data_sources.bdv_data_source import BigDataViewerDataSource
 
     print(

--- a/test/model/data_sources/test_tiff_data_source.py
+++ b/test/model/data_sources/test_tiff_data_source.py
@@ -13,7 +13,7 @@ from navigate.tools.file_functions import delete_folder
 def test_tiff_write_read(is_ome, multiposition, per_stack, z_stack, stop_early):
     import numpy as np
 
-    from navigate.model.dummy import DummyModel
+    from test.model.dummy import DummyModel
     from navigate.model.data_sources.tiff_data_source import TiffDataSource
 
     print(

--- a/test/model/devices/daq/test_daq_base.py
+++ b/test/model/devices/daq/test_daq_base.py
@@ -1,6 +1,6 @@
 def test_initialize_daq():
     from navigate.model.devices.daq.daq_base import DAQBase
-    from navigate.model.dummy import DummyModel
+    from test.model.dummy import DummyModel
 
     model = DummyModel()
     DAQBase(model.configuration)
@@ -10,7 +10,7 @@ def test_calculate_all_waveforms():
     import numpy as np
 
     from navigate.model.devices.daq.daq_base import DAQBase
-    from navigate.model.dummy import DummyModel
+    from test.model.dummy import DummyModel
 
     model = DummyModel()
     daq = DAQBase(model.configuration)

--- a/test/model/devices/daq/test_daq_ni.py
+++ b/test/model/devices/daq/test_daq_ni.py
@@ -40,7 +40,7 @@ import pytest
 @pytest.mark.hardware
 def test_initialize_daq_ni():
     from navigate.model.devices.daq.daq_ni import NIDAQ
-    from navigate.model.dummy import DummyModel
+    from test.model.dummy import DummyModel
 
     model = DummyModel()
     daq = NIDAQ(model.configuration)
@@ -49,10 +49,8 @@ def test_initialize_daq_ni():
 
 @pytest.mark.hardware
 def test_daq_ni_functions():
-    import random
-
     from navigate.model.devices.daq.daq_ni import NIDAQ
-    from navigate.model.dummy import DummyModel
+    from test.model.dummy import DummyModel
 
     model = DummyModel()
     daq = NIDAQ(model.configuration)

--- a/test/model/devices/daq/test_daq_synthetic.py
+++ b/test/model/devices/daq/test_daq_synthetic.py
@@ -1,6 +1,6 @@
 def test_initialize_daq_synthetic():
     from navigate.model.devices.daq.daq_synthetic import SyntheticDAQ
-    from navigate.model.dummy import DummyModel
+    from test.model.dummy import DummyModel
 
     model = DummyModel()
     daq = SyntheticDAQ(model.configuration)
@@ -10,7 +10,7 @@ def test_synthetic_daq_functions():
     import random
 
     from navigate.model.devices.daq.daq_synthetic import SyntheticDAQ
-    from navigate.model.dummy import DummyModel
+    from test.model.dummy import DummyModel
 
     model = DummyModel()
     daq = SyntheticDAQ(model.configuration)

--- a/test/model/devices/filter_wheel/test_filter_wheel_base.py
+++ b/test/model/devices/filter_wheel/test_filter_wheel_base.py
@@ -1,6 +1,6 @@
 def test_filter_wheel_base_functions():
     from navigate.model.devices.filter_wheel.filter_wheel_base import FilterWheelBase
-    from navigate.model.dummy import DummyModel
+    from test.model.dummy import DummyModel
 
     model = DummyModel()
     microscope_name = model.configuration["experiment"]["MicroscopeState"][

--- a/test/model/devices/filter_wheel/test_filter_wheel_synthetic.py
+++ b/test/model/devices/filter_wheel/test_filter_wheel_synthetic.py
@@ -37,7 +37,7 @@ def test_synthetic_filter_wheel_functions():
     from navigate.model.devices.filter_wheel.filter_wheel_synthetic import (
         SyntheticFilterWheel,
     )
-    from navigate.model.dummy import DummyModel
+    from test.model.dummy import DummyModel
 
     model = DummyModel()
     microscope_name = model.configuration["experiment"]["MicroscopeState"][

--- a/test/model/devices/lasers/test_laser_base.py
+++ b/test/model/devices/lasers/test_laser_base.py
@@ -2,7 +2,7 @@ def test_laser_base_functions():
     import random
 
     from navigate.model.devices.lasers.laser_base import LaserBase
-    from navigate.model.dummy import DummyModel
+    from test.model.dummy import DummyModel
 
     model = DummyModel()
     microscope_name = model.configuration["experiment"]["MicroscopeState"][

--- a/test/model/devices/remote_focus/test_remote_focus_base.py
+++ b/test/model/devices/remote_focus/test_remote_focus_base.py
@@ -41,7 +41,7 @@ import numpy as np
 
 def test_remote_focus_base_init():
     from navigate.model.devices.remote_focus.remote_focus_base import RemoteFocusBase
-    from navigate.model.dummy import DummyModel
+    from test.model.dummy import DummyModel
 
     model = DummyModel()
     microscope_name = model.configuration["experiment"]["MicroscopeState"][
@@ -53,7 +53,7 @@ def test_remote_focus_base_init():
 @pytest.mark.parametrize("smoothing", [0] + list(np.random.rand(5) * 100))
 def test_remote_focus_base_adjust(smoothing):
     from navigate.model.devices.remote_focus.remote_focus_base import RemoteFocusBase
-    from navigate.model.dummy import DummyModel
+    from test.model.dummy import DummyModel
 
     model = DummyModel()
     microscope_name = model.configuration["experiment"]["MicroscopeState"][

--- a/test/model/devices/remote_focus/test_remote_focus_ni.py
+++ b/test/model/devices/remote_focus/test_remote_focus_ni.py
@@ -3,11 +3,9 @@ import pytest
 
 @pytest.mark.hardware
 def test_remote_focus_ni_functions():
-    import random
-
     from navigate.model.devices.daq.daq_ni import NIDAQ
     from navigate.model.devices.remote_focus.remote_focus_ni import RemoteFocusNI
-    from navigate.model.dummy import DummyModel
+    from test.model.dummy import DummyModel
 
     model = DummyModel()
     daq = NIDAQ(model.configuration)

--- a/test/model/devices/remote_focus/test_remote_focus_synthetic.py
+++ b/test/model/devices/remote_focus/test_remote_focus_synthetic.py
@@ -2,7 +2,7 @@ def test_remote_focus_synthetic_functions():
     from navigate.model.devices.remote_focus.remote_focus_synthetic import (
         SyntheticRemoteFocus,
     )
-    from navigate.model.dummy import DummyModel
+    from test.model.dummy import DummyModel
 
     model = DummyModel()
     microscope_name = model.configuration["experiment"]["MicroscopeState"][

--- a/test/model/devices/shutter/test_laser_shutter_base.py
+++ b/test/model/devices/shutter/test_laser_shutter_base.py
@@ -31,7 +31,7 @@
 #
 import unittest
 from navigate.model.devices.shutter.laser_shutter_base import ShutterBase
-from navigate.model.dummy import DummyModel
+from test.model.dummy import DummyModel
 
 
 class TestLaserBase(unittest.TestCase):

--- a/test/model/devices/shutter/test_laser_shutter_synthetic.py
+++ b/test/model/devices/shutter/test_laser_shutter_synthetic.py
@@ -37,7 +37,7 @@ import unittest
 
 # Local Imports
 from navigate.model.devices.shutter.laser_shutter_synthetic import SyntheticShutter
-from navigate.model.dummy import DummyModel
+from test.model.dummy import DummyModel
 
 
 class TestSyntheticShutter(unittest.TestCase):

--- a/test/model/devices/stages/test_stage_base.py
+++ b/test/model/devices/stages/test_stage_base.py
@@ -38,7 +38,6 @@ import random
 
 # Local Imports
 from navigate.model.devices.stages.stage_base import StageBase
-from navigate.model.dummy import DummyModel
 
 
 class TestStageBase:

--- a/test/model/devices/stages/test_stage_galvo.py
+++ b/test/model/devices/stages/test_stage_galvo.py
@@ -38,7 +38,7 @@ import random
 
 # Local Imports
 from navigate.model.devices.stages.stage_galvo import GalvoNIStage
-from navigate.model.dummy import DummyModel
+from test.model.dummy import DummyModel
 from navigate.tools.common_functions import copy_proxy_object
 
 

--- a/test/model/devices/test_synthetic_hardware.py
+++ b/test/model/devices/test_synthetic_hardware.py
@@ -36,7 +36,7 @@ import unittest
 # Third Party Imports
 
 # Local Imports
-from navigate.model.dummy import DummyModel
+from test.model.dummy import DummyModel
 
 
 class TestSyntheticHardware(unittest.TestCase):

--- a/test/model/devices/zoom/test_zoom_synthetic.py
+++ b/test/model/devices/zoom/test_zoom_synthetic.py
@@ -37,7 +37,7 @@ import unittest
 
 # Local Imports
 from navigate.model.devices.zoom.zoom_synthetic import SyntheticZoom
-from navigate.model.dummy import DummyModel
+from test.model.dummy import DummyModel
 
 
 class TestZoomSynthetic(unittest.TestCase):

--- a/test/model/dummy.py
+++ b/test/model/dummy.py
@@ -162,8 +162,11 @@ class DummyModel:
     def __init__(self):
         """Initialize the Dummy model."""
         # Set up the model, experiment, waveform dictionaries
-        base_directory = Path(__file__).resolve().parent.parent
-        configuration_directory = Path.joinpath(base_directory, "config")
+        base_directory = Path(__file__).resolve().parent.parent.parent
+        configuration_directory = Path.joinpath(base_directory,
+                                                "src",
+                                                "navigate",
+                                                "config")
 
         config = Path.joinpath(configuration_directory, "configuration.yaml")
         experiment = Path.joinpath(configuration_directory, "experiment.yml")

--- a/test/model/features/test_aslm_feature_container.py
+++ b/test/model/features/test_aslm_feature_container.py
@@ -41,7 +41,7 @@ from navigate.model.features.feature_container import (
 )
 from navigate.model.features.common_features import WaitToContinue, LoopByCount
 from navigate.model.features.feature_container import dummy_True
-from navigate.model.dummy import DummyModel
+from test.model.dummy import DummyModel
 
 
 class DummyFeature:

--- a/test/model/features/test_autofocus.py
+++ b/test/model/features/test_autofocus.py
@@ -38,7 +38,7 @@ import numpy as np
 # Local imports
 from navigate.model.features.autofocus import power_tent
 from navigate.model.features.autofocus import Autofocus
-from navigate.model.dummy import DummyModel
+from test.model.dummy import DummyModel
 
 
 class TestPowerTentFunction(unittest.TestCase):

--- a/test/view/popups/test_remotefocuspopup.py
+++ b/test/view/popups/test_remotefocuspopup.py
@@ -40,7 +40,7 @@ import time
 from navigate.view.popups.waveform_parameter_popup_window import (
     WaveformParameterPopupWindow,
 )
-from navigate.model.dummy import DummyModel
+from test.model.dummy import DummyModel
 from navigate.controller.configuration_controller import ConfigurationController
 
 


### PR DESCRIPTION
The Dummy variant of the model has always been improperly located in the /src directory, rather than the /tests directory. This refactor corrects that.