### PR TITLE
Quick docs

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -54,6 +54,7 @@ technology developers.
    :maxdepth: 2
 
    user_guide/hardware_overview
+   user_guide/file_formats
    user_guide/gui_walkthrough
    user_guide/setup_microscope
    user_guide/acquiring_home

--- a/docs/source/user_guide/acquiring_guide.rst
+++ b/docs/source/user_guide/acquiring_guide.rst
@@ -12,14 +12,14 @@ Standard Acquisition Modes
 ==========================
 
 **navigate** features standard acquisition modes including Continuous/Live, Single Frame
-and Z-Stack, which can be saved to TIFF, H5 and N5 data formats. Saving is toggled under 
-the GUI's :ref:`timepoint settings <user_guide/gui_walkthrough:timepoint settings>`.
+and Z-Stack, which can be saved to TIFF, OME-TIFF, HDF5, N5, and OME-Zarr data formats.
+Saving is toggled under the GUI's :ref:`timepoint settings <user_guide/gui_walkthrough:timepoint settings>`.
 
-These modes (and other custom modes) can be selected in the program's 
+These modes (and other custom modes) can be selected in the program's
 :ref:`acquisition bar <user_guide/gui_walkthrough:acquisition bar>` dropdown list.
 
-Each acquisition mode is implemented as a :doc:`feature list <features>` and can be used 
-in sequence with other features that can, for example, 
+Each acquisition mode is implemented as a :doc:`feature list <features>` and can be used
+in sequence with other features that can, for example,
 :doc:`make smart decisions <../intermediate>`.
 
 ----------------
@@ -28,11 +28,11 @@ Continuous Scan
 ---------------
 
 This creates a live view of what is on the camera. It is not possible to save data in
-this mode, only to preview what is in focus. This mode is helpful for alignment, 
-parameter tuning, and scrolling around the sample with the stage. 
+this mode, only to preview what is in focus. This mode is helpful for alignment,
+parameter tuning, and scrolling around the sample with the stage.
 
 It is implemented as
-a :doc:`feature list <features>`, shown in its 
+a :doc:`feature list <features>`, shown in its
 :ref:`textual form <user_guide/features:text representation of feature lists>` below.
 
 .. code-block:: python
@@ -49,8 +49,8 @@ a :doc:`feature list <features>`, shown in its
 
 The sequence begins with the `PrepareNextChannel` feature and loops over
 `experiment.MicroscopeState.selected_channels`. As such, continuous mode will
-display a live preview of all 
-:ref:`selected color channels <user_guide/gui_walkthrough:channel settings>` in 
+display a live preview of all
+:ref:`selected color channels <user_guide/gui_walkthrough:channel settings>` in
 sequence, then return the first color channel and start again.
 
 ----------------
@@ -58,7 +58,7 @@ sequence, then return the first color channel and start again.
 Single Acquisition
 ------------------
 
-This takes a single image of each 
+This takes a single image of each
 :ref:`selected channel <user_guide/gui_walkthrough:channel settings>` and optionally
 saves them to a file. Its feature list is identical to that of "Continuous Scan".
 
@@ -69,10 +69,10 @@ Z-Stack Acquisition
 
 This takes an image stack over the range and at the step size defined by the
 :ref:`stack acquisition settings <user_guide/gui_walkthrough:stack acquisition settings>`
-and optionally saves the stack to a file. The color channels will appear as in 
+and optionally saves the stack to a file. The color channels will appear as in
 "Continuous Scan" and "Single Acquisition" if :guilabel:`Laser Cycling Settings` is set to
-"Per Z" in the stack acquisition settings. A single z-stack will be taken for each 
-color channel, one channel at a time, if :guilabel:`Laser Cycling Settings` is set to 
+"Per Z" in the stack acquisition settings. A single z-stack will be taken for each
+color channel, one channel at a time, if :guilabel:`Laser Cycling Settings` is set to
 "Per Stack".
 
 Z-Stack acquisition is implemented as the feature list below.
@@ -90,10 +90,10 @@ Z-Stack acquisition is implemented as the feature list below.
         )
     ]
 
-Note that in the z-stack the color channel looping is abstracted into 
-``ZStackAcquisition``, but we will take one set of z-stacks at each 
+Note that in the z-stack the color channel looping is abstracted into
+``ZStackAcquisition``, but we will take one set of z-stacks at each
 :ref:`timepoint <user_guide/gui_walkthrough:timepoint settings>`. It is also
-worth noting that ``ZStackAcquisition`` handles moving through 
+worth noting that ``ZStackAcquisition`` handles moving through
 :ref:`multiple positions <user_guide/gui_walkthrough:multiposition>`.
 ``ZStackAcquisition`` will loop over ``Z`` or ``C`` first, as decided by "Per Stack"
 or "Per Z", and then will loop over positions.
@@ -105,56 +105,26 @@ Customized
 
 The customized acquisition mode can be used to run any feature list of the user's choosing.
 Data acquisition with **navigate** is almost infinitely reconfigurable with the either the
-:doc:`feature container <features>`, if a desired acquisition can be 
-performed using a reconfiguration of existing features and saving formats, or the 
+:doc:`feature container <features>`, if a desired acquisition can be
+performed using a reconfiguration of existing features and saving formats, or the
 :doc:`plugin architecture <../plugin/plugin_home>`, if new features or saving formats are
-required. We strongly recommend the reader check through the 
+required. We strongly recommend the reader check through the
 :doc:`available features <../_autosummary/navigate.model.features>` and see if they can be
 combined into a acquisition feature list before writing a new acquisition feature.
 
 ----------------
 
-Saving Formats
-==============
 
-**navigate** comes pre-packaged with TIFF, OME-TIFF, and H5/N5
-(`BigDataViewer <https://imagej.net/plugins/bdv/>`_) file saving formats. The 
-performance of these saving data sources is limited by write speed to disk. To 
-achieve maximal saving speed, we recommend saving all data to a local SSD. See 
-:ref:`Hardware Considerations <software_installation:hardware considerations>` for more
-information.
-
-----------------
-
-TIFF/OME-TIFF
--------------
-
-**navigate** uses the `tifffile <https://pypi.org/project/tifffile/>`_ package to write
-TIFF, BigTIFF, and OME-TIFF data to file. The **navigate** package creates a custom
-:doc:`OME-TIFF XML <../_autosummary/navigate.model.metadata_sources.ome_tiff_metadata.OMETIFFMetadata>`
-to store metadata.
-
-----------------
-
-BigDataViewer H5/N5
--------------------
-
-**navigate** uses `h5py <https://docs.h5py.org/en/stable/index.html>`_ (H5) and
-`zarr <https://zarr.readthedocs.io/en/stable/>`_ (N5) to store data in a BigDataViewer
-file format. This is a pyramidal format, necessitating the saving of both the original
-data and down sampled versions of this data. The additional data slows down the write
-speed. The N5 format is faster than H5 because it allows multithreaded writes.
-
-Image Pipeline
-==============
+Analysis Pipeline
+=================
 
 Images are stored from the camera onto a circular buffer of size ``databuffer_size``, a
-setting under ``experiment.CameraParameters`` in the 
+setting under ``experiment.CameraParameters`` in the
 :doc:`software configuration <software_configuration>`. By default, this
-buffer is 100 frames in length. 
+buffer is 100 frames in length.
 
 Image processing and saving operations (see the
-:doc:`feature container <../contributing/feature_container>` data operations) are 
-performed on frames in this buffer. These operations must take less time than it takes 
-to add a new frame to the buffer, or the buffer will eventually overflow. This is, in 
+:doc:`feature container <../contributing/feature_container>` data operations) are
+performed on frames in this buffer. These operations must take less time than it takes
+to add a new frame to the buffer, or the buffer will eventually overflow. This is, in
 part, why saving to an SSD (as opposed to HDD) is critical.

--- a/docs/source/user_guide/file_formats.rst
+++ b/docs/source/user_guide/file_formats.rst
@@ -1,0 +1,45 @@
+======================
+Supported File Formats
+======================
+
+The choice of file format for saving imaging data in microscopy is crucial
+because it affects data integrity, accessibility, and analysis efficiency.
+Formats like TIFF and its derivative OME-TIFF are widely used due to their ability
+to store metadata and support multiple imaging channels. However, modern formats such
+as Zarr, N5, and HDF5, including OME-ZARR, cater to the needs of large-scale,
+multi-dimensional datasets by enabling efficient data storage, access, and processing at
+cloud-compute scales.
+
+To enable ambitious imaging projects, **navigate** **navigate** comes pre-packaged with TIFF, OME-TIFF, OME-Zarr, HDF5/N5
+(`BigDataViewer <https://imagej.net/plugins/bdv/>`_) file saving formats.
+OME, or Open Microscopy Environment, is a standardized metadata model that ensures
+that imaging data can be accurately understood, shared, and analyzed across different software
+platforms and research groups.
+
+.. Note::
+
+    The performance of saving to these data sources is limited by write speed to disk. To
+    achieve maximal saving speed, we recommend saving all data to a local solid state drive. See
+    :ref:`Hardware Considerations <software_installation:hardware considerations>` for more
+    information.
+
+----------------
+
+TIFF/OME-TIFF
+-------------
+
+**navigate** uses the `tifffile <https://pypi.org/project/tifffile/>`_ package to write
+TIFF, BigTIFF, and OME-TIFF data to file. The **navigate** package creates a custom
+:doc:`OME-TIFF XML <../_autosummary/navigate.model.metadata_sources.ome_tiff_metadata.OMETIFFMetadata>`
+to store metadata.
+
+----------------
+
+BigDataViewer H5/N5/OME-Zarr
+-------------------
+
+**navigate** uses `h5py <https://docs.h5py.org/en/stable/index.html>`_ (H5) and
+`zarr <https://zarr.readthedocs.io/en/stable/>`_ (N5) to store data in a BigDataViewer
+file format. This is a pyramidal format, necessitating the saving of both the original
+data and down sampled versions of this data. The additional data slows down the write
+speed. The N5 format is faster than H5 because it allows multithreaded writes.

--- a/docs/source/user_guide/hardware_overview.rst
+++ b/docs/source/user_guide/hardware_overview.rst
@@ -49,7 +49,8 @@ configure each of these devices is provided :doc:`here <hardware/supported_hardw
         * Mad City Labs Nano-Drive
         * Physik Instrumente
         * Sutter MP285
-        * Thorlabs KST101
+        * Thorlabs Stepper Actuators with a KST101 K-Cube Controller.
+        * Thorlabs Piezoelectric Inertia Actuators with a KIM001 K-Cube Controller
    * - *Shutters*
      -
         * Digitally controlled shutters.


### PR DESCRIPTION
Moved the file types that we support up so that it is more evident to potential users. This information was previously buried.

Our standard text states that the performance of all file types is limited by write speed. Perhaps this is where we could put some information on benchmarking @zacsimile ?