### PR TITLE
Create device connection in LUDLFilterWheel

### DIFF
--- a/src/navigate/model/devices/filter_wheel/ludl.py
+++ b/src/navigate/model/devices/filter_wheel/ludl.py
@@ -78,6 +78,9 @@ class LUDLFilterWheel(FilterWheelBase, SerialDevice):
 
         super().__init__(microscope_name, device_connection, configuration, device_id)
 
+        #: Any: Device connection object.
+        self.serial = device_connection
+
         #: io.TextIOWrapper: Text I/O wrapper for the serial port.
         self.sio = io.TextIOWrapper(io.BufferedRWPair(self.serial, self.serial))
 


### PR DESCRIPTION
There was a small bug where self.serial was never assigned. Adding this line fixed the issue.