### PR TITLE
MS2000 controller error code bug fix

### DIFF
--- a/src/navigate/model/devices/APIs/asi/asi_MS2000_controller.py
+++ b/src/navigate/model/devices/APIs/asi/asi_MS2000_controller.py
@@ -84,7 +84,11 @@ class MS2000Exception(Exception):
         self.code = code
 
         #: str: Error message
-        self.message = self.error_codes[code]
+        try:
+            self.message = self.error_codes[code]
+        except KeyError:
+            # if the exception is not a standard ASI Error Code:
+            self.message = code
 
         # Gets the proper message based on error code received.
         super().__init__(self.message)
@@ -371,10 +375,12 @@ class MS2000Controller:
         self.safe_to_write.set()
         response = response.decode(encoding="ascii")
         # Remove leading and trailing empty spaces
-        self.report_to_console(f"Received Response: {response.strip()}")
+        response = response.strip()
+        self.report_to_console(f"Received Response: {response}")
         if response.startswith(":N"):
-            logger.error(f"Incorrect response received: {response}")
-            raise MS2000Exception(response)
+            if not response.endswith("-21"): # we can ignore HALT command exceptions
+                logger.error(f"Incorrect response received: {response}")
+                raise MS2000Exception(response)
 
         return response  # in case we want to read the response
 


### PR DESCRIPTION
Small bug whereby "\n\r" was not being properly stripped from "response", and HALT command ":N-21" was being thrown when moving, causing the stage to stop. Solution was to strip properly and ignore the HALT command.