### PR TITLE
Investigating additional stage axes.

### DIFF
--- a/src/navigate/controller/configuration_controller.py
+++ b/src/navigate/controller/configuration_controller.py
@@ -34,6 +34,7 @@
 # Standard Library Imports
 import logging
 from multiprocessing.managers import ListProxy, DictProxy
+from typing import Any, Dict, List, Optional, Union, Iterable
 
 # Third Party Imports
 
@@ -45,18 +46,24 @@ logger = logging.getLogger(p)
 
 
 class ConfigurationController:
-    """Configuration Controller - Used to get the configuration of the microscope."""
+    """Configuration Controller - Used to query and expose microscope configuration.
 
-    def __init__(self, configuration):
-        """Initialize the Configuration Controller
+    Parameters
+    ----------
+    configuration : Dict[str, Any]
+        The shared configuration dictionary (possibly using Manager proxies).
+    """
+
+    def __init__(self, configuration: Dict[str, Any]) -> None:
+        """Initialize the Configuration Controller.
 
         Parameters
         ----------
-        configuration : dict
-            The configuration dictionary.
+        configuration : Dict[str, Any]
+            The configuration dictionary (from manager).
         """
-        #: dict: The configuration dictionary.
-        self.configuration = configuration
+        #: Dict[str, Any]: shared configuration dictionary.
+        self.configuration: Dict[str, Any] = configuration
 
         #: str: The microscope name.
         self.microscope_name = None
@@ -78,20 +85,29 @@ class ConfigurationController:
         )
 
     def change_microscope(self) -> bool:
-        """Get the new microscope configuration dict according to the name.
+        """Update to the microscope specified in the configuration.
 
-        Gets the name of the microscope, retrieves its configuration, and updates the
-        Configuration Controller's attributes.
+        Reads the 'microscope_name' key from the experiment section and
+        updates this controller's microscope_config and microscope_name.
 
         Returns
         -------
-        result: bool
+        bool
+            True if the microscope was changed; False if it remained the same.
+
+        Raises
+        ------
+        AssertionError
+            If the microscope name in the configuration is not found in the
+            configuration.yaml file.
         """
         microscope_name = self.configuration["experiment"]["MicroscopeState"][
             "microscope_name"
         ]
         assert (
-            microscope_name in self.configuration["configuration"]["microscopes"].keys()
+            microscope_name
+            in self.configuration["configuration"]["microscopes"].keys(),
+            f"Microscope {microscope_name} not found in configuration.yaml file",
         )
 
         if self.microscope_name == microscope_name:
@@ -103,28 +119,29 @@ class ConfigurationController:
         self.microscope_name = microscope_name
         return True
 
-    def get_microscope_configuration_dict(self):
-        """Return microscope configuration dictionary
+    def get_microscope_configuration_dict(self) -> DictProxy:
+        """Return the current microscope's configuration dictionary.
 
         Returns
         -------
-        microscope_configuration_dict: dict
+        DictProxy
+            The microscope-specific configuration mapping.
         """
         return self.microscope_config
 
     @property
-    def channels_info(self):
-        """Return the channels info
+    def channels_info(self) -> Dict[str, Any]:
+        """Return the channel settings.
 
-        Populate the channel combobox with the channels
-        that are available in the configuration
+        Populate the channel combobox with the channels that are available in the
+        configuration
 
         Returns
         -------
         setting : dict
             Channel settings, e.g. {
-                'laser': ['488nm', '561nm', '642nm'],
-                'filter': ['Empty-Alignment', 'GFP - FF01-515/30-32', '...}
+                'laser': ['488 nm', '561 nm', '642 nm'],
+                'filter': ['Empty-Alignment', 'GFP - FF01-515/30-32']}
         """
         if self.microscope_config is None:
             return {}
@@ -139,16 +156,16 @@ class ConfigurationController:
         return setting
 
     @property
-    def lasers_info(self):
-        """Return the lasers info
+    def lasers_info(self) -> List[str]:
+        """Return the laser information.
 
-        Populate the laser combobox with the lasers
-        that are available in the configuration
+        Populate the laser combobox with the lasers that are available in the
+        configuration
 
         Returns
         -------
         laser_list : list
-            List of lasers, e.g. ['488nm', '561nm', '642nm']
+            List of lasers, e.g. ['488 nm', '561 nm', '642 nm']
         """
         if self.microscope_config is None:
             return []
@@ -158,22 +175,20 @@ class ConfigurationController:
         ]
 
     @property
-    def camera_config_dict(self):
-        """Get camera configuration dict
+    def camera_config_dict(self) -> Optional[Dict[str, Any]]:
+        """Get camera configuration dictionary.
 
         Returns
         -------
         camera_setting: dict
-            Camera Setting, e.g. {
-
-            }
+            Camera Settings.
         """
         if self.microscope_config is not None:
             return self.microscope_config["camera"]
         return None
 
     @property
-    def camera_pixels(self):
+    def camera_pixels(self) -> List[int]:
         """Get default pixel values from camera
 
         Returns
@@ -184,6 +199,7 @@ class ConfigurationController:
             Number of y pixels
         """
         if self.microscope_config is None:
+            # Default to 2048x2048 if no config is available
             return [2048, 2048]
 
         return [
@@ -192,8 +208,8 @@ class ConfigurationController:
         ]
 
     @property
-    def stage_default_position(self):
-        """Get current position of the stage
+    def stage_default_position(self) -> Dict[str, Union[int, float]]:
+        """Get the current position of the stage.
 
         Returns
         -------
@@ -214,8 +230,8 @@ class ConfigurationController:
         return position
 
     @property
-    def stage_step(self):
-        """Get the step size of the stage
+    def stage_step(self) -> Dict[str, Union[int, float]]:
+        """Get the step size of the stage.
 
         Returns
         -------
@@ -235,8 +251,8 @@ class ConfigurationController:
             steps = {"x": 10, "y": 10, "z": 10, "theta": 10, "f": 10}
         return steps
 
-    def get_stage_position_limits(self, suffix):
-        """Return the position limits of the stage
+    def get_stage_position_limits(self, suffix: str) -> Dict[str, Union[int, float]]:
+        """Return the position limits of the stage.
 
         Parameters
         ----------
@@ -255,15 +271,17 @@ class ConfigurationController:
         if self.microscope_config is not None:
             stage_dict = self.microscope_config["stage"]
             for a in axes:
-                position_limits[a] = stage_dict.get(a + suffix, 0 if suffix == "_min" else 100)
+                position_limits[a] = stage_dict.get(
+                    a + suffix, 0 if suffix == "_min" else 100
+                )
         else:
             for a in axes:
                 position_limits[a] = 0 if suffix == "_min" else 100
         return position_limits
 
     @property
-    def stage_flip_flags(self):
-        """Return the flip flags of the stage
+    def stage_flip_flags(self) -> Dict[str, bool]:
+        """Return the flip flags of the stage.
 
         Returns
         -------
@@ -279,10 +297,10 @@ class ConfigurationController:
         for axis in self.stage_axes:
             flip_flags[axis] = stage_dict.get(f"flip_{axis}", False)
         return flip_flags
-    
+
     @property
-    def stage_axes(self):
-        """Return the axes of the stage
+    def stage_axes(self) -> List[str]:
+        """Return the axes of the stage.
 
         Returns
         -------
@@ -298,12 +316,12 @@ class ConfigurationController:
             else:
                 axes = list(stage_config["axes"])
             return axes
-        
+
         return ["x", "y"]
-    
+
     @property
-    def all_stage_axes(self):
-        """Return all the axes of the stage
+    def all_stage_axes(self) -> List[str]:
+        """Return all the axes of the stage.
 
         Returns
         -------
@@ -323,8 +341,8 @@ class ConfigurationController:
         return list(set(axes))
 
     @property
-    def camera_flip_flags(self):
-        """Return the flip flags of the camera
+    def camera_flip_flags(self) -> Dict[str, bool]:
+        """Return the flip flags of the camera.
 
         Returns
         -------
@@ -342,7 +360,7 @@ class ConfigurationController:
         return flip_flags
 
     @property
-    def remote_focus_dict(self):
+    def remote_focus_dict(self) -> Optional[Dict[str, Any]]:
         """Return delay_percent, pulse_percent.
 
         Returns
@@ -356,7 +374,7 @@ class ConfigurationController:
         return None
 
     @property
-    def galvo_parameter_dict(self):
+    def galvo_parameter_dict(self) -> Optional[List[Dict[str, Any]]]:
         """Return galvo parameter dict.
 
         Returns
@@ -365,7 +383,7 @@ class ConfigurationController:
             Dictionary with the galvo parameters.
         """
         if self.microscope_config is not None:
-            # Inject names into unnammed galvos
+            # Inject names into unnamed galvos
             for i, galvo in enumerate(self.microscope_config["galvo"]):
                 if galvo.get("name") is None:
                     self.microscope_config["galvo"][i]["name"] = f"Galvo {i}"
@@ -373,7 +391,7 @@ class ConfigurationController:
         return None
 
     @property
-    def daq_sample_rate(self):
+    def daq_sample_rate(self) -> float:
         """Return daq sample rate.
 
         Returns
@@ -386,20 +404,20 @@ class ConfigurationController:
         return 100000
 
     @property
-    def filter_wheel_setting_dict(self):
+    def filter_wheel_setting_dict(self) -> Optional[List[Dict[str, Any]]]:
         """Return filter wheel setting dict.
 
         Returns
         -------
         filter_wheel_setting_dict : dict
-            Dictionary with the filter wheel settings.
+            Dictionary with the filter-wheel settings.
         """
         if self.microscope_config is not None:
             return self.microscope_config["filter_wheel"]
         return None
 
     @property
-    def stage_setting_dict(self):
+    def stage_setting_dict(self) -> Optional[Dict[str, Any]]:
         """Return stage setting dict.
 
         Returns
@@ -412,7 +430,7 @@ class ConfigurationController:
         return None
 
     @property
-    def z_stages(self):
+    def z_stages(self) -> List[str]:
         """Return a list of all z stage names.
 
         Returns
@@ -420,17 +438,19 @@ class ConfigurationController:
         z_stages : list
             A list of z stage names.
         """
+        z_stages = []
         if self.microscope_config is not None:
             stages = self.microscope_config["stage"]["hardware"]
             if isinstance(stages, ListProxy):
                 stages = list(stages)
-                return [stage["type"] for stage in stages if "z" in stage["axes"]]
+                z_stages = [stage["type"] for stage in stages if "z" in stage["axes"]]
             elif isinstance(stages, DictProxy):
                 stages = dict(stages)
-                return [stages["type"]] if "z" in stages["axes"] else []
+                z_stages = [stages["type"]] if "z" in stages["axes"] else []
+        return z_stages
 
     @property
-    def number_of_channels(self):
+    def number_of_channels(self) -> int:
         """Return number of channels.
 
         Returns
@@ -443,8 +463,8 @@ class ConfigurationController:
         return 5
 
     @property
-    def number_of_filter_wheels(self):
-        """Return number of filter wheels
+    def number_of_filter_wheels(self) -> int:
+        """Return the number of filter wheels.
 
         Returns
         -------
@@ -457,13 +477,13 @@ class ConfigurationController:
         return 1
 
     @property
-    def filter_wheel_names(self):
-        """Return a list of filter wheel names
+    def filter_wheel_names(self) -> List[str]:
+        """Return a list of filter-wheel names
 
         Returns
         -------
         filter_wheel_names : list
-            List of filter wheel names.
+            List of filter-wheel names.
         """
         filter_wheel_names = []
         if self.microscope_config is not None:
@@ -475,7 +495,7 @@ class ConfigurationController:
         return filter_wheel_names
 
     @property
-    def microscope_list(self):
+    def microscope_list(self) -> List[str]:
         """Return a list of microscope names
 
         Returns
@@ -485,18 +505,30 @@ class ConfigurationController:
         """
         return list(self.configuration["configuration"]["microscopes"].keys())
 
-    def get_zoom_value_list(self, microscope_name):
-        """Return a list of zoom values
+    def get_zoom_value_list(self, microscope_name: str) -> Iterable[str]:
+        """Return available zoom values for a given microscope.
+
+        Parameters
+        ----------
+        microscope_name : str
+            Name of the microscope.
 
         Returns
         -------
-        zoom_value_list : list
-            List of zoom values.
+        Iterable[str]
+            Zoom setting keys for the specified microscope.
         """
         return self.configuration["waveform_constants"]["remote_focus_constants"][
             microscope_name
         ].keys()
 
     @property
-    def gui_setting(self):
+    def gui_setting(self) -> Dict[str, Any]:
+        """Return GUI configuration settings.
+
+        Returns
+        -------
+        Dict[str, Any]
+            GUI-related configuration dictionary.
+        """
         return self.configuration["configuration"]["gui"]

--- a/src/navigate/controller/sub_controllers/acquire_bar.py
+++ b/src/navigate/controller/sub_controllers/acquire_bar.py
@@ -161,9 +161,9 @@ class AcquireBarController(GUIController):
             number_of_positions = 1
         else:
             # The first row is a header that describes stage axis designation.
-            number_of_positions = len(
-                self.parent_controller.configuration["multi_positions"]
-            ) - 1
+            number_of_positions = (
+                len(self.parent_controller.configuration["multi_positions"]) - 1
+            )
 
         if mode == "single":
             number_of_slices = 1
@@ -209,10 +209,13 @@ class AcquireBarController(GUIController):
                         else top_percent_complete
                     )
 
-                    bottom_anticipated_images = 100 * (
-                        images_received / bottom_anticipated_images
-                    )
-                    self.view.OvrAcq["value"] = bottom_anticipated_images
+                    try:
+                        bottom_anticipated_images = 100 * (
+                            images_received / bottom_anticipated_images
+                        )
+                        self.view.OvrAcq["value"] = bottom_anticipated_images
+                    except ZeroDivisionError:
+                        pass
 
                 elif mode == "single":
                     top_percent_complete = 100 * (

--- a/src/navigate/controller/sub_controllers/channels_tab.py
+++ b/src/navigate/controller/sub_controllers/channels_tab.py
@@ -427,7 +427,7 @@ class ChannelsTabController(GUIController):
 
         # Shift the start/stop positions by the relative position
         flip_flags = self.parent_controller.configuration_controller.stage_flip_flags
-        if flip_flags["z"]:
+        if flip_flags.get("z", False):
             self.stack_acq_vals["abs_z_start"].set(self.z_origin + end_position)
             self.stack_acq_vals["abs_z_end"].set(self.z_origin + start_position)
         else:
@@ -438,7 +438,7 @@ class ChannelsTabController(GUIController):
         self.microscope_state_dict["start_position"] = start_position
         self.microscope_state_dict["end_position"] = end_position
         self.microscope_state_dict["step_size"] = step_size * (
-            -1 if flip_flags["z"] else 1
+            -1 if flip_flags.get("z", False) else 1
         )
         self.microscope_state_dict["number_z_steps"] = number_z_steps
         self.microscope_state_dict["abs_z_start"] = self.stack_acq_vals[
@@ -757,7 +757,9 @@ class ChannelsTabController(GUIController):
             return
         stage_axes = self.parent_controller.configuration_controller.stage_axes
         # not tiling on theta axis right now
-        tiling_wizard = TilingWizardPopup(self.view, axes=[axis.upper() for axis in stage_axes if axis != "theta"])
+        tiling_wizard = TilingWizardPopup(
+            self.view, axes=[axis.upper() for axis in stage_axes if axis != "theta"]
+        )
         self.tiling_wizard_controller = TilingWizardController(tiling_wizard, self)
 
     @staticmethod

--- a/src/navigate/controller/sub_controllers/multiposition.py
+++ b/src/navigate/controller/sub_controllers/multiposition.py
@@ -41,6 +41,7 @@ import numpy as np
 
 # Local Imports
 from navigate.controller.sub_controllers.gui import GUIController
+from typing import Any, Dict, List, Optional, Callable
 
 
 # Logger Setup
@@ -51,7 +52,7 @@ logger = logging.getLogger(p)
 class MultiPositionController(GUIController):
     """Controller for the Multi-Position Acquisition Interface."""
 
-    def __init__(self, view, parent_controller=None):
+    def __init__(self, view: Any, parent_controller: Optional[Any] = None) -> None:
         """Initialize the Multi-Position Acquisition Interface.
 
         Parameters
@@ -87,30 +88,32 @@ class MultiPositionController(GUIController):
             command=self.eliminate_tiles
         )
 
-    def eliminate_tiles(self):
+    def eliminate_tiles(self) -> None:
         """Eliminate tiles that do not contain tissue."""
         self.parent_controller.execute("eliminate_tiles")
 
-    def set_positions(self, positions):
-        """Set positions to multi-position's table
+    def set_positions(self, positions: List[List[Any]]) -> None:
+        """Set positions to the multi-position table
 
         Parameters
         ----------
         positions : [[]]
-            positions to be set
+            The positions to be set to the multi-position table.
         """
         stage_axes = self.parent_controller.configuration_controller.stage_axes
         data = {}
         if len(positions) == 0:
-            # add current stage position to the table
+            # add the current stage position to the table
             stage_position = self.parent_controller.configuration["experiment"][
                 "StageParameters"
             ]
             # get the current stage position
             positions = [[stage_position[axis] for axis in stage_axes]]
+
         # check if the positions contain the headers (column names)
         cmp_header = [axis.upper() in positions[0] for axis in stage_axes]
-        # if positions[0] contains ["X", "Y", "Z", "R", "F"], then consider it as headers
+
+        # if positions[0] contain ["X", "Y", "Z", "R", "F"], then consider it as headers
         # else add headers to the table
         if not all(cmp_header):
             # if the first row contains some headers, update the headers
@@ -126,18 +129,24 @@ class MultiPositionController(GUIController):
         else:
             headers = positions[0]
             start_index = 1
+
         # if there are some missing headers, add them
         if len(headers) < len(positions[start_index]):
-            headers = headers + ["col-" + str(i) for i in range(len(positions[start_index]) - len(headers))]
+            headers = headers + [
+                "col-" + str(i)
+                for i in range(len(positions[start_index]) - len(headers))
+            ]
         for i, name in enumerate(headers):
-            data[name] = list(pos[i] if i < len(pos) else np.nan for pos in positions[start_index:])
+            data[name] = list(
+                pos[i] if i < len(pos) else np.nan for pos in positions[start_index:]
+            )
         self.table.model.df = pd.DataFrame(data)
         self.table.currentrow = 0
         self.table.redraw()
         self.table.tableChanged()
         self.show_verbose_info("loaded new positions")
 
-    def get_positions(self):
+    def get_positions(self) -> List[List[Any]]:
         """Return all positions from the Multi-Position Acquisition Interface.
 
         Returns
@@ -155,30 +164,27 @@ class MultiPositionController(GUIController):
         rows = self.table.model.df.shape[0]
         for i in range(rows):
             temp = list(self.table.model.df.iloc[i])
-            if (
-                len(
-                    list(
-                        filter(
-                            lambda v: isinstance(v, (float, int)) and not math.isnan(v),
-                            [temp[i] for i in axes_index],
-                        )
+            if len(
+                list(
+                    filter(
+                        lambda v: isinstance(v, (float, int)) and not math.isnan(v),
+                        [temp[i] for i in axes_index],
                     )
                 )
-                == len(axes_index)
-            ):
+            ) == len(axes_index):
                 positions.append(temp)
         return positions
 
-    def handle_double_click(self, event):
+    def handle_double_click(self, event: Any) -> None:
         """Move to a position within the Multi-Position Acquisition Interface.
 
-        When double-clicked the row head, it will call the parent/central controller
+        When double-clicking the row head, it will call the parent/central controller
         to move stage and update stage view
 
         Parameters
         ----------
         event : tkinter event
-            event that triggers the function
+            An event that triggers the function
         """
         # it is calculated based on the GUI position
         rowclicked = self.table.get_row_clicked(event)
@@ -190,10 +196,19 @@ class MultiPositionController(GUIController):
         # df.iloc uses position index
         temp = list(df.iloc[rowclicked])
         stage_axes = self.parent_controller.configuration_controller.stage_axes
-        axes_index = [df.columns.get_loc(axis) for axis in [axis.upper() for axis in stage_axes]]
+        axes_index = [
+            df.columns.get_loc(axis) for axis in [axis.upper() for axis in stage_axes]
+        ]
         # validate position
         # we currently only move to a position doesn't contain nan
-        if len(list(filter(lambda v: isinstance(v, (float, int)) and not math.isnan(v), [temp[i] for i in axes_index]))) != len(stage_axes):
+        if len(
+            list(
+                filter(
+                    lambda v: isinstance(v, (float, int)) and not math.isnan(v),
+                    [temp[i] for i in axes_index],
+                )
+            )
+        ) != len(stage_axes):
             messagebox.showwarning(
                 title="Warning",
                 message="The selected position is invalid, can't go to this position!",
@@ -206,7 +221,7 @@ class MultiPositionController(GUIController):
         self.parent_controller.execute("move_stage_and_update_info", position)
         self.show_verbose_info("move stage to", position)
 
-    def get_position_num(self):
+    def get_position_num(self) -> int:
         """Return the number of positions in the Multi-Position Acquisition Interface.
 
         Returns
@@ -216,7 +231,7 @@ class MultiPositionController(GUIController):
         """
         return self.table.model.df.shape[0]
 
-    def load_positions(self):
+    def load_positions(self) -> None:
         """Load a csv file.
 
         The valid csv file should contain the line of headers: stage axes
@@ -231,13 +246,17 @@ class MultiPositionController(GUIController):
         # validate the csv file
         df.columns = map(lambda v: v.upper(), df.columns)
         stage_axes = self.parent_controller.configuration_controller.stage_axes
-        cmp_header = [axis in df.columns for axis in [axis.upper() for axis in stage_axes]]
+        cmp_header = [
+            axis in df.columns for axis in [axis.upper() for axis in stage_axes]
+        ]
         if not all(cmp_header):
             messagebox.showwarning(
                 title="Warning",
                 message=f"The csv file isn't right, it should contain {[axis.upper() for axis in stage_axes]}",
             )
-            logger.info(f"The csv file isn't right, it should contain {[axis.upper() for axis in stage_axes]}")
+            logger.info(
+                f"The csv file isn't right, it should contain {[axis.upper() for axis in stage_axes]}"
+            )
             return
         self.table.model.df = df
         self.table.currentrow = 0
@@ -247,12 +266,12 @@ class MultiPositionController(GUIController):
         self.table.tableChanged()
         self.show_verbose_info("loaded csv file", filename)
 
-    def export_positions(self):
+    def export_positions(self) -> None:
         """Export the positions in the Multi-Position Acquisition Interface to a
         csv file.
 
-        This function opens a dialog that let the user input a filename
-        Then, it will export positions to that csv file
+        This function opens a dialog that lets the user input a filename.
+        Then, it will export positions to that csv file.
         """
         filename = filedialog.asksaveasfilename(
             defaultextension=".csv",
@@ -263,13 +282,13 @@ class MultiPositionController(GUIController):
         self.table.model.df.to_csv(filename, index=False)
         self.show_verbose_info("exporting csv file", filename)
 
-    def move_to_position(self):
+    def move_to_position(self) -> None:
         """Move to a position within the Multi-Position Acquisition Interface."""
         event = type("MyEvent", (object,), {})
         event.x, event.y = 0, 0
         self.handle_double_click(event)
 
-    def insert_row_func(self):
+    def insert_row_func(self) -> None:
         """Insert a row in the Multi-Position Acquisition Interface."""
         self.table.model.addRow(self.table.currentrow)
         self.table.update_rowcolors()
@@ -277,16 +296,16 @@ class MultiPositionController(GUIController):
         self.table.tableChanged()
         self.show_verbose_info("insert a row before current row")
 
-    def add_stage_position(self):
+    def add_stage_position(self) -> None:
         """Add the current stage position to the Multi-Position Acquisition Interface.
 
         This function will get the stage's current position,
-        Then add it to position list
+        Then add it to the position list
         """
         position = self.parent_controller.execute("get_stage_position")
         self.append_position(position)
 
-    def append_position(self, position):
+    def append_position(self, position: Dict[str, Any]) -> None:
         """Append a position to the Multi-Position Acquisition Interface.
 
         Parameters
@@ -320,7 +339,7 @@ class MultiPositionController(GUIController):
         self.table.tableChanged()
         self.show_verbose_info("add current stage position to position list")
 
-    def remove_positions(self, position_flag_list):
+    def remove_positions(self, position_flag_list: List[bool]) -> None:
         """Remove positions according to position_flag_list
 
         Parameters
@@ -337,6 +356,12 @@ class MultiPositionController(GUIController):
         self.set_positions(new_positions)
 
     @property
-    def custom_events(self):
-        """Return custom events for the Multi-Position Controller."""
+    def custom_events(self) -> Dict[str, Callable[..., Any]]:
+        """Return custom events for the Multi-Position Controller.
+
+        Returns
+        -------
+        Dict[str, Callable[..., Any]]
+            Mapping of event names to handler functions.
+        """
         return {"remove_positions": self.remove_positions}

--- a/src/navigate/controller/sub_controllers/multiposition.py
+++ b/src/navigate/controller/sub_controllers/multiposition.py
@@ -138,7 +138,7 @@ class MultiPositionController(GUIController):
             ]
         for i, name in enumerate(headers):
             data[name] = list(
-                pos[i] if i < len(pos) else np.nan for pos in positions[start_index:]
+                pos[i] if i < len(pos) else 0.0 for pos in positions[start_index:]
             )
         self.table.model.df = pd.DataFrame(data)
         self.table.currentrow = 0


### PR DESCRIPTION
I'm trying to investigate whether or not we will run into any issues with the multi-position table when additional stage axes are added. 

After adding a new axis to the configuration file, I do see the axis listed in the multi-position table, but without any entries:
<img width="726" alt="image" src="https://github.com/user-attachments/assets/5f918e1a-3e21-4d80-891a-198cbe6d2711" />

If I do not correctly specify the flip flags, I get this exception:

<details>

<summary>Traceback</summary>

```
2025-04-30 10:25:51,170 - model - WARNING - base: Stage z1 limits not set in configuration file.
2025-04-30 10:25:51,171 - model - WARNING - base: Stage z2 limits not set in configuration file.
Traceback (most recent call last):
  File "/opt/miniconda3/envs/navigate/bin/navigate", line 8, in <module>
    sys.exit(main())
  File "/Users/Dean/Documents/GitHub/navigate/src/navigate/main.py", line 114, in main
    Controller(
  File "/Users/Dean/Documents/GitHub/navigate/src/navigate/controller/controller.py", line 338, in __init__
    self.populate_experiment_setting(in_initialize=True)
  File "/Users/Dean/Documents/GitHub/navigate/src/navigate/controller/controller.py", line 483, in populate_experiment_setting
    self.channels_tab_controller.populate_experiment_values()
  File "/Users/Dean/Documents/GitHub/navigate/src/navigate/controller/sub_controllers/channels_tab.py", line 261, in populate_experiment_values
    self.update_z_steps()
  File "/Users/Dean/Documents/GitHub/navigate/src/navigate/controller/sub_controllers/channels_tab.py", line 430, in update_z_steps
    if flip_flags["z"]:
KeyError: 'z'
^CFatal Python error: PyEval_RestoreThread: the function must be called with the GIL held, but the GIL is released (the current Python thread state is NULL)
Python runtime state: initialized

Thread 0x000000037168f000 (most recent call first):
  File "/opt/miniconda3/envs/navigate/lib/python3.9/tkinter/__init__.py", line 377 in set
  File "/Users/Dean/Documents/GitHub/navigate/src/navigate/controller/sub_controllers/stages.py", line 373 in set_position_silent
  File "/Users/Dean/Documents/GitHub/navigate/src/navigate/controller/controller.py", line 1380 in update_stage_controller_silent
  File "/Users/Dean/Documents/GitHub/navigate/src/navigate/controller/controller.py", line 1406 in update_event
  File "/opt/miniconda3/envs/navigate/lib/python3.9/threading.py", line 910 in run
  File "/opt/miniconda3/envs/navigate/lib/python3.9/threading.py", line 973 in _bootstrap_inner
  File "/opt/miniconda3/envs/navigate/lib/python3.9/threading.py", line 930 in _bootstrap

Current thread 0x00000001f4c8cc80 (most recent call first):
  File "/opt/miniconda3/envs/navigate/lib/python3.9/threading.py", line 1448 in _shutdown
```
</details>

To prevent this particular error from happening, I added a .get call that defaults to False.

If I run a multi-position acquisition with empty values, I get an exception. 

<details>

<summary>Traceback</summary>

```
zsh: abort      navigate -sh
(navigate) Dean@SW589085 navigate % 
(navigate) Dean@SW589085 navigate % navigate -sh
WARNING: navigate was built to operate on a Windows platform. While much of the software will work for evaluation purposes, some unanticipated behaviors may occur. For example, it is known that the Tkinter-based GUI does not grid symmetrically, nor resize properly on MacOS. Testing on Linux operating systems has not been performed.
2025-04-30 10:26:28,491 - model - WARNING - base: Stage z2 limits not set in configuration file.
Exception in thread camera:
Traceback (most recent call last):
  File "/Users/Dean/Documents/GitHub/navigate/src/navigate/controller/thread_pool.py", line 248, in func
    target(*args, **kwargs)
  File "/Users/Dean/Documents/GitHub/navigate/src/navigate/controller/controller.py", line 1161, in capture_image
    self.acquire_bar_controller.progress_bar(
  File "/Users/Dean/Documents/GitHub/navigate/src/navigate/controller/sub_controllers/acquire_bar.py", line 213, in progress_bar
    images_received / bottom_anticipated_images
ZeroDivisionError: division by zero

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/Dean/Documents/GitHub/navigate/src/navigate/controller/thread_pool.py", line 98, in run
    self._target(*self._args, **self._kwargs)
  File "/Users/Dean/Documents/GitHub/navigate/src/navigate/controller/thread_pool.py", line 250, in func
    logger.exception(
  File "/opt/miniconda3/envs/navigate/lib/python3.9/logging/__init__.py", line 1481, in exception
    self.error(msg, *args, exc_info=exc_info, **kwargs)
  File "/opt/miniconda3/envs/navigate/lib/python3.9/logging/__init__.py", line 1475, in error
    self._log(ERROR, msg, args, **kwargs)
  File "/opt/miniconda3/envs/navigate/lib/python3.9/logging/__init__.py", line 1589, in _log
    self.handle(record)
  File "/opt/miniconda3/envs/navigate/lib/python3.9/logging/__init__.py", line 1599, in handle
    self.callHandlers(record)
  File "/opt/miniconda3/envs/navigate/lib/python3.9/logging/__init__.py", line 1661, in callHandlers
    hdlr.handle(record)
  File "/opt/miniconda3/envs/navigate/lib/python3.9/logging/__init__.py", line 948, in handle
    rv = self.filter(record)
  File "/opt/miniconda3/envs/navigate/lib/python3.9/logging/__init__.py", line 806, in filter
    result = f.filter(record)
  File "/Users/Dean/Documents/GitHub/navigate/src/navigate/log_files/filters.py", line 95, in filter
    if record.getMessage().startswith("Performance"):
  File "/opt/miniconda3/envs/navigate/lib/python3.9/logging/__init__.py", line 367, in getMessage
    msg = msg % self.args
TypeError: not all arguments converted during string formatting

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/miniconda3/envs/navigate/lib/python3.9/threading.py", line 973, in _bootstrap_inner
    self.run()
  File "/Users/Dean/Documents/GitHub/navigate/src/navigate/controller/thread_pool.py", line 100, in run
    logger.exception(
  File "/opt/miniconda3/envs/navigate/lib/python3.9/logging/__init__.py", line 1481, in exception
    self.error(msg, *args, exc_info=exc_info, **kwargs)
  File "/opt/miniconda3/envs/navigate/lib/python3.9/logging/__init__.py", line 1475, in error
    self._log(ERROR, msg, args, **kwargs)
  File "/opt/miniconda3/envs/navigate/lib/python3.9/logging/__init__.py", line 1589, in _log
    self.handle(record)
  File "/opt/miniconda3/envs/navigate/lib/python3.9/logging/__init__.py", line 1599, in handle
    self.callHandlers(record)
  File "/opt/miniconda3/envs/navigate/lib/python3.9/logging/__init__.py", line 1661, in callHandlers
    hdlr.handle(record)
  File "/opt/miniconda3/envs/navigate/lib/python3.9/logging/__init__.py", line 948, in handle
    rv = self.filter(record)
  File "/opt/miniconda3/envs/navigate/lib/python3.9/logging/__init__.py", line 806, in filter
    result = f.filter(record)
  File "/Users/Dean/Documents/GitHub/navigate/src/navigate/log_files/filters.py", line 95, in filter
    if record.getMessage().startswith("Performance"):
  File "/opt/miniconda3/envs/navigate/lib/python3.9/logging/__init__.py", line 367, in getMessage
    msg = msg % self.args
TypeError: not all arguments converted during string formatting
```
</details>

For this one, I wrapped the bottom_anticipated_images in a try/except statement.

And finally, after rebooting the software, and running a multi position acquisition, I get this error in the logs:

<details>

<summary> Traceback </summary>

```
2025-04-30 10:43:44,056 - model - DEBUG - feature_container: SignalContainer - Traceback (most recent call last):
  File "/Users/Dean/Documents/GitHub/navigate/src/navigate/model/features/feature_container.py", line 558, in run
    result, is_end = self.curr_node.run(*args, wait_response=wait_response)
  File "/Users/Dean/Documents/GitHub/navigate/src/navigate/model/features/feature_container.py", line 243, in run
    self.node_funcs["init"]()
  File "/Users/Dean/Documents/GitHub/navigate/src/navigate/model/features/common_features.py", line 1180, in pre_signal_func
    [self.positions[0][i] for i in self.axes_index],
  File "/Users/Dean/Documents/GitHub/navigate/src/navigate/model/features/common_features.py", line 1180, in <listcomp>
    [self.positions[0][i] for i in self.axes_index],
IndexError: list index out of range
```
</details>