### PR TITLE
Dynamic copyright date, default configurator file type

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,14 +13,14 @@
 import os
 import sys
 from navigate import __version__
+import datetime
 
 sys.path.insert(0, os.path.abspath("../../src"))
-
 
 # -- Project information -----------------------------------------------------
 
 project = "navigate"
-copyright = "2024, Dean Lab, UT Southwestern Medical Center"
+copyright = f"{datetime.datetime.now().year}, Dean Lab, UT Southwestern Medical Center"
 author = "Dean Lab, UT Southwestern Medical Center"
 
 # The full version, including alpha/beta/rc tags
@@ -111,8 +111,8 @@ pygments_style = "sphinx"
 
 # -- Linkcheck Options ---------------------------------------------
 linkcheck_ignore = [
-    r'http://proxy\.your_university\.edu:1234',
-    r'https://proxy\.your_university\.edu:1234'
+    r"http://proxy\.your_university\.edu:1234",
+    r"https://proxy\.your_university\.edu:1234",
 ]
 # -- LaTeX output options ----------------------------------------------------
 

--- a/src/navigate/controller/configurator.py
+++ b/src/navigate/controller/configurator.py
@@ -134,7 +134,7 @@ class Configurator:
             temp_dict[key_list[-1]] = value
 
         filename = filedialog.asksaveasfilename(
-            defaultextension=".yml", filetypes=[("Yaml file", "*.yml *.yaml")]
+            defaultextension=".yaml", filetypes=[("Yaml file", "*.yml *.yaml")]
         )
         if not filename:
             return


### PR DESCRIPTION
I have noticed some mildly tricky behavior. Our software by default searches for the configuration.yaml file, but the configurator by default saves to a configuration.yml file.

You can save a new configuration.yml file, the software will not find it, then it will automatically create a configuration.yaml file.