### PR TITLE
Add alternative communication protocol

### DIFF
--- a/src/navigate/config/configuration_database.py
+++ b/src/navigate/config/configuration_database.py
@@ -273,6 +273,13 @@ stage_hardware_widgets = {
         None,
         "*Physik Instrumente only. Example: FRF FRF",
     ],
+    "connection_type": [
+        "Connection Type",
+        "Input",
+        "string",
+        None,
+        "*Physik Instrumente only. Example: USB, Serial.",
+    ],
     "port": ["Serial Port", "Input", "string", None, "Example: COM1"],
     "baudrate": ["Baudrate", "Input", "int", None, "Example: 9600"],
     "timeout": ["Serial Timeout", "Input", "float", None, "Example: 0.25", 0.25],

--- a/src/navigate/model/device_startup_functions.py
+++ b/src/navigate/model/device_startup_functions.py
@@ -418,6 +418,8 @@ def load_stages(configuration, is_synthetic=False, plugin_devices={}):
                         stage_config["serial_number"],
                         stage_config["stages"],
                         stage_config["refmode"],
+                        stage_config.get("connection", "USB"),
+                        stage_config.get("port", None)
                     ),
                     exception=GCSError,
                 )

--- a/src/navigate/model/devices/stages/pi.py
+++ b/src/navigate/model/devices/stages/pi.py
@@ -46,7 +46,7 @@ p = __name__.split(".")[1]
 logger = logging.getLogger(p)
 
 
-def build_PIStage_connection(controller_name, serial_number, stages, reference_modes):
+def build_PIStage_connection(controller_name, serial_number, stages, reference_modes, connection_type, port):
     """Connect to the Physik Instrumente (PI) Stage
 
     Parameters
@@ -59,17 +59,40 @@ def build_PIStage_connection(controller_name, serial_number, stages, reference_m
         Stages to connect to, e.g., "M-111.1DG"
     reference_modes : str
         Reference modes for the stages, e.g., "FRF"
+    connection_type : str
+        The communication protocol for the Physik Instrumente controller.
+            - USB
+            - serial
+    port : int
+        The comport to communicate over for RS232 commands. Default is None.
 
     Returns
     -------
     stage_connection : dict
         Dictionary containing the pi_tools and pi_device objects
+
+    Note
+    ----
+        Please see https://pipython.physikinstrumente.com/connect.html
     """
     pi_stages = stages.split()
     pi_reference_modes = reference_modes.split()
     pi_tools = pitools
     pi_device = GCSDevice(controller_name)
-    pi_device.ConnectUSB(serialnum=serial_number)
+
+    if connection_type.lower() == "usb":
+        pi_device.ConnectUSB(serialnum=serial_number)
+    elif connection_type.lower() == "serial":
+        if port is None:
+            Raise: Exception("Please configure the COMPORT in your configuration.yaml file.")
+        if "com" in port.lower():
+            port = port.lower().split("com")[1]
+        pi_device.ConnectRS232(comport=int(port), baudrate=115200)
+    elif connection_type.lower() == "tcpip":
+        Raise: NotImplementedError
+    elif connection_type.lower() == "gpib":
+        Raise: NotImplementedError
+
     pi_tools.startup(
         pi_device, stages=list(pi_stages), refmodes=list(pi_reference_modes)
     )


### PR DESCRIPTION
Collaborator at UTD tried to connect to a Physik Instrumente stage via RS232, which wasn't supported.

Tested on microscope and it seems to work.
```
from pipython import pitools, GCSError, GCSDevice
import pipython
import time
controller = 'E-709'
stage = 'P-726.1CD'
axis = 'Z'

pidevice=GCSDevice(controller)
pidevice.ConnectRS232(comport=8, baudrate=115200)
ready = pidevice.IsControllerReady()
print("The PI Device is Ready:", ready)

pi_tools = pitools
# startup(pidevice, stages=None, refmodes=None, servostates=True, controlmodes=None, **kwargs) pi_tools.startup(pidevice, stages="P-726.1CD", refmodes="ATZ", servostates=True)

stage_connection = {"pi_tools": pi_tools, "pi_device": pidevice}

distance = [0, 100, 0, 100, 0, 100]

for val in distance:
    pi_tools.moveandwait(pidevice, axes=axis, values=val, timeout=300)
    time.sleep(0.1)
```