### PR TITLE
Add OME-Zarr Data Source

### DIFF
--- a/src/navigate/model/data_sources/__init__.py
+++ b/src/navigate/model/data_sources/__init__.py
@@ -1,6 +1,6 @@
 """ File type specific data sources. """
 
-FILE_TYPES = ["TIFF", "OME-TIFF", "H5", "N5"]
+FILE_TYPES = ["TIFF", "OME-TIFF", "H5", "N5", "OME-Zarr"]
 
 
 def get_data_source(file_type):
@@ -31,6 +31,11 @@ def get_data_source(file_type):
         from .bdv_data_source import BigDataViewerDataSource
 
         return BigDataViewerDataSource
+
+    elif file_type == "OME-Zarr":
+        from .zarr_data_source import OMEZarrDataSource
+
+        return OMEZarrDataSource
 
     else:
         raise NotImplementedError(f"Unknown file type {file_type}. Cannot open.")

--- a/src/navigate/model/data_sources/bdv_data_source.py
+++ b/src/navigate/model/data_sources/bdv_data_source.py
@@ -121,8 +121,6 @@ class BigDataViewerDataSource(PyramidalDataSource):
         configuration : DictProxy
             The configuration experiment.
         """
-        self._subdivisions = None
-        self._shapes = None
 
         # Set rotation and affine transform information in metadata.
         self.metadata.get_affine_parameters(configuration=configuration)

--- a/src/navigate/model/data_sources/bdv_data_source.py
+++ b/src/navigate/model/data_sources/bdv_data_source.py
@@ -63,8 +63,6 @@ class BigDataViewerDataSource(PyramidalDataSource):
         """
         #: np.array: The image.
         self.image = None
-        #: str : Image dtype
-        self.dtype = "int16"
         #: list: The views.
         self._views = []
         #: zarr.N5Store: The N5 store.
@@ -160,7 +158,7 @@ class BigDataViewerDataSource(PyramidalDataSource):
                 # print(z, dz, dataset_name, self.image[dataset_name].shape,
                 #       data[::dx, ::dy].shape)
                 zs = min(z // dz, self.shapes[i, 0] - 1)  # TODO: Is this necessary?
-                self.image[dataset_name][zs, ...] = data[::dy, ::dx].astype(np.int16)
+                self.image[dataset_name][zs, ...] = data[::dy, ::dx].astype(np.uint16)
                 if is_kw and (i == 0):
                     self._views.append(kw)
         self._current_frame += 1
@@ -255,6 +253,7 @@ class BigDataViewerDataSource(PyramidalDataSource):
                 data=self.subdivisions,
                 dtype="int32",
             )
+            self.image[setup_group_name].attrs["dataType"] = "uint16"
 
         # Create the datasets to populate
         for t in range(self.shape_t):
@@ -272,7 +271,7 @@ class BigDataViewerDataSource(PyramidalDataSource):
                         dataset_name,
                         chunks=tuple(self.subdivisions[j, ...][::-1]),
                         shape=self.shapes[j, ...],
-                        dtype="int16",
+                        dtype="uint16",
                     )
 
     def _setup_n5(self, *args, create_flag=True):
@@ -300,7 +299,7 @@ class BigDataViewerDataSource(PyramidalDataSource):
             setup_group_name = f"setup{i}"
             setup = self.image.create_group(setup_group_name)
             setup.attrs["downsamplingFactors"] = self.resolutions.tolist()
-            setup.attrs["dataType"] = "int16"
+            setup.attrs["dataType"] = "uint16"
             for t in range(self.shape_t):
                 time_group_name = f"timepoint{t}"
                 timepoint = setup.create_group(time_group_name)
@@ -311,7 +310,7 @@ class BigDataViewerDataSource(PyramidalDataSource):
                     sx = timepoint.zeros(
                         s_group_name, shape=tuple(shape), chunks=(shape[0], shape[1], 1)
                     )
-                    sx.attrs["dataType"] = "int16"
+                    sx.attrs["dataType"] = "uint16"
                     sx.attrs["blockSize"] = [shape[0], shape[1], 1]
                     sx.attrs["dimensions"] = list(shape)
         # print(self.image.tree())

--- a/src/navigate/model/data_sources/bdv_data_source.py
+++ b/src/navigate/model/data_sources/bdv_data_source.py
@@ -138,8 +138,6 @@ class BigDataViewerDataSource(PyramidalDataSource):
         """
         self.mode = "w"
 
-        is_kw = len(kw) > 0
-
         c, z, t, p = self._cztp_indices(
             self._current_frame, self.metadata.per_stack
         )  # find current channel
@@ -148,6 +146,7 @@ class BigDataViewerDataSource(PyramidalDataSource):
             self.setup()
 
         ds_name = self.ds_name(t, c, p)
+        is_kw = len(kw) > 0
         for i in range(self.subdivisions.shape[0]):
             dx, dy, dz = self.resolutions[i, ...]
             if z % dz == 0:

--- a/src/navigate/model/data_sources/bdv_data_source.py
+++ b/src/navigate/model/data_sources/bdv_data_source.py
@@ -226,6 +226,13 @@ class BigDataViewerDataSource(PyramidalDataSource):
         """Set up the HDF5 file.
 
         This function creates the file and the datasets to populate.
+
+        Parameters
+        ----------
+        args : tuple
+            The setup start and end.
+        create_flag : bool
+            Flag to create the file.
         """
         if create_flag:
             self.image = h5py.File(self.file_name, "a")
@@ -278,6 +285,13 @@ class BigDataViewerDataSource(PyramidalDataSource):
         This function creates the file and the datasets to populate. By default,
         it implements blosc compression. Consequently, the anticipated file
         size, and the actual file size, do not match. This is not the case for HDF5.
+
+        Parameters
+        ----------
+        args : tuple
+            The setup start and end.
+        create_flag : bool
+            Flag to create the file.
 
         Note
         ----

--- a/src/navigate/model/data_sources/data_source.py
+++ b/src/navigate/model/data_sources/data_source.py
@@ -102,6 +102,9 @@ class DataSource:
         #: int: Number of positions in the data source.
         self.positions = 1
 
+        # Set the mode using the getters/setters below
+        self.mode = mode
+
         #: int: Current frame number.
         self._current_frame = 0
 

--- a/src/navigate/model/data_sources/data_source.py
+++ b/src/navigate/model/data_sources/data_source.py
@@ -74,7 +74,8 @@ class DataSource:
         self._closed = True
         #: int: Number of bits per pixel.
         self.bits = 16
-        self.dtype = "uint16"
+        if not hasattr(self, "dtype"):
+            self.dtype = "uint16"
 
         #: float: Pixel size in x dimension (microns).
         #: float: Pixel size in y dimension (microns).

--- a/src/navigate/model/data_sources/data_source.py
+++ b/src/navigate/model/data_sources/data_source.py
@@ -74,6 +74,7 @@ class DataSource:
         self._closed = True
         #: int: Number of bits per pixel.
         self.bits = 16
+        self.dtype = "uint16"
 
         #: float: Pixel size in x dimension (microns).
         #: float: Pixel size in y dimension (microns).
@@ -198,6 +199,10 @@ class DataSource:
         """
         return (self.shape_x, self.shape_y, self.shape_c, self.shape_z, self.shape_t)
 
+    def setup(self):
+        """Additional steps for establishing the initial file setup."""
+        pass
+
     def set_metadata_from_configuration_experiment(
         self, configuration: DictProxy
     ) -> None:
@@ -214,7 +219,7 @@ class DataSource:
 
     def set_metadata(self, metadata_config: dict) -> None:
         """Sets the metadata
-        
+
         Parameters
         ----------
         metadata_config : dict
@@ -327,11 +332,19 @@ class DataSource:
         # )
 
     def _mode_checks(self) -> None:
-        """Run additional checks after setting the mode."""
-        pass
+        """Checks that the mode is valid."""
+        self._write_mode = self._mode == "w"
+        self.close()  # if anything was already open, close it
+        if self._write_mode:
+            self._current_frame = 0
+            self._views = []
+            self.setup()
+        else:
+            self.read()
+        self._closed = False
 
     def write(self, data: npt.ArrayLike, **kw) -> None:
-        """Write data to file.
+        """Writes 2D image to the data source.
 
         Parameters
         ----------

--- a/src/navigate/model/data_sources/data_source.py
+++ b/src/navigate/model/data_sources/data_source.py
@@ -102,9 +102,6 @@ class DataSource:
         #: int: Number of positions in the data source.
         self.positions = 1
 
-        #: str: Mode to open the file in. Can be 'r' or 'w'.
-        self.mode = mode
-
         #: int: Current frame number.
         self._current_frame = 0
 

--- a/src/navigate/model/data_sources/pyramidal_data_source.py
+++ b/src/navigate/model/data_sources/pyramidal_data_source.py
@@ -1,0 +1,247 @@
+# Copyright (c) 2021-2024  The University of Texas Southwestern Medical Center.
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted for academic and research use only
+# (subject to the limitations in the disclaimer below)
+# provided that the following conditions are met:
+
+#      * Redistributions of source code must retain the above copyright notice,
+#      this list of conditions and the following disclaimer.
+
+#      * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+
+#      * Neither the name of the copyright holders nor the names of its
+#      contributors may be used to endorse or promote products derived from this
+#      software without specific prior written permission.
+
+# NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE GRANTED BY
+# THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+# CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+# PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+# BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+# IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import numpy as np
+import numpy.typing as npt
+
+from .data_source import DataSource
+from ...tools.slicing import ensure_slice, ensure_iter, slice_len
+
+
+class PyramidalDataSource(DataSource):
+    """General class for data sources that store data in a pyramidal structure.
+
+    Implements resolution/subdivision calculations and __getitem__ with
+    indexing by subivision.
+    """
+
+    def __init__(self, file_name: str = None, mode: str = "w") -> None:
+        """Initializes the PyramidalDataSource.
+
+        Parameters
+        ----------
+        file_name : str
+            The name of the file to write to.
+        mode : str
+            The mode to open the file in. Must be "w" for write or "r" for read.
+        """
+        #: np.array: The resolution of each down-sampled pyramid level.
+        self._resolutions = np.array(
+            [[1, 1, 1], [2, 2, 1], [4, 4, 1], [8, 8, 1]], dtype=int
+        )
+        #: np.array: The number of subdivisions in each dimension.
+        self._subdivisions = None
+        #: np.array: The shape of the image.
+        self._shapes = None
+
+        super().__init__(file_name, mode)
+
+    @property
+    def resolutions(self) -> npt.ArrayLike:
+        """Getter for resolutions.
+
+        Store as XYZ per BDV spec.
+
+        Returns
+        -------
+        resolutions : npt.ArrayLike
+            The resolutions.
+        """
+        return self._resolutions
+
+    @property
+    def subdivisions(self) -> npt.ArrayLike:
+        """Getter for subdivisions.
+
+        Store as XYZ per BDV spec.
+
+        Returns
+        -------
+        subdivisions : npt.ArrayLike
+            The subdivisions.
+        """
+        if self._subdivisions is None:
+            self._subdivisions = np.zeros((4, 3), dtype=int)
+            self._subdivisions[:, 0] = np.gcd(32, self.shapes[:, 0])
+            self._subdivisions[:, 1] = np.gcd(32, self.shapes[:, 1])
+            self._subdivisions[:, 2] = np.gcd(32, self.shapes[:, 2])
+
+            # Safety
+            self._subdivisions = np.maximum(self._subdivisions, 1)
+
+            # Reverse to XYZ
+            self._subdivisions = self._subdivisions[:, ::-1]
+        return self._subdivisions
+
+    @property
+    def shapes(self) -> npt.ArrayLike:
+        """Getter for image shape.
+
+        Store as ZYX rather than XYZ, per BDV spec.
+
+        Returns
+        -------
+        shapes : npt.ArrayLike
+            The shapes.
+        """
+        if self._shapes is None:
+            self._shapes = np.maximum(
+                np.ceil(
+                    np.array([self.shape_z, self.shape_y, self.shape_x])[None, :]
+                    / self.resolutions[:, ::-1]
+                ).astype(int),
+                1,
+            )
+        return self._shapes
+
+    @property
+    def nbytes(self) -> int:
+        """Getter for image size.
+
+        Size in bytes. Overrides base class. Accounts for subdivisions.
+
+        Returns
+        -------
+        size : int
+            The size of the image in bytes.
+        """
+        return (
+            np.prod(self.shapes, axis=1)
+            * self.shape_t
+            * self.shape_c
+            * self.positions
+            * self.bits
+            // 8
+        ).sum()
+
+    def __getitem__(self, keys):
+        """Magic method to get slice requests passed by, e.g., ds[:,2:3,...].
+        Allows arbitrary slicing of dataset via calls to get_slice().
+
+        Order is xycztps where x, y, z are array indices, c is channel,
+        t is timepoints, p is positions and s is subdivisions to index along.
+
+        TODO: Add subdivisions.
+
+        Parameters
+        ----------
+        keys : tuple
+            Tuple of indices.
+
+        Returns
+        -------
+        npt.ArrayLike
+            Array of shape (p, t, z, c, y, x)
+        """
+
+        # Check lengths
+        if isinstance(keys, slice) or isinstance(keys, int):
+            length = 1
+        else:
+            length = len(keys)
+
+        if length < 1:
+            raise IndexError(
+                "Too few indices. Indices may be (x, y, c, z, t, p, subdiv)."
+            )
+        elif length > 7:
+            raise IndexError(
+                "Too many indices. Indices may be (x, y, c, z, t, p, subdiv)."
+            )
+
+        # Get indices as slices/ranges
+        xs = ensure_slice(keys, 0)
+        ys = ensure_slice(keys, 1)
+        cs = ensure_iter(keys, 2, self.shape[2])
+        zs = ensure_slice(keys, 3)
+        ts = ensure_iter(keys, 4, self.shape[4])
+        ps = ensure_iter(keys, 5, self.positions)
+
+        if length > 1 and keys[-1] == Ellipsis:
+            keys = keys[:-1]
+            length -= 1
+
+        if length > 6 and isinstance(keys[6], int):
+            subdiv = keys[6]
+        else:
+            subdiv = 0
+
+        if len(cs) == 1 and len(ts) == 1 and len(ps) == 1:
+            return self.get_slice(xs, ys, cs[0], zs, ts[0], ps[0], subdiv)
+
+        sliced_ds = np.empty(
+            (
+                len(ps),
+                len(ts),
+                slice_len(zs, self.shape_z) // self.resolutions[subdiv][2],
+                len(cs),
+                slice_len(ys, self.shape_y) // self.resolutions[subdiv][1],
+                slice_len(xs, self.shape_x) // self.resolutions[subdiv][0],
+            ),
+            dtype=self.dtype,
+        )
+
+        for c in cs:
+            for t in ts:
+                for p in ps:
+                    sliced_ds[p, t, :, c, :, :] = self.get_slice(
+                        xs, ys, c, zs, t, p, subdiv
+                    )
+
+        return sliced_ds
+
+    def get_slice(self, x, y, c, z=0, t=0, p=0, subdiv=0) -> npt.ArrayLike:
+        """Get a 3D slice of the dataset for a single c, t, p, subdiv.
+
+        Parameters
+        ----------
+        x : int or slice
+            x indices to grab
+        y : int or slice
+            y indices to grab
+        c : int
+            Single channel
+        z : int or slice
+            z indices to grab
+        t : int
+            Single timepoint
+        p : int
+            Single position
+        subdiv : int
+            Subdivision of the dataset to index along
+
+        Returns
+        -------
+        npt.ArrayLike
+            3D (z, y, x) slice of data set
+        """
+        raise NotImplementedError("Implemented in a derived class.")

--- a/src/navigate/model/data_sources/pyramidal_data_source.py
+++ b/src/navigate/model/data_sources/pyramidal_data_source.py
@@ -30,11 +30,14 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+# Standard library imports
 from multiprocessing.managers import DictProxy
 
+# Third-party imports
 import numpy as np
 import numpy.typing as npt
 
+# Local application imports
 from .data_source import DataSource
 from ...tools.slicing import ensure_slice, ensure_iter, slice_len
 
@@ -43,7 +46,7 @@ class PyramidalDataSource(DataSource):
     """General class for data sources that store data in a pyramidal structure.
 
     Implements resolution/subdivision calculations and __getitem__ with
-    indexing by subivision.
+    indexing by subdivision.
     """
 
     def __init__(self, file_name: str = None, mode: str = "w") -> None:
@@ -260,5 +263,10 @@ class PyramidalDataSource(DataSource):
         -------
         npt.ArrayLike
             3D (z, y, x) slice of data set
+
+        Raises
+        ------
+        NotImplementedError
+            If the method is not implemented in a derived class.
         """
         raise NotImplementedError("Implemented in a derived class.")

--- a/src/navigate/model/data_sources/pyramidal_data_source.py
+++ b/src/navigate/model/data_sources/pyramidal_data_source.py
@@ -30,6 +30,8 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+from multiprocessing.managers import DictProxy
+
 import numpy as np
 import numpy.typing as npt
 
@@ -142,6 +144,21 @@ class PyramidalDataSource(DataSource):
             * self.bits
             // 8
         ).sum()
+
+    def set_metadata_from_configuration_experiment(
+        self, configuration: DictProxy
+    ) -> None:
+        """Sets the metadata from according to the microscope configuration.
+
+        Parameters
+        ----------
+        configuration : DictProxy
+            The configuration experiment.
+        """
+        self._subdivisions = None
+        self._shapes = None
+
+        return super().set_metadata_from_configuration_experiment(configuration)
 
     def __getitem__(self, keys):
         """Magic method to get slice requests passed by, e.g., ds[:,2:3,...].

--- a/src/navigate/model/data_sources/tiff_data_source.py
+++ b/src/navigate/model/data_sources/tiff_data_source.py
@@ -154,7 +154,7 @@ class TiffDataSource(DataSource):
             setattr(self, f"shape_{ax.lower()}", self.data.shape[i])
 
     def write(self, data: npt.ArrayLike, **kw) -> None:
-        """Write data to a tiff file.
+        """Writes 2D image to the data source.
 
         One channel, all z-position, one timepoint = one stack.
         N channels are opened simultaneously for writing.
@@ -267,18 +267,6 @@ class TiffDataSource(DataSource):
             )
             self.file_name.append(file_name)
             self.uid.append(str(uuid.uuid4()))
-
-    def _mode_checks(self) -> None:
-        """Check that the mode is valid."""
-        self._write_mode = self._mode == "w"
-        self.close()  # if anything was already open, close it
-        if self._write_mode:
-            self._current_frame = 0
-            self._views = []
-            # self._setup_write_image()
-        else:
-            self.read()
-        self._closed = False
 
     def close(self, internal=False) -> None:
         """Close the file.

--- a/src/navigate/model/data_sources/zarr_data_source.py
+++ b/src/navigate/model/data_sources/zarr_data_source.py
@@ -1,0 +1,162 @@
+# Copyright (c) 2021-2024  The University of Texas Southwestern Medical Center.
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted for academic and research use only
+# (subject to the limitations in the disclaimer below)
+# provided that the following conditions are met:
+
+#      * Redistributions of source code must retain the above copyright notice,
+#      this list of conditions and the following disclaimer.
+
+#      * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+
+#      * Neither the name of the copyright holders nor the names of its
+#      contributors may be used to endorse or promote products derived from this
+#      software without specific prior written permission.
+
+# NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE GRANTED BY
+# THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+# CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+# PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+# BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+# IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import zarr
+import numpy.typing as npt
+import zarr.storage
+
+from .pyramidal_data_source import PyramidalDataSource
+from ..metadata_sources.zarr_metadata import OMEZarrMetadata
+
+GROUP_PREFIX = "p"
+
+
+class OMEZarrDataSource(PyramidalDataSource):
+    """OME-Zarr data source.
+
+    This class implements an OME-Zarr image data source using the Zarr v2 format.
+    """
+
+    def __init__(self, file_name: str = None, mode: str = "w") -> None:
+
+        self.metadata = OMEZarrMetadata()
+        self.__store = None
+        self._current_position = -1
+
+        super().__init__(file_name, mode)
+
+    def get_slice(self, x, y, c, z=0, t=0, p=0, subdiv=0) -> npt.ArrayLike:
+        """Get a 3D slice of the dataset for a single c, t, p, subdiv.
+
+        Parameters
+        ----------
+        x : int or slice
+            x indices to grab
+        y : int or slice
+            y indices to grab
+        c : int
+            Single channel
+        z : int or slice
+            z indices to grab
+        t : int
+            Single timepoint
+        p : int
+            Single position
+        subdiv : int
+            Subdivision of the dataset to index along
+
+        Returns
+        -------
+        npt.ArrayLike
+            3D (z, y, x) slice of data set
+        """
+        dataset_name = f"{GROUP_PREFIX}{p}_{subdiv}"
+        return self.image[dataset_name][t, c, z, y, x]
+
+    def setup(self):
+        """Set up the Zarr writer."""
+        # Use FSStore as a universal backend
+        self.__store = zarr.storage.FSStore(self.file_name, mode=self.mode)
+        self.image = zarr.group(store=self.__store, overwrite=True)
+        self._current_position = -1
+
+    def new_position(self, pos, view):
+        """Create new arrays on the fly for each position in self.positions."""
+        name = f"{GROUP_PREFIX}{pos}"
+        paths = []
+        # Create the subdivisions...
+        for si, zyx_shape in enumerate(self.shapes):
+            shape = tuple([self.shape_t, self.shape_c] + list(zyx_shape))
+            setup = f"{name}_{si}"
+            arr = self.image.create(
+                name=setup,
+                shape=shape,
+                chunks=(1,) * len(shape[:-2]) + shape[-2:],
+                dtype=self.dtype,
+            )
+            # xarray multidim
+            paths.append(arr.path)
+            arr.attrs["_ARRAY_DIMENSIONS"] = shape
+
+        # Append setup to multiscales
+        scales = self.image.attrs.get("multiscales", [])
+        scales.append(
+            self.metadata.multiscales_dict(name, paths, self.resolutions, view)
+        )
+        self.image.attrs["multiscales"] = scales
+
+    def write(self, data: npt.ArrayLike, **kw) -> None:
+        """Writes 2D image to the data source."""
+        self.mode = "w"
+
+        if self.__store is None:
+            self.setup()
+
+        c, z, t, p = self._cztp_indices(
+            self._current_frame, self.metadata.per_stack
+        )  # find current channel
+
+        if self._current_position != p:
+            self._current_position = p
+            if len(kw) > 0:
+                self.new_position(p, kw)
+            else:
+                self.new_position(p)
+
+        for ri, res in enumerate(self.resolutions):
+            dx, dy, dz = res
+            dataset_name = f"{GROUP_PREFIX}{p}_{ri}"
+            zs = min(z // dz, self.shapes[ri, 0] - 1)
+            self.image[dataset_name][t, c, zs, ...] = data[::dy, ::dx].astype(
+                self.dtype
+            )
+
+        self._current_frame += 1
+
+    def read(self) -> None:
+        """Reads data from the image file."""
+        self.mode = "r"
+        self.__store = zarr.storage.FSStore(self.file_name, mode=self.mode)
+        self.image = zarr.group(store=self.__store)
+        # TODO: parse the image metadata
+        self.get_shape_from_metadata()
+
+    def close(self) -> None:
+        """Close the image file."""
+        if self._closed:
+            if self.__store is not None:
+                self.__store = None
+            return
+        self._check_shape(self._current_frame - 1, self.metadata.per_stack)
+        self.__store.close()
+        self._closed = True
+        self.__store = None

--- a/src/navigate/model/data_sources/zarr_data_source.py
+++ b/src/navigate/model/data_sources/zarr_data_source.py
@@ -30,10 +30,14 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+# Standard library imports
+
+# Third-party imports
 import zarr
 import numpy.typing as npt
 import zarr.storage
 
+# Local application imports
 from .pyramidal_data_source import PyramidalDataSource
 from ..metadata_sources.zarr_metadata import OMEZarrMetadata
 
@@ -48,6 +52,7 @@ class OMEZarrDataSource(PyramidalDataSource):
 
     def __init__(self, file_name: str = None, mode: str = "w") -> None:
 
+        #: OMEZarrMetadata: Metadata object for the OME-Zarr data source.
         self.metadata = OMEZarrMetadata()
         self.__store = None
         self._current_position = -1
@@ -86,11 +91,21 @@ class OMEZarrDataSource(PyramidalDataSource):
         """Set up the Zarr writer."""
         # Use FSStore as a universal backend
         self.__store = zarr.storage.FSStore(self.file_name, mode=self.mode)
+
+        #: zarr.group: Zarr group object for the image data source.
         self.image = zarr.group(store=self.__store, overwrite=True)
         self._current_position = -1
 
     def new_position(self, pos, view):
-        """Create new arrays on the fly for each position in self.positions."""
+        """Create new arrays on the fly for each position in self.positions.
+
+        Parameters
+        ----------
+        pos : int
+            Position index
+        view : str
+            View name
+        """
         name = f"{GROUP_PREFIX}{pos}"
         paths = []
         # Create the subdivisions...
@@ -115,7 +130,16 @@ class OMEZarrDataSource(PyramidalDataSource):
         self.image.attrs["multiscales"] = scales
 
     def write(self, data: npt.ArrayLike, **kw) -> None:
-        """Writes 2D image to the data source."""
+        """Writes 2D image to the data source.
+
+        Parameters
+        ----------
+        data : npt.ArrayLike
+            2D image data
+        kw : dict
+            Keyword arguments
+        """
+        #: str: Mode of the data source.
         self.mode = "w"
 
         if self.__store is None:

--- a/src/navigate/model/metadata_sources/bdv_metadata.py
+++ b/src/navigate/model/metadata_sources/bdv_metadata.py
@@ -143,23 +143,23 @@ class BigDataViewerMetadata(XMLMetadata):
                 "text": file_name,
             }
 
-        elif ext == "tiff" or ext == "tif":
-            """
-            Need to iterate through the time points, etc.
-            <ImageLoader format="spimreconstruction.filelist">
-                <imglib2container>ArrayImgFactory</imglib2container>
-                <ZGrouped>false</ZGrouped>
-                <files>
-                    <FileMapping view_setup="0" timepoint="0" series="0" channel="0">
-                        <file type="relative">1_CH00_000000.tif</file>
-                    </FileMapping>
-                    <FileMapping view_setup="1" timepoint="0" series="0" channel="0">
-                        <file type="relative">1_CH01_000000.tif</file>
-                    </FileMapping>
-                </files>
-            </ImageLoader>
-            """
-            pass
+        # elif ext == "tiff" or ext == "tif":
+        #     """
+        #     Need to iterate through the time points, etc.
+        #     <ImageLoader format="spimreconstruction.filelist">
+        #         <imglib2container>ArrayImgFactory</imglib2container>
+        #         <ZGrouped>false</ZGrouped>
+        #         <files>
+        #             <FileMapping view_setup="0" timepoint="0" series="0" channel="0">
+        #                 <file type="relative">1_CH00_000000.tif</file>
+        #             </FileMapping>
+        #             <FileMapping view_setup="1" timepoint="0" series="0" channel="0">
+        #                 <file type="relative">1_CH01_000000.tif</file>
+        #             </FileMapping>
+        #         </files>
+        #     </ImageLoader>
+        #     """
+        #     pass
 
         elif ext == "n5":
             """

--- a/src/navigate/model/metadata_sources/bdv_metadata.py
+++ b/src/navigate/model/metadata_sources/bdv_metadata.py
@@ -143,6 +143,7 @@ class BigDataViewerMetadata(XMLMetadata):
                 "text": file_name,
             }
 
+        # TODO: Consider adding support for tiff/tif files. Needs evaluation.
         # elif ext == "tiff" or ext == "tif":
         #     """
         #     Need to iterate through the time points, etc.
@@ -321,6 +322,8 @@ class BigDataViewerMetadata(XMLMetadata):
             The z position of the stage.
         theta : float
             The theta position of the stage.
+        f : Optional[float], optional
+            The focus position of the stage, by default None
 
         Returns
         -------

--- a/src/navigate/model/metadata_sources/zarr_metadata.py
+++ b/src/navigate/model/metadata_sources/zarr_metadata.py
@@ -30,9 +30,13 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+# Standard library imports
 from typing import Optional, Union, List, Dict
+
+# Third-party imports
 import numpy.typing as npt
 
+# Local application imports
 from .metadata import Metadata
 
 NGFF_VERSION = "0.4"
@@ -44,6 +48,11 @@ class OMEZarrMetadata(Metadata):
         """Return tczyx axes in navigate units.
 
         https://ngff.openmicroscopy.org/0.4/#axes-md
+
+        Returns
+        -------
+        List
+            A list of dictionaries containing the axis name, type, and unit.
         """
         axes = [
             {"name": "t", "type": "time", "unit": "second"},
@@ -107,7 +116,18 @@ class OMEZarrMetadata(Metadata):
     def _scale_transform(
         self, subdiv: Union[npt.ArrayLike, List] = [1, 1, 1]
     ) -> List[float]:
-        """Calculate the image scale after subdivision."""
+        """Calculate the image scale after subdivision.
+
+        Parameters
+        ----------
+        subdiv : List
+            The subdivision of the dataset.
+
+        Returns
+        -------
+        List
+            The scale of the dataset.
+        """
         return [
             self.dt,
             self.dc,
@@ -119,7 +139,20 @@ class OMEZarrMetadata(Metadata):
     def _coordinate_transformations(
         self, scale: Optional[List] = None, translation: Optional[List] = None
     ) -> Dict:
-        """Package scale and translation in a dict."""
+        """Package scale and translation in a dict.
+
+        Parameters
+        ----------
+        scale : List
+            The scale of the dataset.
+        translation : List
+            The translation of the dataset.
+
+        Returns
+        -------
+        Dict
+            A dictionary containing the transformation.
+        """
         transformation = []
         if (
             scale is None
@@ -148,7 +181,26 @@ class OMEZarrMetadata(Metadata):
         resolutions: Union[npt.ArrayLike, List],
         view: Optional[Dict] = None,
     ) -> Dict:
-        """https://ngff.openmicroscopy.org/0.4/index.html#multiscale-md"""
+        """Create a multiscale dictionary for the OME-Zarr metadata.
+
+        https://ngff.openmicroscopy.org/0.4/index.html#multiscale-md
+
+        Parameters
+        ----------
+        name : str
+            The name of the dataset.
+        paths : list
+            The paths of the dataset.
+        resolutions : List
+            The resolutions of the dataset.
+        view : Dict
+            The view of the dataset.
+
+        Returns
+        -------
+        Dict
+            A dictionary containing the multiscale metadata.
+        """
         d = {"version": NGFF_VERSION, "name": name, "axes": self._axes}
 
         datasets = []

--- a/src/navigate/model/metadata_sources/zarr_metadata.py
+++ b/src/navigate/model/metadata_sources/zarr_metadata.py
@@ -1,0 +1,171 @@
+# Copyright (c) 2021-2024  The University of Texas Southwestern Medical Center.
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted for academic and research use only
+# (subject to the limitations in the disclaimer below)
+# provided that the following conditions are met:
+
+#      * Redistributions of source code must retain the above copyright notice,
+#      this list of conditions and the following disclaimer.
+
+#      * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+
+#      * Neither the name of the copyright holders nor the names of its
+#      contributors may be used to endorse or promote products derived from this
+#      software without specific prior written permission.
+
+# NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE GRANTED BY
+# THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+# CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+# PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+# BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+# IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+from typing import Optional, Union, List, Dict
+import numpy.typing as npt
+
+from .metadata import Metadata
+
+NGFF_VERSION = "0.4"
+
+
+class OMEZarrMetadata(Metadata):
+    @property
+    def _axes(self) -> Dict:
+        """Return tczyx axes in navigate units.
+
+        https://ngff.openmicroscopy.org/0.4/#axes-md
+        """
+        axes = [
+            {"name": "t", "type": "time", "unit": "second"},
+            {"name": "c", "type": "channel"},
+            {"name": "z", "type": "space", "unit": "micrometer"},
+            {"name": "y", "type": "space", "unit": "micrometer"},
+            {"name": "x", "type": "space", "unit": "micrometer"},
+        ]
+
+        return axes
+
+    def _stage_positions_to_translation_transform(
+        self, x: float, y: float, z: float, theta: float, f: Optional[float] = None
+    ) -> List[float]:
+        """Grab the translation from the stage.
+
+        Ignore theta, focus for now.
+
+        Parameters
+        ----------
+        x : float
+            The x position of the stage (um).
+        y : float
+            The y position of the stage (um).
+        z : float
+            The z position of the stage (um).
+        theta : float
+            The theta position of the stage (deg).
+        f : float
+            The focus position of the stage (um).
+
+        Returns
+        -------
+        List
+            A translation for each axis.
+        """
+
+        # Set the transform positions
+        xp, yp, zp = x, y, z
+
+        # Allow additional axes (e.g. f) to couple onto existing axes (e.g. z)
+        # if they are both moving along the same physical dimension
+        if self._coupled_axes is not None:
+            for leader, follower in self._coupled_axes.items():
+                if leader.lower() not in "xyz":
+                    print(
+                        f"Unrecognized coupled axis {leader}. "
+                        "Not gonna do anything with this."
+                    )
+                    continue
+                elif leader.lower() == "x":
+                    xp += float(locals()[f"{follower.lower()}"])
+                elif leader.lower() == "y":
+                    yp += float(locals()[f"{follower.lower()}"])
+                elif leader.lower() == "z":
+                    zp += float(locals()[f"{follower.lower()}"])
+
+        # t, c, z, y, x
+        return [0.0, 0.0, zp, yp, xp]
+
+    def _scale_transform(
+        self, subdiv: Union[npt.ArrayLike, List] = [1, 1, 1]
+    ) -> List[float]:
+        """Calculate the image scale after subdivision."""
+        return [
+            self.dt,
+            self.dc,
+            self.dz * subdiv[2],
+            self.dy * subdiv[1],
+            self.dx * subdiv[0],
+        ]
+
+    def _coordinate_transformations(
+        self, scale: Optional[List] = None, translation: Optional[List] = None
+    ) -> Dict:
+        """Package scale and translation in a dict."""
+        transformation = []
+        if (
+            scale is None
+            or not isinstance(scale, list)
+            or len(scale) != len(self._axes)
+        ):
+            if translation is not None:
+                raise UserWarning("Translation cannot be provided without scale.")
+            return transformation
+        else:
+            transformation.append({"type": "scale", "scale": scale})
+
+        if (
+            translation is not None
+            and isinstance(translation, list)
+            and len(translation) == len(self._axes)
+        ):
+            transformation.append({"type": "translation", "translation": translation})
+
+        return transformation
+
+    def multiscales_dict(
+        self,
+        name: str,
+        paths: list,
+        resolutions: Union[npt.ArrayLike, List],
+        view: Optional[Dict] = None,
+    ) -> Dict:
+        """https://ngff.openmicroscopy.org/0.4/index.html#multiscale-md"""
+        d = {"version": NGFF_VERSION, "name": name, "axes": self._axes}
+
+        datasets = []
+        for path, res in zip(paths, resolutions):
+            scale = self._scale_transform(res)
+            dd = {
+                "path": path,
+                "coordinateTransforms": self._coordinate_transformations(scale),
+            }
+            datasets.append(dd)
+        d["datasets"] = datasets
+
+        if view is not None:
+            scale = [1.0] * len(self._axes)
+            translation = self._stage_positions_to_translation_transform(**view)
+            d["coordinateTransformations"] = self._coordinate_transformations(
+                scale, translation
+            )
+
+        return d

--- a/test/model/data_sources/test_bdv_data_source.py
+++ b/test/model/data_sources/test_bdv_data_source.py
@@ -18,9 +18,10 @@ def recurse_dtype(group):
             elif key == "subdivisions":
                 assert subgroup.dtype == "int32"
             elif key == "cells":
-                assert subgroup.dtype == "int16"
+                assert subgroup.dtype == "uint16"
         else:
             print("Unknown how to handle:", key, subgroup_type)
+
 
 def bdv_ds(fn, multiposition, per_stack, z_stack, stop_early, size):
     from test.model.dummy import DummyModel
@@ -88,8 +89,9 @@ def bdv_ds(fn, multiposition, per_stack, z_stack, stop_early, size):
             break
 
     return ds
-    
-def close_bdv_ds(ds, file_name = None): 
+
+
+def close_bdv_ds(ds, file_name=None):
     ds.close()
 
     if file_name is None:
@@ -107,6 +109,7 @@ def close_bdv_ds(ds, file_name = None):
     except PermissionError:
         # Windows seems to think these files are still open
         pass
+
 
 @pytest.mark.parametrize("multiposition", [True, False])
 @pytest.mark.parametrize("per_stack", [True, False])
@@ -134,6 +137,7 @@ def test_bdv_write(multiposition, per_stack, z_stack, stop_early, size, ext):
 
     assert True
 
+
 @pytest.mark.parametrize("multiposition", [True, False])
 @pytest.mark.parametrize("per_stack", [True, False])
 @pytest.mark.parametrize("z_stack", [True, False])
@@ -142,22 +146,105 @@ def test_bdv_getitem(multiposition, per_stack, z_stack, size):
     ds = bdv_ds("test.h5", multiposition, per_stack, z_stack, False, size)
 
     # Check indexing
-    assert ds[0,...].shape == (ds.positions, ds.shape_t, ds.shape_z, ds.shape_c, ds.shape_y, 1)
-    assert ds[:,0,...].shape == (ds.positions, ds.shape_t, ds.shape_z, ds.shape_c, 1, ds.shape_x)
-    assert ds[:,:,0,...].shape == (ds.positions, ds.shape_t, ds.shape_z, 1, ds.shape_y, ds.shape_x)
-    assert ds[:,:,:,0,...].shape == (ds.positions, ds.shape_t, 1, ds.shape_c, ds.shape_y, ds.shape_x)
-    assert ds[:,:,:,:,0,...].shape == (ds.positions, 1, ds.shape_z, ds.shape_c, ds.shape_y, ds.shape_x)
-    assert ds[:,:,:,:,:,0].shape == (1, ds.shape_t, ds.shape_z, ds.shape_c, ds.shape_y, ds.shape_x)
-
+    assert ds[0, ...].shape == (
+        ds.positions,
+        ds.shape_t,
+        ds.shape_z,
+        ds.shape_c,
+        ds.shape_y,
+        1,
+    )
+    assert ds[:, 0, ...].shape == (
+        ds.positions,
+        ds.shape_t,
+        ds.shape_z,
+        ds.shape_c,
+        1,
+        ds.shape_x,
+    )
+    assert ds[:, :, 0, ...].shape == (
+        ds.positions,
+        ds.shape_t,
+        ds.shape_z,
+        1,
+        ds.shape_y,
+        ds.shape_x,
+    )
+    assert ds[:, :, :, 0, ...].shape == (
+        ds.positions,
+        ds.shape_t,
+        1,
+        ds.shape_c,
+        ds.shape_y,
+        ds.shape_x,
+    )
+    assert ds[:, :, :, :, 0, ...].shape == (
+        ds.positions,
+        1,
+        ds.shape_z,
+        ds.shape_c,
+        ds.shape_y,
+        ds.shape_x,
+    )
+    assert ds[:, :, :, :, :, 0].shape == (
+        1,
+        ds.shape_t,
+        ds.shape_z,
+        ds.shape_c,
+        ds.shape_y,
+        ds.shape_x,
+    )
 
     # Check slicing
     sx = 5
-    assert ds[:sx,...].shape == (ds.positions, ds.shape_t, ds.shape_z, ds.shape_c, ds.shape_y, min(ds.shape_x, sx))
-    assert ds[:,:sx,...].shape == (ds.positions, ds.shape_t, ds.shape_z, ds.shape_c, min(ds.shape_y, sx), ds.shape_x)
-    assert ds[:,:,:sx,...].shape == (ds.positions, ds.shape_t, ds.shape_z, min(ds.shape_c, sx), ds.shape_y, ds.shape_x)
-    assert ds[:,:,:,:sx,...].shape == (ds.positions, ds.shape_t, min(ds.shape_z, sx), ds.shape_c, ds.shape_y, ds.shape_x)
-    assert ds[:,:,:,:,:sx,...].shape == (ds.positions, min(ds.shape_t,sx), ds.shape_z, ds.shape_c, ds.shape_y, ds.shape_x)
-    assert ds[:,:,:,:,:,:sx].shape == (min(ds.positions, sx), ds.shape_t, ds.shape_z, ds.shape_c, ds.shape_y, ds.shape_x)
+    assert ds[:sx, ...].shape == (
+        ds.positions,
+        ds.shape_t,
+        ds.shape_z,
+        ds.shape_c,
+        ds.shape_y,
+        min(ds.shape_x, sx),
+    )
+    assert ds[:, :sx, ...].shape == (
+        ds.positions,
+        ds.shape_t,
+        ds.shape_z,
+        ds.shape_c,
+        min(ds.shape_y, sx),
+        ds.shape_x,
+    )
+    assert ds[:, :, :sx, ...].shape == (
+        ds.positions,
+        ds.shape_t,
+        ds.shape_z,
+        min(ds.shape_c, sx),
+        ds.shape_y,
+        ds.shape_x,
+    )
+    assert ds[:, :, :, :sx, ...].shape == (
+        ds.positions,
+        ds.shape_t,
+        min(ds.shape_z, sx),
+        ds.shape_c,
+        ds.shape_y,
+        ds.shape_x,
+    )
+    assert ds[:, :, :, :, :sx, ...].shape == (
+        ds.positions,
+        min(ds.shape_t, sx),
+        ds.shape_z,
+        ds.shape_c,
+        ds.shape_y,
+        ds.shape_x,
+    )
+    assert ds[:, :, :, :, :, :sx].shape == (
+        min(ds.positions, sx),
+        ds.shape_t,
+        ds.shape_z,
+        ds.shape_c,
+        ds.shape_y,
+        ds.shape_x,
+    )
 
     close_bdv_ds(ds)
 

--- a/test/model/data_sources/test_data_source.py
+++ b/test/model/data_sources/test_data_source.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 
 def test_data_source_mode():
@@ -7,15 +8,18 @@ def test_data_source_mode():
     ds = DataSource()
 
     # set read and write
-    ds.mode = "r"
-    assert ds.mode == "r"
+
+    with pytest.raises(NotImplementedError):
+        ds.mode = "r"
+        assert ds.mode == "r"
 
     ds.mode = "w"
     assert ds.mode == "w"
 
     # set unknown mode, default to read
-    ds.mode = "goblin"
-    assert ds.mode == "r"
+    with pytest.raises(NotImplementedError):
+        ds.mode = "goblin"
+        assert ds.mode == "r"
 
 
 def test_data_source_cztp_indices():

--- a/test/model/data_sources/test_zarr_data_source.py
+++ b/test/model/data_sources/test_zarr_data_source.py
@@ -1,0 +1,110 @@
+import os
+
+import pytest
+import numpy as np
+
+from navigate.tools.file_functions import delete_folder
+
+
+def zarr_ds(fn, multiposition, per_stack, z_stack, stop_early, size):
+    from test.model.dummy import DummyModel
+    from navigate.model.data_sources.zarr_data_source import OMEZarrDataSource
+
+    print(
+        f"Conditions are multiposition: {multiposition} per_stack: {per_stack} "
+        f"z_stack: {z_stack} stop_early: {stop_early}"
+    )
+
+    # Set up model with a random number of z-steps to modulate the shape
+    model = DummyModel()
+    z_steps = np.random.randint(1, 3)
+    timepoints = np.random.randint(1, 3)
+
+    x_size, y_size = size
+    model.configuration["experiment"]["CameraParameters"]["x_pixels"] = x_size
+    model.configuration["experiment"]["CameraParameters"]["y_pixels"] = y_size
+    model.img_width = x_size
+    model.img_height = y_size
+
+    model.configuration["experiment"]["MicroscopeState"]["image_mode"] = (
+        "z-stack" if z_stack else "single"
+    )
+    model.configuration["experiment"]["MicroscopeState"]["number_z_steps"] = z_steps
+    model.configuration["experiment"]["MicroscopeState"][
+        "is_multiposition"
+    ] = multiposition
+    model.configuration["experiment"]["MicroscopeState"]["timepoints"] = timepoints
+    if per_stack:
+        model.configuration["experiment"]["MicroscopeState"][
+            "stack_cycling_mode"
+        ] = "per_stack"
+    else:
+        model.configuration["experiment"]["MicroscopeState"][
+            "stack_cycling_mode"
+        ] = "per_slice"
+
+    # Establish a BDV data source
+    ds = OMEZarrDataSource(fn)
+    ds.set_metadata_from_configuration_experiment(model.configuration)
+
+    # Populate one image per channel per timepoint
+    n_images = ds.shape_c * ds.shape_z * ds.shape_t * ds.positions
+    print(
+        f"x: {ds.shape_x} y: {ds.shape_y} z: {ds.shape_z} c: {ds.shape_c} "
+        f"t: {ds.shape_t} positions: {ds.positions} per_stack: {ds.metadata.per_stack}"
+    )
+    data = (np.random.rand(n_images, ds.shape_y, ds.shape_x) * 2**16).astype("uint16")
+    dbytes = np.sum(
+        ds.shapes.prod(1) * ds.shape_t * ds.shape_c * ds.positions * 2
+    )  # 2 bytes per pixel (16-bit)
+    assert dbytes == ds.nbytes
+    data_positions = (np.random.rand(n_images, 5) * 50e3).astype(float)
+    for i in range(n_images):
+        ds.write(
+            data[i, ...].squeeze(),
+            x=data_positions[i, 0],
+            y=data_positions[i, 1],
+            z=data_positions[i, 2],
+            theta=data_positions[i, 3],
+            f=data_positions[i, 4],
+        )
+        if stop_early and np.random.rand() > 0.5:
+            break
+
+    return ds
+
+
+def close_zarr_ds(ds, file_name=None):
+    ds.close()
+
+    if file_name is None:
+        file_name = ds.file_name
+
+    # Delete
+    try:
+        if os.path.isdir(file_name):
+            # zarr is a directory
+            delete_folder(file_name)
+        else:
+            os.remove(file_name)
+    except PermissionError:
+        # Windows seems to think these files are still open
+        pass
+
+
+@pytest.mark.parametrize("multiposition", [True, False])
+@pytest.mark.parametrize("per_stack", [True, False])
+@pytest.mark.parametrize("z_stack", [True, False])
+@pytest.mark.parametrize("stop_early", [True, False])
+@pytest.mark.parametrize("size", [(1024, 2048), (2048, 1024), (2048, 2048)])
+def test_zarr_write(multiposition, per_stack, z_stack, stop_early, size):
+
+    fn = "test.zarr"
+
+    ds = zarr_ds(fn, multiposition, per_stack, z_stack, stop_early, size)
+
+    file_name = ds.file_name
+
+    close_zarr_ds(ds, file_name=file_name)
+
+    assert True

--- a/test/model/metadata_sources/test_zarr_metadata.py
+++ b/test/model/metadata_sources/test_zarr_metadata.py
@@ -1,0 +1,189 @@
+import pytest
+
+SPACE_UNITS = [
+    "angstrom",
+    "attometer",
+    "centimeter",
+    "decimeter",
+    "exameter",
+    "femtometer",
+    "foot",
+    "gigameter",
+    "hectometer",
+    "inch",
+    "kilometer",
+    "megameter",
+    "meter",
+    "micrometer",
+    "mile",
+    "millimeter",
+    "nanometer",
+    "parsec",
+    "petameter",
+    "picometer",
+    "terameter",
+    "yard",
+    "yoctometer",
+    "yottameter",
+    "zeptometer",
+    "zettameter",
+]
+
+TIME_UNITS = [
+    "attosecond",
+    "centisecond",
+    "day",
+    "decisecond",
+    "exasecond",
+    "femtosecond",
+    "gigasecond",
+    "hectosecond",
+    "hour",
+    "kilosecond",
+    "megasecond",
+    "microsecond",
+    "millisecond",
+    "minute",
+    "nanosecond",
+    "petasecond",
+    "picosecond",
+    "second",
+    "terasecond",
+    "yoctosecond",
+    "yottasecond",
+    "zeptosecond",
+    "zettasecond",
+]
+
+
+@pytest.fixture
+def dummy_metadata(dummy_model):
+    from navigate.model.metadata_sources.zarr_metadata import OMEZarrMetadata
+
+    # Create metadata
+    md = OMEZarrMetadata()
+
+    md.configuration = dummy_model.configuration
+
+    return md
+
+
+def test_axes(dummy_metadata):
+
+    axes = dummy_metadata._axes
+
+    # Check length
+    assert (len(axes) > 1) and (len(axes) < 6)
+
+    # Check list types and count
+    time_count = 0
+    space_count = 0
+    channel_count = 0
+    custom_count = 0
+    for d in axes:
+        if d["type"] == "time":
+            assert d["unit"] in TIME_UNITS
+            time_count += 1
+        elif d["type"] == "space":
+            assert d["unit"] in SPACE_UNITS
+            space_count += 1
+        elif d["type"] == "channel":
+            channel_count += 1
+        else:
+            custom_count += 1
+
+    assert (space_count > 1) and (space_count < 4)
+    assert time_count < 2
+    assert ((channel_count < 2) and (custom_count == 0)) or (
+        (channel_count == 0) and (custom_count < 2)
+    )
+
+    # Check order
+    order_type = [x["type"] for x in axes]
+    if "time" in order_type:
+        # Time must be first, if present
+        assert order_type.index("time") == 0
+    if "channel" in order_type:
+        # Channel must be before all the space axes, if present
+        ci = order_type.index("channel")
+        for i, el in enumerate(order_type):
+            if el == "space":
+                assert i > ci
+
+    # Skip zyx order spec as the naming of axes is not enforcable.
+
+
+def test_stage_positions_to_translation_transform(dummy_metadata):
+    import random
+
+    pos = [random.random() for _ in range(5)]
+
+    translation = dummy_metadata._stage_positions_to_translation_transform(*pos)
+
+    axes = dummy_metadata._axes
+
+    assert len(translation) == len(axes)
+
+
+def test_scale_transform(dummy_metadata):
+    scale = dummy_metadata._scale_transform()
+
+    axes = dummy_metadata._axes
+
+    assert len(scale) == len(axes)
+
+
+def test_coordinate_transformations(dummy_metadata):
+    import random
+
+    pos = [random.random() for _ in range(5)]
+
+    translation = dummy_metadata._stage_positions_to_translation_transform(*pos)
+    scale = dummy_metadata._scale_transform()
+
+    assert len(dummy_metadata._coordinate_transformations(scale)) == 1
+
+    combo = dummy_metadata._coordinate_transformations(scale, translation)
+    assert len(combo) == 2
+    assert combo[0]["type"] == "scale" and combo[1]["type"] == "translation"
+
+    with pytest.raises(UserWarning):
+        dummy_metadata._coordinate_transformations(translation=translation)
+
+
+def test_multiscale_metadata(dummy_metadata):
+    """https://ngff.openmicroscopy.org/0.4/#multiscale-md"""
+    import numpy as np
+    import random
+
+    resolutions = np.array([[1, 1, 1], [2, 2, 1], [4, 4, 1], [8, 8, 1]], dtype=int)
+    paths = [f"path{i}" for i in range(resolutions.shape[0])]
+    view = {k: random.random() for k in ["x", "y", "z", "theta", "f"]}
+
+    msd = dummy_metadata.multiscales_dict("test", paths, resolutions, view)
+
+    # Each "multiscales" dictionary MUST contain the field "axes"
+    assert "axes" in msd.keys()
+
+    # Each "multiscales" dictionary MUST contain the field "datasets"
+    assert "datasets" in msd.keys()
+    # Each dictionary in "datasets" MUST contain the field "path",
+    # whose value contains the path to the array for this resolution
+    # relative to the current zarr group. The "path"s MUST be ordered
+    # from largest (i.e. highest resolution) to smallest.
+    # Each "datasets" dictionary MUST have the same number of dimensions
+    # and MUST NOT have more than 5 dimensions.
+
+    # Each "multiscales" dictionary SHOULD contain the field "name"
+    assert "name" in msd.keys()
+
+    # Each "multiscales" dictionary MAY contain the field "coordinateTransformations"
+    assert "coordinateTransformations" in msd.keys()
+
+    # It SHOULD contain the field "version"
+    assert "version" in msd.keys()
+
+    # Each "multiscales" dictionary SHOULD contain the field "type", which gives
+    # the type of downscaling method used to generate the multiscale image pyramid.
+    # It SHOULD contain the field "metadata", which contains a dictionary with
+    # additional information about the downscaling method.


### PR DESCRIPTION
This PR...

* Establishes a generalized pyramidal data source for multi-resolution writing.
* Adds an OME-Zarr data source/writer to `navigate` (closes #766).
* Includes a fix for `uint16` writing in BDV H5 files as described here: https://github.com/bigdataviewer/bigdataviewer-core/issues/102.

The OME-Zarr writing seems to work. I can open it in a notebook and it looks to me like it satisfies the minimum requirements at https://ngff.openmicroscopy.org/0.4/. I can open the Zarr with File > Import in ImageJ. However, even though the path and shape discovery works, I cannot open the Zarr images with Plugins > BDV > HDF5/N5/Zarr/OME-NGFF Viewer. I'm not sure if this is due to a bug in my writer, lack of support for NGFF version 0.4 in this plugin, or something else. Does anyone with Zarr experience (@dpshepherd ?) have any ideas as to what is going on?

*** PLEASE CHECK THIS WORKS ON ACTUAL MICROSCOPES BEFORE MERGING. ***

Future: Write speed is not optimized for N5 or Zarr. We should thread the writing, possibly with a `Synchronizer` (https://zarr.readthedocs.io/en/stable/api/sync.html), to achieve faster speeds. Alternatively, we could decline to write the subsampled versions of the image for now.

Future: The reader is half-implemented and won't read the metadata at the moment.