### PR TITLE
Fix missing filter wheel id

### DIFF
--- a/src/navigate/model/devices/filter_wheel/asi.py
+++ b/src/navigate/model/devices/filter_wheel/asi.py
@@ -72,7 +72,7 @@ class ASIFilterWheel(FilterWheelBase, SerialDevice):
             The ID of the device. Default is 0.
         """
 
-        super().__init__(microscope_name, device_connection, configuration)
+        super().__init__(microscope_name, device_connection, configuration, device_id)
 
         #: float: Delay for filter wheel to change positions.
         self.wait_until_done_delay = self.device_config["filter_wheel_delay"]

--- a/src/navigate/model/devices/filter_wheel/ludl.py
+++ b/src/navigate/model/devices/filter_wheel/ludl.py
@@ -76,7 +76,7 @@ class LUDLFilterWheel(FilterWheelBase, SerialDevice):
             The ID of the device. Default is 0.
         """
 
-        super().__init__(microscope_name, device_connection, configuration)
+        super().__init__(microscope_name, device_connection, configuration, device_id)
 
         #: io.TextIOWrapper: Text I/O wrapper for the serial port.
         self.sio = io.TextIOWrapper(io.BufferedRWPair(self.serial, self.serial))

--- a/src/navigate/model/devices/filter_wheel/ni.py
+++ b/src/navigate/model/devices/filter_wheel/ni.py
@@ -69,7 +69,7 @@ class NIFilterWheel(FilterWheelBase, NIDevice):
             The ID of the device. Default is 0.
         """
 
-        super().__init__(microscope_name, device_connection, configuration)
+        super().__init__(microscope_name, device_connection, configuration, device_id)
 
         #: float: Delay for filter wheel to change positions.
         self.wait_until_done_delay = self.device_config["filter_wheel_delay"]

--- a/src/navigate/model/devices/filter_wheel/sutter.py
+++ b/src/navigate/model/devices/filter_wheel/sutter.py
@@ -72,7 +72,7 @@ class SutterFilterWheel(FilterWheelBase, SerialDevice):
         device_id : int
             The ID of the device. Default is 0.
         """
-        super().__init__(microscope_name, device_connection, configuration)
+        super().__init__(microscope_name, device_connection, configuration, device_id)
 
         #: bool: Wait until filter wheel has completed movement.
         self.wait_until_done = True

--- a/src/navigate/model/devices/filter_wheel/synthetic.py
+++ b/src/navigate/model/devices/filter_wheel/synthetic.py
@@ -61,7 +61,7 @@ class SyntheticFilterWheel(FilterWheelBase):
         device_id : int
             The ID of the device. Default is 0.
         """
-        super().__init__(microscope_name, device_connection, configuration)
+        super().__init__(microscope_name, device_connection, configuration, device_id)
 
 
     def __str__(self):


### PR DESCRIPTION
If the device id is not provided when creating the filter wheel object, errors may occur when multiple filter wheel devices or wheel number are present. This PR fix this issue.