### PR TITLE
Fix Window Menu

### DIFF
--- a/src/navigate/controller/sub_controllers/menu_controller.py
+++ b/src/navigate/controller/sub_controllers/menu_controller.py
@@ -378,28 +378,28 @@ class MenuController(GUIController):
             self.view.menubar.menu_window: {
                 "Channel Settings": [
                     "standard",
-                    lambda: self.switch_tabs(1),
+                    lambda *args: self.switch_tabs(1),
                     "Ctrl+1",
                     "<Control-Key-1>",
                     "<Control_L-Key-1",
                 ],
                 "Camera Settings": [
                     "standard",
-                    lambda: self.switch_tabs(2),
+                    lambda *args: self.switch_tabs(2),
                     "Ctrl+2",
                     "<Control-Key-2>",
                     "<Control_L-Key-2",
                 ],
                 "Stage Control": [
                     "standard",
-                    lambda: self.switch_tabs(3),
+                    lambda *args: self.switch_tabs(3),
                     "Ctrl+3",
                     "<Control-Key-3>",
                     "<Control_L-Key-3",
                 ],
                 "Multiposition Table": [
                     "standard",
-                    lambda: self.switch_tabs(4),
+                    lambda *args: self.switch_tabs(4),
                     "Ctrl+4",
                     "<Control-Key-4>",
                     "<Control_L-Key-4",

--- a/src/navigate/controller/sub_controllers/menu_controller.py
+++ b/src/navigate/controller/sub_controllers/menu_controller.py
@@ -378,28 +378,28 @@ class MenuController(GUIController):
             self.view.menubar.menu_window: {
                 "Channel Settings": [
                     "standard",
-                    lambda event: self.switch_tabs(1),
+                    lambda: self.switch_tabs(1),
                     "Ctrl+1",
                     "<Control-Key-1>",
                     "<Control_L-Key-1",
                 ],
                 "Camera Settings": [
                     "standard",
-                    lambda event: self.switch_tabs(2),
+                    lambda: self.switch_tabs(2),
                     "Ctrl+2",
                     "<Control-Key-2>",
                     "<Control_L-Key-2",
                 ],
                 "Stage Control": [
                     "standard",
-                    lambda event: self.switch_tabs(3),
+                    lambda: self.switch_tabs(3),
                     "Ctrl+3",
                     "<Control-Key-3>",
                     "<Control_L-Key-3",
                 ],
                 "Multiposition Table": [
                     "standard",
-                    lambda event: self.switch_tabs(4),
+                    lambda: self.switch_tabs(4),
                     "Ctrl+4",
                     "<Control-Key-4>",
                     "<Control_L-Key-4",
@@ -407,7 +407,7 @@ class MenuController(GUIController):
                 "add_separator": ["standard", None, None, None, None],
                 "Popout Camera Display": [
                     "standard",
-                    self.not_implemented,
+                    lambda: self.popout_camera_display(),
                     None,
                     None,
                     None,
@@ -894,6 +894,10 @@ class MenuController(GUIController):
     def switch_tabs(self, tab):
         """Switch tabs."""
         self.parent_controller.view.settings.select(tab - 1)
+
+    def popout_camera_display(self):
+        """Pop out camera display."""
+        self.parent_controller.view.camera_waveform.popout()
 
     def popup_feature_list_setting(self):
         """Show feature list popup window"""

--- a/src/navigate/view/main_application_window.py
+++ b/src/navigate/view/main_application_window.py
@@ -163,7 +163,9 @@ class MainApp(ttk.Frame):
         # notebook
         #: SettingsNotebook: The settings notebook for the application
         self.settings = SettingsNotebook(self.frame_left, self.root)
+
         #: CameraNotebook: The camera notebook for the application
         self.camera_waveform = CameraNotebook(self.frame_top_right, self.root)
+
         #: AcquireBar: The acquire bar for the application
         self.acqbar = AcquireBar(self.top_frame, self.root)

--- a/test/controller/sub_controllers/test_menu_controller.py
+++ b/test/controller/sub_controllers/test_menu_controller.py
@@ -39,7 +39,10 @@ import tkinter as tk
 import pytest
 
 # Local Imports
-from navigate.controller.sub_controllers.menu_controller import MenuController, FakeEvent
+from navigate.controller.sub_controllers.menu_controller import (
+    MenuController,
+    FakeEvent,
+)
 
 
 class TestFakeEvent(unittest.TestCase):
@@ -64,6 +67,9 @@ class TestStageMovement(unittest.TestCase):
 
     def tearDown(self):
         self.root.destroy()
+
+    def test_initialize_menus(self):
+        self.mc.initialize_menus()
 
     def test_stage_movement_with_ttk_entry(self):
         self.mc.parent_controller.view.focus_get.return_value = MagicMock(
@@ -183,25 +189,27 @@ class TestMenuController(unittest.TestCase):
         class MockWidget:
             def __int__(self):
                 self.value = False
+
             def set(self, value):
                 self.value = value
+
             def get(self):
                 return self.value
-            
-        channel_tab_controller = MagicMock()
-        self.menu_controller.parent_controller.channels_tab_controller = channel_tab_controller
-        channel_tab_controller.timepoint_vals = {
-            "is_save": MockWidget()
-        }
-        self.menu_controller.view.settings.channels_tab.stack_timepoint_frame\
-            .save_data.get = MagicMock(return_value = False)
-        self.menu_controller.toggle_save()
-        assert channel_tab_controller.timepoint_vals["is_save"].get() == True
 
-        self.menu_controller.view.settings.channels_tab.stack_timepoint_frame\
-            .save_data.get = MagicMock(return_value=True)
+        channel_tab_controller = MagicMock()
+        self.menu_controller.parent_controller.channels_tab_controller = (
+            channel_tab_controller
+        )
+        channel_tab_controller.timepoint_vals = {"is_save": MockWidget()}
+        temp = self.menu_controller.view.settings.channels_tab.stack_timepoint_frame
+        temp.save_data.get = MagicMock(return_value=False)
         self.menu_controller.toggle_save()
-        assert channel_tab_controller.timepoint_vals["is_save"].get() == False
+        assert channel_tab_controller.timepoint_vals["is_save"].get() is True
+
+        temp = self.menu_controller.view.settings.channels_tab.stack_timepoint_frame
+        temp.save_data.get = MagicMock(return_value=True)
+        self.menu_controller.toggle_save()
+        assert channel_tab_controller.timepoint_vals["is_save"].get() is False
 
     def test_stage_movement(self):
         # TODO: DummyController does not have a stage controller.
@@ -216,7 +224,9 @@ class TestMenuController(unittest.TestCase):
             )
 
     @patch("src.navigate.controller.sub_controllers.menu_controller.platform.system")
-    @patch("src.navigate.controller.sub_controllers.menu_controller.subprocess.check_call")
+    @patch(
+        "src.navigate.controller.sub_controllers.menu_controller.subprocess.check_call"
+    )
     def test_open_folder(self, mock_check_call, mock_system):
         mock_system.return_value = "Darwin"
         self.menu_controller.open_folder("test_path")


### PR DESCRIPTION
The hot-keys to change windows did work, but when you manually selected the items in the menu (e.g., Channel Settings, Stage Control, etc.), it did not. Lambda function was poorly defined.

Popout camera tab was also not implemented, and now it is.

Few ruff formatting changes. Some of our calls are definitely getting too long, and this is making it harder to be compliant with pre-commit hooks.