### PR TITLE
fix bug: 784 loading multipositions throws KeyError

### DIFF
--- a/src/navigate/controller/sub_controllers/multi_position_controller.py
+++ b/src/navigate/controller/sub_controllers/multi_position_controller.py
@@ -217,7 +217,10 @@ class MultiPositionController(GUIController):
             return
         model = TableModel(dataframe=df)
         self.table.updateModel(model)
-        self.table.redraw()
+        try:
+            self.table.redraw()
+        except KeyError:
+            pass
         self.show_verbose_info("loaded csv file", filename)
 
     def export_positions(self):

--- a/src/navigate/controller/sub_controllers/multi_position_controller.py
+++ b/src/navigate/controller/sub_controllers/multi_position_controller.py
@@ -31,7 +31,7 @@
 
 
 # Standard Library Imports
-from tkinter import filedialog
+from tkinter import filedialog, messagebox
 import math
 import logging
 
@@ -211,8 +211,10 @@ class MultiPositionController(GUIController):
         df.columns = map(lambda v: v.upper(), df.columns)
         cmp_header = df.columns == ["X", "Y", "Z", "R", "F"]
         if not cmp_header.all():
-            #  TODO: show error message
-            print("The csv file isn't right, it should contain [X, Y, Z, R, F]")
+            messagebox.showwarning(
+                title="Warning",
+                message="The csv file isn't right, it should contain [X, Y, Z, R, F]"
+            )
             logger.info("The csv file isn't right, it should contain [X, Y, Z, R, F]")
             return
         model = TableModel(dataframe=df)


### PR DESCRIPTION
I attempted to load the CSV file on my computer, and there were no errors. I recalled that the software successfully loaded the CSV file, and the multi-position table was updated correctly the last time we tried it on the working computer, despite encountering this error message. Therefore, we can ignore this error for now. Additionally, I tested loading a CSV file with random axes heads or no axes heads, and Navigate displayed a warning message to inform the users.