### PR TITLE
Ensure all scales >0

### DIFF
--- a/src/navigate/model/metadata_sources/zarr_metadata.py
+++ b/src/navigate/model/metadata_sources/zarr_metadata.py
@@ -135,8 +135,8 @@ class OMEZarrMetadata(Metadata):
             The scale of the dataset.
         """
         return [
-            self.dt,
-            self.dc,
+            1,  # t
+            1,  # c
             self.dz * subdiv[2],
             self.dy * subdiv[1],
             self.dx * subdiv[0],


### PR DESCRIPTION
OME-Zarr is out of spec when `self.dt = 0`. Since we never downsample in time, leave permanently at 1.