### PR TITLE
818 fatal not a git repository or any of the parent directories git

### DIFF
--- a/src/navigate/_commit.py
+++ b/src/navigate/_commit.py
@@ -100,5 +100,3 @@ def get_version_from_file(file_name='VERSION'):
 __commit__ = get_git_revision_hash()
 if __commit__ is None:
     __commit__ = get_version_from_file()
-
-print(f"Commit: {__commit__}")


### PR DESCRIPTION
I tried to address the unnecessary error, as well as the comment to have the `__version__` be dynamic. 

It prioritizes the git hash, if we are in a git repository, since this is more specific. 

If we are not in a git repository (e.g., downloaded form PyPI), then it pulls the version number from the VERSION file.

Wanted to make sure this aligned with your vision of it being dynamic. 