### PR TITLE
Handle absence of Git

### DIFF
--- a/src/navigate/_commit.py
+++ b/src/navigate/_commit.py
@@ -56,6 +56,7 @@ def get_git_revision_hash() -> str:
     file_directory = os.path.abspath(os.path.dirname(__file__))
     os.chdir(file_directory)
 
+    commit_hash = None
     try:
         is_git_repo = (
             subprocess.check_output(
@@ -70,10 +71,12 @@ def get_git_revision_hash() -> str:
                 .decode("ascii")
                 .strip()
             )
-        else:
-            commit_hash = None
     except subprocess.CalledProcessError:
-        commit_hash = None
+        # CalledProcessError: Command '['git', 'rev-parse', 'HEAD']' returned non-zero exit status.
+        pass
+    except FileNotFoundError:
+        # FileNotFoundError: [WinError 2] The system cannot find the file specified.
+        pass
 
     os.chdir(working_directory)
     return commit_hash

--- a/src/navigate/controller/controller.py
+++ b/src/navigate/controller/controller.py
@@ -75,6 +75,7 @@ from navigate.model.model import Model
 from navigate.model.concurrency.concurrency_tools import ObjectInSubprocess
 
 # Misc. Local Imports
+from navigate._commit import get_git_revision_hash, get_version_from_file
 from navigate.config.config import (
     load_configs,
     update_config_dict,
@@ -146,6 +147,9 @@ class Controller:
             Command line input arguments for non-default
             file paths or using synthetic hardware modes.
         """
+        logger.info(f"Navigate GIT Hash: {get_git_revision_hash()}")
+        logger.info(f"Navigate Version: {get_version_from_file()}")
+
         #: Tk top-level widget: Tk.tk GUI instance.
         self.root = root
 


### PR DESCRIPTION
When git has not be installed on the computer, we get a FileNotFoundError. Added an exception to handle this case, and also now log the get hash and navigate version number from the controller. Initially tried to do this from an __init__ file, which calls the _commit.py file, but I think this takes place before the logger is set up and therefore, of course, it does not log.