### PR TITLE
add rising ramp percentage setting to galvo waveform

### DIFF
--- a/src/navigate/config/config.py
+++ b/src/navigate/config/config.py
@@ -823,6 +823,12 @@ def verify_waveform_constants(manager, configuration):
             ):
                 update_config_dict(manager, waveform_dict, microscope_name, {})
 
+            galvo_config = {
+                "amplitude": "0",
+                "offset": 0,
+                "rising_ramp": 50,
+                "frequency": 10,
+            }
             for zoom in config_dict["zoom"]["position"].keys():
                 if (
                     zoom not in waveform_dict[microscope_name].keys()
@@ -832,18 +838,14 @@ def verify_waveform_constants(manager, configuration):
                         manager,
                         waveform_dict[microscope_name],
                         zoom,
-                        {
-                            "amplitude": "0",
-                            "offset": 0,
-                            "frequency": 10,
-                        },
+                        galvo_config,
                     )
                 else:
-                    for k in ["amplitude", "offset", "frequency"]:
+                    for k in galvo_config.keys():
                         if k not in waveform_dict[microscope_name][zoom].keys():
                             waveform_dict[microscope_name][zoom][k] = config_dict[
                                 "galvo"
-                            ][i].get(k, "0")
+                            ][i].get(k, galvo_config[k])
                         else:
                             try:
                                 float(waveform_dict[microscope_name][zoom][k])

--- a/src/navigate/controller/sub_controllers/waveform_popup.py
+++ b/src/navigate/controller/sub_controllers/waveform_popup.py
@@ -165,6 +165,9 @@ class WaveformPopupController(GUIController):
             self.variables[galvo + " Off"].trace_add(
                 "write", self.update_galvo_setting(galvo, " Off", "offset")
             )
+            self.variables[galvo + " Rising"].trace_add(
+                "write", self.update_galvo_setting(galvo, " Rising", "rising_ramp")
+            )
             self.variables[galvo + " Freq"].trace_add(
                 "write", self.update_galvo_setting(galvo, " Freq", "frequency")
             )
@@ -414,6 +417,9 @@ class WaveformPopupController(GUIController):
             )
             self.variables[galvo + " Off"].set(
                 self.galvo_setting[galvo][self.resolution][self.mag].get("offset", 0)
+            )
+            self.variables[galvo + " Rising"].set(
+                self.galvo_setting[galvo][self.resolution][self.mag].get("rising_ramp", 50)
             )
             self.variables[galvo + " Freq"].set(
                 self.galvo_setting[galvo][self.resolution][self.mag].get("frequency", 0)
@@ -690,7 +696,7 @@ class WaveformPopupController(GUIController):
                     value = float(variable_value)
                 except ValueError:
                     return
-                if "Freq" not in widget_name and (
+                if ("Amp" in widget_name or "Off" in widget_name) and (
                     value < self.galvo_min[galvo_name]
                     or value > self.galvo_max[galvo_name]
                 ):
@@ -983,6 +989,10 @@ class WaveformPopupController(GUIController):
                 self.galvo_setting[galvo_name][self.resolution][self.mag][factor_name][
                     parameter_name
                 ] = value
+
+            logger.debug(
+                f"Galvo parameter {factor_name}.{parameter_name} changed: {value} for {galvo_name}"
+            )
 
             self.event_id = self.view.popup.after(
                 500,

--- a/src/navigate/model/devices/galvo/base.py
+++ b/src/navigate/model/devices/galvo/base.py
@@ -170,6 +170,7 @@ class GalvoBase:
                 try:
                     galvo_amplitude = float(galvo_parameters.get("amplitude", 0))
                     galvo_offset = float(galvo_parameters.get("offset", 0))
+                    galvo_rising_ramp = float(galvo_parameters.get("rising_ramp", 50))
                     galvo_frequency = (
                         float(galvo_parameters.get("frequency", 0)) / exposure_time
                     )
@@ -203,6 +204,7 @@ class GalvoBase:
                         frequency=galvo_frequency,
                         amplitude=galvo_amplitude,
                         offset=galvo_offset,
+                        duty_cycle=galvo_rising_ramp,
                         phase=self.camera_delay,
                     )
                 elif self.galvo_waveform == "sine":

--- a/src/navigate/view/popups/waveform_parameter_popup_window.py
+++ b/src/navigate/view/popups/waveform_parameter_popup_window.py
@@ -199,7 +199,7 @@ class WaveformParameterPopupWindow:
             map(lambda i: f"Galvo {i}", range(self.configuration_controller.galvo_num))
         )
 
-        title_labels = ["Galvo", "Amplitude", "Offset", "Frequency"]
+        title_labels = ["Galvo", "Amplitude", "Offset", "Rising Ramp(%)", "Frequency"]
         # Loop for widgets
         for i in range(len(title_labels)):
             # Title labels
@@ -235,6 +235,17 @@ class WaveformParameterPopupWindow:
                 row=i + 1, column=2, sticky=tk.NSEW, pady=(10, 0), padx=(0, 5)
             )
 
+            self.inputs[galvo_labels[i] + " Rising"] = LabelInput(
+                parent=self.galvo_frame,
+                input_class=ValidatedSpinbox,
+                input_var=tk.StringVar(),
+                input_args={"from_": 0, "to": 100, "increment": 1}
+            )
+
+            self.inputs[galvo_labels[i] + " Rising"].grid(
+                row=i + 1, column=3, sticky=tk.NSEW, pady=(10, 0), padx=(0, 5)
+            )
+
             self.inputs[galvo_labels[i] + " Freq"] = LabelInput(
                 parent=self.galvo_frame,
                 input_class=ValidatedSpinbox,
@@ -243,7 +254,7 @@ class WaveformParameterPopupWindow:
             )
 
             self.inputs[galvo_labels[i] + " Freq"].grid(
-                row=i + 1, column=3, sticky=tk.NSEW, pady=(10, 0), padx=(0, 5)
+                row=i + 1, column=4, sticky=tk.NSEW, pady=(10, 0), padx=(0, 5)
             )
 
             # Button for automatic estimate of galvo frequency
@@ -252,7 +263,7 @@ class WaveformParameterPopupWindow:
             )
 
             self.buttons[galvo_labels[i] + " Freq"].grid(
-                row=i + 1, column=4, sticky=tk.NE, pady=(10, 0)
+                row=i + 1, column=5, sticky=tk.NE, pady=(10, 0)
             )
 
         self.inputs["galvo_info"] = LabelInput(
@@ -273,7 +284,7 @@ class WaveformParameterPopupWindow:
         )
         self.inputs["all_channels"].grid(
             row=len(galvo_labels) + 1,
-            column=2,
+            column=3,
             columnspan=2,
             sticky=tk.NE,
             pady=(10, 0),
@@ -286,7 +297,7 @@ class WaveformParameterPopupWindow:
         )
         self.buttons["advanced_galvo_setting"].grid(
             row=len(galvo_labels) + 1,
-            column=4,
+            column=5,
             sticky=tk.NSEW,
             pady=(10, 0),
         )


### PR DESCRIPTION
Ted asked about setting an asymmetric Galvo sawtooth waveform. In response, I added a new waveform setting option that allows users to specify the percentage of the rising ramp duration.

By default, the rising ramp occupies 50% of the duration, as shown in the graph below.
![Screenshot 2025-03-04 at 3 00 32 PM](https://github.com/user-attachments/assets/66d4aca9-8c2a-46f3-8aef-ee9ca2b19326)

The rising ramp percentage setting and the resulting waveform are shown below.
![Screenshot 2025-03-04 at 2 59 43 PM](https://github.com/user-attachments/assets/c7b9a3bb-6acb-49be-b7eb-ee00e5652097)
![Screenshot 2025-03-04 at 3 00 14 PM](https://github.com/user-attachments/assets/c1cbda6d-deb7-40f9-9e1b-6b2b3f40a82f)
