### PR TITLE
Speedup Histogram - Small Bug Fix

### DIFF
--- a/src/navigate/controller/sub_controllers/camera_view.py
+++ b/src/navigate/controller/sub_controllers/camera_view.py
@@ -1470,7 +1470,10 @@ class MIPViewController(BaseViewController):
         self.render_widgets["perspective"].set("XY")
 
         self.get_selected_channels()
-        self.render_widgets["channel"].set(self.selected_channels[0])
+        if isinstance(
+                self.selected_channels, list) and len(
+            self.selected_channels) > 0:
+            self.render_widgets["channel"].set(self.selected_channels[0])
 
         # event binding
         self.render_widgets["perspective"].get_variable().trace_add(
@@ -1564,7 +1567,10 @@ class MIPViewController(BaseViewController):
             Camera parameters.
         """
         super().initialize_non_live_display(microscope_state, camera_parameters)
-        self.render_widgets["channel"].set(self.selected_channels[0])
+        if isinstance(
+                self.selected_channels, list) and len(
+            self.selected_channels) > 0:
+            self.render_widgets["channel"].set(self.selected_channels[0])
         self.perspective = self.render_widgets["perspective"].get()
         self.XY_image_width = self.original_image_width
         self.XY_image_height = self.original_image_height

--- a/src/navigate/controller/sub_controllers/camera_view.py
+++ b/src/navigate/controller/sub_controllers/camera_view.py
@@ -1470,9 +1470,7 @@ class MIPViewController(BaseViewController):
         self.render_widgets["perspective"].set("XY")
 
         self.get_selected_channels()
-        if isinstance(
-                self.selected_channels, list) and len(
-            self.selected_channels) > 0:
+        if isinstance(self.selected_channels, list) and len(self.selected_channels) > 0:
             self.render_widgets["channel"].set(self.selected_channels[0])
 
         # event binding
@@ -1567,9 +1565,7 @@ class MIPViewController(BaseViewController):
             Camera parameters.
         """
         super().initialize_non_live_display(microscope_state, camera_parameters)
-        if isinstance(
-                self.selected_channels, list) and len(
-            self.selected_channels) > 0:
+        if isinstance(self.selected_channels, list) and len(self.selected_channels) > 0:
             self.render_widgets["channel"].set(self.selected_channels[0])
         self.perspective = self.render_widgets["perspective"].get()
         self.XY_image_width = self.original_image_width

--- a/src/navigate/controller/sub_controllers/histogram.py
+++ b/src/navigate/controller/sub_controllers/histogram.py
@@ -146,14 +146,16 @@ class HistogramController:
         image : SharedNDArray
             Image data
         """
+        down_sampling_constant = 8
         data = image.flatten()
+        data = data[::down_sampling_constant]
         self.ax.cla()
         counts, _, _ = self.ax.hist(data, bins=20, color="black", rwidth=1)
 
         x_maximum = np.max(data) + np.std(data)
         x_minimum = np.min(data) - np.std(data)
         x_minimum = 1 if x_minimum < 1 else x_minimum
-        y_maximum = 10**6
+        y_maximum = 10**6 // down_sampling_constant
 
         self.ax.set_xlim(x_minimum, x_maximum)
         self.ax.set_ylim(1, y_maximum)


### PR DESCRIPTION
To accelerate the histogram, which some have complained causes the program to be laggy, I now only use 1/8th of the data coming off the camera to create the histogram. Seems fairly responsive on BT-MesoSPIM.

Also, @samcal06 found that if no channel settings are selected in the GUI, and we start up the software, setting the selected channel in the render_widgets of the camera_view controllers throws an error.