### PR TITLE
fix: properly close and unlink shared memory on macOS

### DIFF
--- a/src/navigate/controller/controller.py
+++ b/src/navigate/controller/controller.py
@@ -380,6 +380,9 @@ class Controller:
         if img_width == self.img_width and img_height == self.img_height:
             return
 
+        if self.data_buffer is not None:
+            for i in range(len(self.data_buffer)):
+                self.data_buffer[i].shared_memory.close()
         self.data_buffer = self.model.get_data_buffer(img_width, img_height)
         self.img_width = img_width
         self.img_height = img_height

--- a/src/navigate/model/concurrency/concurrency_tools.py
+++ b/src/navigate/model/concurrency/concurrency_tools.py
@@ -114,7 +114,7 @@ class SharedNDArray(np.ndarray):
         obj.shared_memory = shm
         obj.offset = offset
         if must_unlink:
-            weakref.finalize(obj, shm.unlink)
+            weakref.finalize(obj, obj.__clean_up_shm)
         return obj
 
     def __array_finalize__(self, obj):
@@ -162,6 +162,13 @@ class SharedNDArray(np.ndarray):
             None,
         )
         return SharedNDArray, args
+    
+    def __clean_up_shm(self):
+        try:
+            self.shared_memory.close()
+            self.shared_memory.unlink()
+        except Exception:
+            pass
 
 
 class ResultThread(threading.Thread):

--- a/src/navigate/model/concurrency/concurrency_tools.py
+++ b/src/navigate/model/concurrency/concurrency_tools.py
@@ -114,7 +114,7 @@ class SharedNDArray(np.ndarray):
         obj.shared_memory = shm
         obj.offset = offset
         if must_unlink:
-            weakref.finalize(obj, obj.__clean_up_shm)
+            weakref.finalize(obj, cls.__clean_up_shm, cls, shm)
         return obj
 
     def __array_finalize__(self, obj):
@@ -163,10 +163,10 @@ class SharedNDArray(np.ndarray):
         )
         return SharedNDArray, args
     
-    def __clean_up_shm(self):
+    def __clean_up_shm(cls, shm):
         try:
-            self.shared_memory.close()
-            self.shared_memory.unlink()
+            shm.close()
+            shm.unlink()
         except Exception:
             pass
 

--- a/src/navigate/model/model.py
+++ b/src/navigate/model/model.py
@@ -266,6 +266,10 @@ class Model:
         ]
         self.update_data_buffer(self.img_width, self.img_height)
 
+        self.data_buffer_positions = SharedNDArray(
+            shape=(self.number_of_frames, 5), dtype=float
+        )  # x, y, z, theta, f
+
         # Image Writer/Save functionality
         #: ImageWriter: Image writer.
         self.image_writer = None
@@ -409,13 +413,16 @@ class Model:
         """
         self.img_width = img_width
         self.img_height = img_height
+        if self.data_buffer is not None:
+            for i in range(self.number_of_frames):
+                self.data_buffer[i].shared_memory.close()
+                self.data_buffer[i].shared_memory.unlink()
+
         self.data_buffer = [
             SharedNDArray(shape=(img_height, img_width), dtype="uint16")
             for _ in range(self.number_of_frames)
         ]
-        self.data_buffer_positions = SharedNDArray(
-            shape=(self.number_of_frames, 5), dtype=float
-        )  # z-index, x, y, z, theta, f
+
         for microscope_name in self.microscopes:
             self.microscopes[microscope_name].update_data_buffer(
                 self.data_buffer,

--- a/test/model/concurrency/test_concurrency_tools.py
+++ b/test/model/concurrency/test_concurrency_tools.py
@@ -357,9 +357,10 @@ def test_accessing_unlinked_memory_in_subprocess():
     p.store_array(a)
     p.a.sum()
     try:
-        p.a.sum()
-        del p
+        # close and unlink the memory
         del a
+        # try to access the memory
+        p.a.sum()
     except FileNotFoundError:
         pass  # we expected this error
     else:


### PR DESCRIPTION
On macOS, calling unlink() on shared memory sometimes results in a FileNotFoundError. Additionally, when modifying the ROI, the databuffer size changes, which can lead to an exception: "You tried to simultaneously open more SharedNDArrays than are allowed by your system!"

This PR ensures shared memory is properly closed before unlinking to prevent FileNotFoundError. At the same time, it properly releases memory when resizing the data buffer after an ROI change , preventing excessive open shared memory objects.