### PR TITLE
Close ni tasks

### DIFF
--- a/src/navigate/controller/thread_pool.py
+++ b/src/navigate/controller/thread_pool.py
@@ -412,7 +412,6 @@ class SynchronizedThreadPool:
         """
 
         if event == "exception":
-            logger.exception("****in local trace: exception stops the thread")
             if os.getenv("GITHUB_ACTIONS") == "true":
                 return
             raise SystemExit()

--- a/src/navigate/controller/thread_pool.py
+++ b/src/navigate/controller/thread_pool.py
@@ -414,6 +414,9 @@ class SynchronizedThreadPool:
         if event == "exception":
             if os.getenv("GITHUB_ACTIONS") == "true":
                 return
+
+            # Silence traceback to avoid printing to console.
+            sys.tracebacklimit = 0
             raise SystemExit()
         return self.localtrace
 

--- a/src/navigate/controller/thread_pool.py
+++ b/src/navigate/controller/thread_pool.py
@@ -97,11 +97,7 @@ class SelfLockThread(threading.Thread):
             try:
                 self._target(*self._args, **self._kwargs)
             except Exception as e:
-                print(
-                    f"{self.name} thread ended because of exception!: {e}",
-                    traceback.format_exc(),
-                )
-                logger.debug(
+                logger.exception(
                     f"{self.name} thread ended because of exception!: {e}",
                     traceback.format_exc(),
                 )
@@ -251,13 +247,7 @@ class SynchronizedThreadPool:
                 try:
                     target(*args, **kwargs)
                 except Exception as e:
-                    print(
-                        threading.current_thread().name,
-                        "thread exception happened!",
-                        e,
-                        traceback.format_exc(),
-                    )
-                    logger.debug(
+                    logger.exception(
                         threading.current_thread().name,
                         "thread exception happened!",
                         e,
@@ -422,8 +412,7 @@ class SynchronizedThreadPool:
         """
 
         if event == "exception":
-            print("****in local trace: exception stops the thread")
-            logger.debug("****in local trace: exception stops the thread")
+            logger.exception("****in local trace: exception stops the thread")
             if os.getenv("GITHUB_ACTIONS") == "true":
                 return
             raise SystemExit()

--- a/src/navigate/model/devices/camera/hamamatsu.py
+++ b/src/navigate/model/devices/camera/hamamatsu.py
@@ -143,7 +143,7 @@ class HamamatsuBase(CameraBase):
 
     def __del__(self):
         """Delete HamamatsuOrca class."""
-        pass
+        self.close_camera()
 
     @property
     def serial_number(self):

--- a/src/navigate/model/devices/camera/hamamatsu.py
+++ b/src/navigate/model/devices/camera/hamamatsu.py
@@ -143,7 +143,8 @@ class HamamatsuBase(CameraBase):
 
     def __del__(self):
         """Delete HamamatsuOrca class."""
-        self.close_camera()
+        self.camera_controller.dev_close()
+        # self.close_camera()
 
     @property
     def serial_number(self):

--- a/src/navigate/model/devices/filter_wheel/asi.py
+++ b/src/navigate/model/devices/filter_wheel/asi.py
@@ -170,6 +170,10 @@ class ASIFilterWheel(FilterWheelBase):
             logger.debug("ASI Filter Wheel - Closing Device.")
             self.filter_wheel.disconnect_from_serial()
 
+    def __del__(self):
+        """Destructor for the ASIFilterWheel class."""
+        self.close()
+
 
 @log_initialization
 class ASICubeSlider(FilterWheelBase):

--- a/src/navigate/model/devices/filter_wheel/asi.py
+++ b/src/navigate/model/devices/filter_wheel/asi.py
@@ -87,15 +87,15 @@ class ASIFilterWheel(FilterWheelBase):
 
         Parameters
         ----------
-        device_connection : dict
-            Dictionary of device connections.
+        device_connection : TigerController
+            Communication object for the ASI Filter Wheel.
         device_config : dict
             Dictionary of device configuration parameters.
         """
 
         super().__init__(device_connection, device_config)
 
-        #: obj: ASI Tiger Controller object.
+        #: TigerController: ASI Tiger Controller object.
         self.filter_wheel = device_connection
 
         #: dict: Configuration dictionary.

--- a/src/navigate/model/devices/filter_wheel/base.py
+++ b/src/navigate/model/devices/filter_wheel/base.py
@@ -32,6 +32,7 @@
 
 #  Standard Library Imports
 import logging
+from typing import Any, Dict
 
 # Third Party Imports
 
@@ -47,20 +48,20 @@ logger = logging.getLogger(p)
 class FilterWheelBase:
     """FilterWheelBase - Parent class for controlling filter wheels."""
 
-    def __init__(self, device_connection, device_config):
+    def __init__(self, device_connection: Any, device_config: Dict[str, Any]) -> None:
         """Initialize the FilterWheelBase class.
 
         Parameters
         ----------
-        device_connection : dict
-            Dictionary of device connections.
-        device_config : dict
+        device_connection : Any
+            The communication instance with the device.
+        device_config : Dict[str, Any]
             Dictionary of device configuration parameters.
         """
-        #: object: Device connection object.
+        #: Any: Device connection object.
         self.device_connection = device_connection
 
-        #: dict: Dictionary of device configuration parameters.
+        #: Dict[str, Any]: Dictionary of device configuration parameters.
         self.device_config = device_config
 
         #: dict: Dictionary of filters available on the filter wheel.

--- a/src/navigate/model/devices/filter_wheel/base.py
+++ b/src/navigate/model/devices/filter_wheel/base.py
@@ -72,9 +72,13 @@ class FilterWheelBase:
         #: int: index of filter wheel
         self.filter_wheel_number = device_config["hardware"]["wheel_number"]
 
-    def __str__(self):
+    def __str__(self) -> str:
         """Return the string representation of the FilterWheelBase class."""
         return "FilterWheelBase"
+
+    def __del__(self) -> None:
+        """Destructor for the FilterWheelBase class."""
+        pass
 
     def check_if_filter_in_filter_dictionary(self, filter_name: str) -> bool:
         """Checks if the filter designation (string) given exists in the

--- a/src/navigate/model/devices/filter_wheel/ludl.py
+++ b/src/navigate/model/devices/filter_wheel/ludl.py
@@ -161,3 +161,8 @@ class LUDLFilterWheel(FilterWheelBase):
         logger.debug("LUDLFilterWheel - Closing the Filter Wheel Serial Port")
         self.set_filter(list(self.filter_dictionary.keys())[0])
         self.serial.close()
+
+    def __del__(self):
+        """Destructor for the LUDLFilterWheel class."""
+        if self.serial.is_open:
+            self.close()

--- a/src/navigate/model/devices/filter_wheel/ni.py
+++ b/src/navigate/model/devices/filter_wheel/ni.py
@@ -145,14 +145,14 @@ class DAQFilterWheel(FilterWheelBase):
             except DaqError as e:
                 logger.debug(e)
 
-    def close(self):
+    def close(self) -> None:
         """Close the DAQ Filter Wheel
 
         Sets the filter wheel to the home position and then closes the port.
         """
         pass
 
-    def __del__(self):
+    def __del__(self) -> None:
         """Delete the DAQFilterWheel object."""
         if self.filter_wheel_task:
             try:

--- a/src/navigate/model/devices/filter_wheel/ni.py
+++ b/src/navigate/model/devices/filter_wheel/ni.py
@@ -33,6 +33,7 @@
 #  Standard Library Imports
 import logging
 import time
+import traceback
 
 # Third Party Imports
 import nidaqmx
@@ -150,3 +151,12 @@ class DAQFilterWheel(FilterWheelBase):
         Sets the filter wheel to the home position and then closes the port.
         """
         pass
+
+    def __del__(self):
+        """Delete the DAQFilterWheel object."""
+        if self.filter_wheel_task:
+            try:
+                self.filter_wheel_task.stop()
+                self.filter_wheel_task.close()
+            except Exception:
+                logger.exception(f"Error stopping task: {traceback.format_exc()}")

--- a/src/navigate/model/devices/filter_wheel/sutter.py
+++ b/src/navigate/model/devices/filter_wheel/sutter.py
@@ -285,7 +285,7 @@ class SutterFilterWheel(FilterWheelBase):
             )
         return self.serial.read(num_bytes)
 
-    def close(self):
+    def close(self) -> None:
         """Close the SutterFilterWheel serial port.
 
         Sets the filter wheel to the Empty-Alignment position and then closes the port.
@@ -293,3 +293,8 @@ class SutterFilterWheel(FilterWheelBase):
         logger.debug("SutterFilterWheel - Closing the Filter Wheel Serial Port")
         self.set_filter(list(self.filter_dictionary.keys())[0])
         self.serial.close()
+
+    def __del__(self) -> None:
+        """Delete the SutterFilterWheel class."""
+        if self.serial.is_open():
+            self.close()

--- a/src/navigate/model/devices/filter_wheel/sutter.py
+++ b/src/navigate/model/devices/filter_wheel/sutter.py
@@ -62,7 +62,7 @@ def build_filter_wheel_connection(comport, baudrate, timeout=0.25):
     Returns
     -------
     serial.Serial
-        Serial port connection to the filter wheel.
+        The serial port connection to the filter wheel.
 
     Raises
     ------
@@ -94,17 +94,18 @@ class SutterFilterWheel(FilterWheelBase):
 
         Parameters
         ----------
-        device_connection : dict
-            Dictionary of device connections.
-        device_config : dict
+        device_connection : serial.Serial
+            The communication instance with the filter wheel.
+        device_config : Dict[str, Any]
             Dictionary of device configuration parameters.
         """
         super().__init__(device_connection, device_config)
 
-        #: obj: Serial port connection to the filter wheel.
+        #: serial.Serial: Serial port connection to the filter wheel.
         self.serial = device_connection
 
-        #: dict: Dictionary of filter names and corresponding filter wheel positions.
+        #: Dict[str, Any]: Dictionary of filter names and corresponding filter wheel
+        # positions.
         self.device_config = device_config
 
         #: bool: Wait until filter wheel has completed movement.
@@ -146,20 +147,11 @@ class SutterFilterWheel(FilterWheelBase):
         # Set filter to the 0th position by default upon initialization.
         self.set_filter(list(self.filter_dictionary.keys())[0])
 
-    def __str__(self):
+    def __str__(self) -> str:
         """String representation of the class."""
         return "SutterFilterWheel"
 
-    def __enter__(self):
-        """Enter the SutterFilterWheel context manager."""
-        return self
-
-    def __exit__(self, *args, **kwargs):
-        """Exit the SutterFilterWheel context manager."""
-        logger.debug("SutterFilterWheel - Closing Device.")
-        self.close()
-
-    def filter_change_delay(self, filter_name):
+    def filter_change_delay(self, filter_name: str) -> None:
         """Calculate duration of time necessary to change filter wheel positions.
 
         Calculate duration of time necessary to change filter wheel positions.
@@ -195,7 +187,7 @@ class SutterFilterWheel(FilterWheelBase):
         except IndexError:
             self.wait_until_done_delay = 0.01
 
-    def set_filter(self, filter_name, wait_until_done=True):
+    def set_filter(self, filter_name: str, wait_until_done: bool = True):
         """Change the filter wheel to the filter designated by the filter
         position argument.
 
@@ -249,7 +241,7 @@ class SutterFilterWheel(FilterWheelBase):
                 # read 0D back.
                 self.read(1)
 
-    def read(self, num_bytes):
+    def read(self, num_bytes: int) -> bytes:
         """Reads the specified number of bytes from the serial port.
 
         Parameters
@@ -259,8 +251,8 @@ class SutterFilterWheel(FilterWheelBase):
 
         Returns
         -------
-        bytes
-            Bytes read from the serial port.
+        response : bytes
+            The bytes read from the serial port.
 
         Raises
         ------
@@ -296,5 +288,5 @@ class SutterFilterWheel(FilterWheelBase):
 
     def __del__(self) -> None:
         """Delete the SutterFilterWheel class."""
-        if self.serial.is_open():
+        if self.serial.is_open:
             self.close()

--- a/src/navigate/model/devices/filter_wheel/synthetic.py
+++ b/src/navigate/model/devices/filter_wheel/synthetic.py
@@ -108,3 +108,7 @@ class SyntheticFilterWheel(FilterWheelBase):
         Sets the filter wheel to the Empty-Alignment position and then closes the port.
         """
         pass
+
+    def __del__(self):
+        """Delete the SyntheticFilterWheel."""
+        pass

--- a/src/navigate/model/devices/galvo/ni.py
+++ b/src/navigate/model/devices/galvo/ni.py
@@ -32,6 +32,7 @@
 
 #  Standard Library Imports
 import logging
+import traceback
 from typing import Any, Dict
 
 # Third Party Imports
@@ -129,5 +130,9 @@ class GalvoNI(GalvoBase):
             task.write([0], auto_start=True)
             task.stop()
             task.close()
-        except Exception as e:
-            print(f"Galvo turn_off error: {e}")
+        except Exception:
+            logger.exception(f"Error stopping task: {traceback.format_exc()}")
+
+    def __del__(self):
+        """Close the GalvoNI at exit."""
+        self.turn_off()

--- a/src/navigate/model/devices/lasers/ni.py
+++ b/src/navigate/model/devices/lasers/ni.py
@@ -32,6 +32,7 @@
 
 # Standard Library Imports
 import logging
+import traceback
 from typing import Any, Dict
 
 # Third Party Imports
@@ -234,3 +235,17 @@ class LaserNI(LaserBase):
                 self.laser_do_task.close()
         except DaqError as e:
             logger.exception(e)
+
+    def __del__(self):
+        """Delete the NI Task before exit."""
+        if self.laser_ao_task:
+            try:
+                self.laser_ao_task.close()
+            except Exception as e:
+                logger.exception(f"Error stopping task: {traceback.format_exc()}")
+
+        if self.laser_do_task:
+            try:
+                self.laser_do_task.close()
+            except Exception as e:
+                logger.exception(f"Error stopping task: {traceback.format_exc()}")

--- a/src/navigate/model/devices/mirrors/base.py
+++ b/src/navigate/model/devices/mirrors/base.py
@@ -57,7 +57,7 @@ class MirrorBase:
             Name of microscope in configuration
         device_connection : object
             Hardware device to connect to
-        configuration : multiprocesing.managers.DictProxy
+        configuration : multiprocessing.managers.DictProxy
             Global configuration of the microscope
         """
         if microscope_name not in configuration["configuration"]["microscopes"].keys():
@@ -81,3 +81,7 @@ class MirrorBase:
     def __str__(self):
         """Return the string representation of the mirror."""
         return "MirrorBase"
+
+    def __del__(self) -> None:
+        """Delete the MirrorBase class."""
+        pass

--- a/src/navigate/model/devices/mirrors/imop.py
+++ b/src/navigate/model/devices/mirrors/imop.py
@@ -73,6 +73,10 @@ class ImagineOpticsMirror(MirrorBase):
         # flatten the mirror
         self.flat()
 
+    def __del__(self) -> None:
+        """Delete the ImagineOpticsMirror class."""
+        pass
+
     def flat(self):
         """Move the mirror to the flat position."""
         self.mirror_controller.flat()

--- a/src/navigate/model/devices/mirrors/synthetic.py
+++ b/src/navigate/model/devices/mirrors/synthetic.py
@@ -65,6 +65,10 @@ class SyntheticMirror(MirrorBase):
         #: bool: Is this a synthetic mirror?
         self.is_synthetic = True
 
-    def flat(self):
+    def flat(self) -> None:
         """Flat the mirror."""
+        pass
+
+    def __del__(self) -> None:
+        """Delete the object."""
         pass

--- a/src/navigate/model/devices/remote_focus/equipment_solutions.py
+++ b/src/navigate/model/devices/remote_focus/equipment_solutions.py
@@ -149,9 +149,11 @@ class RemoteFocusEquipmentSolutions(RemoteFocusNI):
 
     def __del__(self):
         """Close the RemoteFocusEquipmentSolutions Class"""
-        logger.debug("Closing RemoteFocusEquipmentSolutions Serial Port")
-        self.close_connection()
-
+        try:
+            self.send_command("k0\r")
+            self.serial.close()
+        except Exception:
+            pass
     def read_bytes(self, num_bytes: int) -> bytes:
         """Read the specified number of bytes from RemoteFocusEquipmentSolutions.
 
@@ -222,13 +224,6 @@ class RemoteFocusEquipmentSolutions(RemoteFocusNI):
                 "Error in communicating with Voice Coil via COMPORT", self.comport
             )
 
-    def close_connection(self):
-        """Close RemoteFocusEquipmentSolutions class"""
-        try:
-            self.send_command("k0\r")
-            self.serial.close()
-        except Exception:
-            pass
 
 
 if __name__ == "__main__":

--- a/src/navigate/model/devices/remote_focus/ni.py
+++ b/src/navigate/model/devices/remote_focus/ni.py
@@ -80,6 +80,12 @@ class RemoteFocusNI(RemoteFocusBase):
         #: str: The board name.
         self.board_name = self.device_config["hardware"]["channel"].split("/")[0]
 
+    def __del__(self):
+        """Delete the RemoteFocusNI object.
+
+        Deletion of the NIDAQ task is handled by the NIDAQ object."""
+        pass
+
     def adjust(self, exposure_times, sweep_times, offset=None):
         """Adjust the waveform.
 

--- a/src/navigate/model/devices/shutter/ni.py
+++ b/src/navigate/model/devices/shutter/ni.py
@@ -32,6 +32,7 @@
 
 # Standard Library Imports
 import logging
+import traceback
 from typing import Any, Dict
 
 # Third Party Imports
@@ -88,7 +89,13 @@ class ShutterTTL(ShutterBase):
 
     def __del__(self):
         """Close the ShutterTTL at exit."""
-        self.shutter_task.close()
+        if self.shutter_task:
+            try:
+                self.shutter_task.stop()
+                self.shutter_task.close()
+            except Exception:
+                logger.exception(f"Error stopping task: {traceback.format_exc()}")
+
 
     def open_shutter(self):
         """Open the shutter"""

--- a/src/navigate/model/devices/stages/asi_MSTwoThousand.py
+++ b/src/navigate/model/devices/stages/asi_MSTwoThousand.py
@@ -169,14 +169,14 @@ class ASIStage(StageBase):
             # Speed optimizations - Set speed to 90% of maximum on each axis
             self.set_speed(percent=0.9)
 
-    def __del__(self):
+    def __del__(self) -> None:
         """Delete the ASI Stage connection."""
         try:
             if self.ms2000_controller is not None:
                 self.ms2000_controller.disconnect_from_serial()
                 logger.debug("ASI stage connection closed")
         except (AttributeError, BaseException) as e:
-            logger.error("ASI Stage Exception", e)
+            logger.exception("ASI Stage Exception", e)
             raise e
 
     def get_axis_position(self, axis):

--- a/src/navigate/model/devices/stages/base.py
+++ b/src/navigate/model/devices/stages/base.py
@@ -121,6 +121,10 @@ class StageBase:
         #: bool: Whether the stage has limits enabled or not. Default is True.
         self.stage_limits = True
 
+    def __del__(self):
+        """Destructor for the StageBase class."""
+        pass
+
     def __str__(self):
         """Return a string representation of the stage."""
         return "StageBase"

--- a/src/navigate/model/devices/stages/mcl.py
+++ b/src/navigate/model/devices/stages/mcl.py
@@ -81,8 +81,8 @@ class MCLStage(StageBase):
         ----------
         microscope_name : str
             Name of the microscope.
-        device_connection : dict
-            Dictionary containing the connection information for the device.
+        device_connection : mcl_controller
+            Communication object for the stage.
         configuration : dict
             Dictionary containing the configuration information for the device.
         device_id : int
@@ -94,7 +94,8 @@ class MCLStage(StageBase):
 
         # Mapping from self.axes to corresponding MCL channels
         if device_connection is not None:
-            #: object: MCL controller object.
+
+            #: mcl_controller: MCL controller object.
             self.mcl_controller = device_connection["controller"]
 
             #: int: MCL handle.

--- a/src/navigate/model/devices/stages/mcl.py
+++ b/src/navigate/model/devices/stages/mcl.py
@@ -109,6 +109,13 @@ class MCLStage(StageBase):
                 axis: axes_mapping[axis] for axis in self.axes if axis in axes_mapping
             }
 
+    def __del__(self):
+        """Close the connection to the stage."""
+        try:
+            self.mcl_controller.MCL_ReleaseHandle(self.handle)
+        except self.mcl_controller.MadlibError as e:
+            logger.exception(f"{e}")
+
     def report_position(self):
         """Report the position of the stage.
 

--- a/src/navigate/model/devices/stages/ni.py
+++ b/src/navigate/model/devices/stages/ni.py
@@ -32,6 +32,7 @@
 
 # Standard Library Imports
 import logging
+import traceback
 from multiprocessing.managers import ListProxy
 import time
 from typing import Any, Dict
@@ -322,3 +323,12 @@ class GalvoNIStage(StageBase):
             self.ao_task.stop()
             self.ao_task.close()
             self.ao_task = None
+
+    def close(self) -> None:
+        """Close the Galvo stage."""
+        if self.ao_task:
+            try:
+                self.ao_task.stop()
+                self.ao_task.close()
+            except Exception:
+                logger.exception(f"Error stopping task: {traceback.format_exc()}")

--- a/src/navigate/model/devices/stages/ni.py
+++ b/src/navigate/model/devices/stages/ni.py
@@ -332,3 +332,7 @@ class GalvoNIStage(StageBase):
                 self.ao_task.close()
             except Exception:
                 logger.exception(f"Error stopping task: {traceback.format_exc()}")
+
+    def __del__(self) -> None:
+        """Close the Galvo stage."""
+        self.close()

--- a/src/navigate/model/devices/stages/pi.py
+++ b/src/navigate/model/devices/stages/pi.py
@@ -136,7 +136,7 @@ class PIStage(StageBase):
         #: list: List of PI axes available.
         self.pi_axes = list(self.axes_mapping.values())
 
-    def __del__(self):
+    def __del__(self) -> None:
         """Delete the PI Connection
 
         Raises
@@ -147,10 +147,11 @@ class PIStage(StageBase):
         try:
             if hasattr(self, "pi_device"):
                 self.stop()
+                self.pi_device.CloseConnection()
             logger.debug("PI connection closed")
-        except (AttributeError, GCSError) as e:  # except BaseException:
+        except (AttributeError, GCSError) as e:
             print("Error while disconnecting the PI stage")
-            logger.error(f"Error while disconnecting the PI stage - {e}")
+            logger.exception(f"Error while disconnecting the PI stage - {e}")
             raise e
 
     def report_position(self):

--- a/src/navigate/model/devices/stages/synthetic.py
+++ b/src/navigate/model/devices/stages/synthetic.py
@@ -79,6 +79,10 @@ class SyntheticStage(StageBase):
         self.volts_per_micron = "0.1 * x"
         self.camera_delay = 0.01
 
+    def __del__(self) -> None:
+        """Destructor."""
+        pass
+
     def report_position(self):
         """Report the current position of the stage.
 

--- a/src/navigate/model/devices/stages/tl_kcube_inertial.py
+++ b/src/navigate/model/devices/stages/tl_kcube_inertial.py
@@ -111,7 +111,7 @@ class TLKIMStage(StageBase):
         self.kim_axes = list(self.axes_mapping.values())
 
         if device_connection is not None:
-            #: object: Thorlabs KIM Stage controller
+            #: navigate.model.devices.APIs.thorlabs.kcube_inertial: Thorlabs KIM Stage
             self.kim_controller = device_connection
 
         device_config = configuration["configuration"]["microscopes"][microscope_name][
@@ -128,8 +128,8 @@ class TLKIMStage(StageBase):
         try:
             self.stop()
             self.kim_controller.KIM_Close(self.serial_number)
-        except AttributeError:
-            pass
+        except Exception as e:
+            logger.exception(e)
 
     def report_position(self):
         """Report the position of the stage.

--- a/src/navigate/model/devices/stages/tl_kcube_steppermotor.py
+++ b/src/navigate/model/devices/stages/tl_kcube_steppermotor.py
@@ -151,8 +151,8 @@ class TLKSTStage(StageBase):
         try:
             self.stop()
             self.kst_controller.KST_Close(self.serial_number)
-        except AttributeError:
-            pass
+        except Exception as e:
+            logger.exception(e)
 
     def report_position(self):
         """

--- a/src/navigate/model/devices/zoom/base.py
+++ b/src/navigate/model/devices/zoom/base.py
@@ -72,7 +72,11 @@ class ZoomBase:
         #: float: the desired zoom setting
         self.zoomvalue = None
 
-    def __str__(self):
+    def __del__(self) -> None:
+        """Delete the ZoomBase object."""
+        pass
+
+    def __str__(self) -> str:
         """Return the string representation of the ZoomBase object."""
         return "ZoomBase"
 

--- a/src/navigate/model/devices/zoom/dynamixel.py
+++ b/src/navigate/model/devices/zoom/dynamixel.py
@@ -143,7 +143,10 @@ class DynamixelZoom(ZoomBase):
 
     def __del__(self):
         """Delete the DynamixelZoom Instance"""
-        self.dynamixel.closePort(self.port_num)
+        try:
+            self.dynamixel.closePort(self.port_num)
+        except Exception as e:
+            logger.exception(e)
 
     def set_zoom(self, zoom, wait_until_done=False):
         """Change the DynamixelZoom Servo.

--- a/src/navigate/model/microscope.py
+++ b/src/navigate/model/microscope.py
@@ -988,27 +988,30 @@ class Microscope:
     def terminate(self) -> None:
         """Close hardware explicitly."""
 
+        # TODO: I get a DCAM warning if I call the __del__ method.
         self.camera.close_camera()
+
         del self.daq
 
-        for key in list(self.lasers.keys()):
-            del self.lasers[key]
+        for key in list(self.filter_wheel.keys()):
+            del self.filter_wheel[key]
 
         for key in list(self.galvo.keys()):
             del self.galvo[key]
 
-        # filter wheels too?
+        for key in list(self.lasers.keys()):
+            del self.lasers[key]
 
-        del self.shutter
+        # mirrors?
 
         del self.remote_focus_device
 
-        try:
-            for stage, _ in self.stages_list:
-                stage.close()
-        except Exception as e:
-            print(f"Stage delete failure: {e}")
-        pass
+        del self.shutter
+
+        for stage, _ in self.stages_list:
+            del stage
+
+        # zoom?
 
     def run_command(self, command: str, *args) -> None:
         """Run command.

--- a/src/navigate/model/microscope.py
+++ b/src/navigate/model/microscope.py
@@ -99,11 +99,17 @@ class Microscope:
         #: obj: Camera object.
         self.camera = None
 
+        #: Any: Shutter device.
+        self.shutter = None
+
         #: dict: Dictionary of lasers.
         self.lasers = {}
 
         #: dict: Dictionary of galvanometers.
         self.galvo = {}
+
+        #: Any: Remote focus device.
+        self.remote_focus_device = None
 
         #: dict: Dictionary of filter_wheels
         self.filter_wheel = {}
@@ -981,16 +987,21 @@ class Microscope:
 
     def terminate(self) -> None:
         """Close hardware explicitly."""
+
         self.camera.close_camera()
+        del self.daq
 
-        for k in self.galvo:
-            self.galvo[k].turn_off()
+        for key in list(self.lasers.keys()):
+            del self.lasers[key]
 
-        try:
-            # Currently only for RemoteFocusEquipmentSolutions
-            self.remote_focus_device.close_connection()
-        except AttributeError:
-            pass
+        for key in list(self.galvo.keys()):
+            del self.galvo[key]
+
+        # filter wheels too?
+
+        del self.shutter
+
+        del self.remote_focus_device
 
         try:
             for stage, _ in self.stages_list:

--- a/src/navigate/model/microscope.py
+++ b/src/navigate/model/microscope.py
@@ -1054,12 +1054,14 @@ class Microscope:
             self.info[device_name] = device_ref_name
 
     def terminate(self) -> None:
-        """Close hardware explicitly."""
+        """Close hardware explicitly.
 
-        # TODO: I get a DCAM warning if I call the __del__ method.
-        self.camera.close_camera()
+        Closes all devices other than plugin devices and deformable mirrors.
+        """
 
-        del self.daq
+        for device in [self.camera, self.daq, self.remote_focus_device,
+                       self.shutter, self.zoom]:
+            del device
 
         for key in list(self.filter_wheel.keys()):
             del self.filter_wheel[key]
@@ -1070,16 +1072,8 @@ class Microscope:
         for key in list(self.lasers.keys()):
             del self.lasers[key]
 
-        # mirrors?
-
-        del self.remote_focus_device
-
-        del self.shutter
-
         for stage, _ in self.stages_list:
             del stage
-
-        # zoom?
 
     def run_command(self, command: str, *args) -> None:
         """Run command.

--- a/test/model/devices/filter_wheel/test_sutter.py
+++ b/test/model/devices/filter_wheel/test_sutter.py
@@ -167,7 +167,7 @@ class TestSutterFilterWheel(unittest.TestCase):
 
     def test_exit(self):
         self.mock_device_connection.reset_mock()
-        self.filter_wheel.__exit__()
+        del self.filter_wheel
         self.mock_device_connection.close.assert_called()
 
 


### PR DESCRIPTION
Tried to create a more uniform way for closing tasks so that our console isn't cluttered upon exit.

There remains one traceback from the threading library.

If we replace `raise SystemExit()` with `os._exit(1)` in the following code this is eliminated completely:

```
        if event == "exception":
            if os.getenv("GITHUB_ACTIONS") == "true":
                return

            # Silence traceback to avoid printing to console.
            sys.tracebacklimit = 0
            raise SystemExit()
        return self.localtrace
```

I was hesitant to make this change because this method apparently does not invoke the normal Python cleanup routines (like flushing I/O buffers, calling finally blocks, etc.).
