### PR TITLE
ProjectionMode feature + Adaptive Optics cleanup

### DIFF
--- a/src/navigate/controller/sub_controllers/adaptive_optics.py
+++ b/src/navigate/controller/sub_controllers/adaptive_optics.py
@@ -63,9 +63,11 @@ class AdaptiveOpticsPopupController(GUIController):
 
         self.view.popup.protocol("WM_DELETE_WINDOW", self.view.popup.dismiss)
 
-        self.parent_controller.configuration["experiment"]["AdaptiveOpticsParameters"][
-            "HighlightedMode"
-        ] = None
+        self.mirror_params = self.parent_controller.configuration["experiment"]["MirrorParameters"]
+        self.ao_params = self.parent_controller.configuration["experiment"]["AdaptiveOpticsParameters"]
+        self.tw_params = self.ao_params["TonyWilson"]
+
+        self.ao_params["HighlightedMode"] = None
 
         #: list of dicts: list of dicts containing trace data
         self.trace_list = []
@@ -78,16 +80,6 @@ class AdaptiveOpticsPopupController(GUIController):
 
         #: dict: dictionary of mode labels
         self.mode_labels = self.view.get_labels()
-
-        # TODO: just for testing, remove later...
-        #: list: list of cameras
-        self.camera_list = self.view.camera_list
-        self.camera_list[
-            "values"
-        ] = self.parent_controller.configuration_controller.microscope_list
-        self.camera_list.bind(
-            "<<ComboboxSelected>>", lambda evt: self.change_camera(evt)
-        )
 
         #: Figure: figure for mirror plot
         self.fig = self.view.fig
@@ -129,20 +121,27 @@ class AdaptiveOpticsPopupController(GUIController):
                 "<Leave>", lambda evt: evt.widget.config(background="SystemButtonFace")
             )
 
+        # update all experiment values each time one is changed
+        # from navigate.view.custom_widgets.LabelInputWidgetFactory import LabelInput
+        # for k in self.widgets:
+        #     input = self.widgets[k]
+        #     if type(input) == LabelInput:
+        #         input.widget.bind(
+        #             "<KeyRelease>", self.on_input_change
+        #         )
+
+        self.widgets["iterations"].widget.bind( "<KeyRelease>", self.on_input_change)
+        self.widgets["steps"].widget.bind(      "<KeyRelease>", self.on_input_change)
+        self.widgets["amplitude"].widget.bind(  "<KeyRelease>", self.on_input_change)
+
+        self.widgets["from"]["button"].bind(    "<<ComboboxSelected>>", self.on_input_change)
+        self.widgets["metric"]["button"].bind(  "<<ComboboxSelected>>", self.on_input_change)
+        self.widgets["fitfunc"]["button"].bind( "<<ComboboxSelected>>", self.on_input_change)
+
         self.populate_experiment_values()
 
-    def change_camera(self, evt):
-        """Change the camera to the selected camera
-
-        Parameters
-        ----------
-        evt : Event
-            The event that triggered this function
-        """
-        # cam_id = evt.widget.get().split("_")[-1]
-        # self.parent_controller.execute("change_camera", int(cam_id))
-        cam_name = evt.widget.get()
-        self.parent_controller.execute("resolution", cam_name)
+    def on_input_change(self, evt):
+        self.update_experiment_values()
 
     def set_highlighted_mode(self, evt, mode):
         """Set the highlighted mode
@@ -155,7 +154,7 @@ class AdaptiveOpticsPopupController(GUIController):
             The mode to highlight
         """
         evt.widget.config(background="red")
-        self.parent_controller.configuration["experiment"]["AdaptiveOpticsParameters"][
+        self.ao_params[
             "HighlightedMode"
         ] = mode
         self.plot_tw_trace()
@@ -172,11 +171,7 @@ class AdaptiveOpticsPopupController(GUIController):
 
     def populate_experiment_values(self):
         """Populate the experiment values"""
-        self.camera_list.set(
-            self.parent_controller.configuration["experiment"]["MicroscopeState"][
-                "microscope_name"
-            ]
-        )
+
         self.widgets["save_report"]["variable"].set(
             self.parent_controller.configuration["experiment"][
                 "AdaptiveOpticsParameters"
@@ -217,41 +212,26 @@ class AdaptiveOpticsPopupController(GUIController):
         modes_dict = {}
         coef_list = self.get_coef_from_widgets()
         keys = self.view.mode_names
+        
         for i, coef in enumerate(coef_list):
             modes_dict[keys[i]] = coef
-        self.parent_controller.configuration["experiment"]["MirrorParameters"][
-            "modes"
-        ] = modes_dict
+        
+        self.mirror_params["modes"] = modes_dict
 
-        self.parent_controller.configuration["experiment"]["AdaptiveOpticsParameters"][
-            "TonyWilson"
-        ]["iterations"] = int(self.widgets["iterations"].get())
-        self.parent_controller.configuration["experiment"]["AdaptiveOpticsParameters"][
-            "TonyWilson"
-        ]["steps"] = int(self.widgets["steps"].get())
-        self.parent_controller.configuration["experiment"]["AdaptiveOpticsParameters"][
-            "TonyWilson"
-        ]["amplitude"] = float(self.widgets["amplitude"].get())
-        self.parent_controller.configuration["experiment"]["AdaptiveOpticsParameters"][
-            "TonyWilson"
-        ]["from"] = self.widgets["from"]["variable"].get()
-        self.parent_controller.configuration["experiment"]["AdaptiveOpticsParameters"][
-            "TonyWilson"
-        ]["metric"] = self.widgets["metric"]["variable"].get()
-        self.parent_controller.configuration["experiment"]["AdaptiveOpticsParameters"][
-            "TonyWilson"
-        ]["fitfunc"] = self.widgets["fitfunc"]["variable"].get()
+        try:
+            self.tw_params["iterations"] = int(self.widgets["iterations"].get())
+            self.tw_params["steps"] = int(self.widgets["steps"].get())
+            self.tw_params["amplitude"] = float(self.widgets["amplitude"].get())
+            self.tw_params["from"] = self.widgets["from"]["variable"].get()
+            self.tw_params["metric"] = self.widgets["metric"]["variable"].get()
+            self.tw_params["fitfunc"] = self.widgets["fitfunc"]["variable"].get()
+        except ValueError:
+            pass
 
-        self.parent_controller.configuration["experiment"]["AdaptiveOpticsParameters"][
-            "save_report"
-        ] = self.widgets["save_report"]["variable"].get()
+        self.ao_params["save_report"] = self.widgets["save_report"]["variable"].get()
 
         for k in self.modes_armed.keys():
-            self.parent_controller.configuration["experiment"][
-                "AdaptiveOpticsParameters"
-            ]["TonyWilson"]["modes_armed"][k] = self.modes_armed[k]["variable"].get()
-
-        # print(self.parent_controller.configuration['experiment']['MirrorParameters']['modes'])
+            self.tw_params["modes_armed"][k] = self.modes_armed[k]["variable"].get()
 
     def get_coef_from_widgets(self):
         """Get the coefficients from the widgets

--- a/src/navigate/model/devices/stage/ni.py
+++ b/src/navigate/model/devices/stage/ni.py
@@ -163,6 +163,8 @@ class NIStage(StageBase, NIDevice):
         #: object: DAQ ao task
         self.ao_task = None
 
+        self.backup_ao_task = None
+
         self.switch_mode("normal")
 
     # for stacking, we could have 2 axis here or not, y is for tiling, not necessary
@@ -320,10 +322,10 @@ class NIStage(StageBase, NIDevice):
                     self.configuration["experiment"]["StageParameters"][self.axes[0]]
                 ),
             )
-        elif self.ao_task:
-            self.ao_task.stop()
-            self.ao_task.close()
-            self.ao_task = None
+        # elif self.ao_task:
+        #     self.ao_task.stop()
+        #     self.ao_task.close()
+        #     self.ao_task = None
 
     def close(self) -> None:
         """Close the Galvo stage."""

--- a/src/navigate/model/devices/stage/ni.py
+++ b/src/navigate/model/devices/stage/ni.py
@@ -312,6 +312,8 @@ class NIStage(StageBase, NIDevice):
         self.sweep_times = sweep_times
         if mode == "normal":
             if self.ao_task is None:
+                if self.daq.analog_outputs is not None:
+                    self.daq.analog_outputs.pop(self.axes_channels[0], None)
                 self.ao_task = nidaqmx.Task()
                 self.ao_task.ao_channels.add_ao_voltage_chan(self.axes_channels[0])
             self.move_axis_absolute(

--- a/src/navigate/model/devices/stage/ni.py
+++ b/src/navigate/model/devices/stage/ni.py
@@ -163,8 +163,6 @@ class NIStage(StageBase, NIDevice):
         #: object: DAQ ao task
         self.ao_task = None
 
-        self.backup_ao_task = None
-
         self.switch_mode("normal")
 
     # for stacking, we could have 2 axis here or not, y is for tiling, not necessary
@@ -322,10 +320,10 @@ class NIStage(StageBase, NIDevice):
                     self.configuration["experiment"]["StageParameters"][self.axes[0]]
                 ),
             )
-        # elif self.ao_task:
-        #     self.ao_task.stop()
-        #     self.ao_task.close()
-        #     self.ao_task = None
+        elif self.ao_task:
+            self.ao_task.stop()
+            self.ao_task.close()
+            self.ao_task = None
 
     def close(self) -> None:
         """Close the Galvo stage."""

--- a/src/navigate/model/features/adaptive_optics.py
+++ b/src/navigate/model/features/adaptive_optics.py
@@ -159,9 +159,7 @@ class TonyWilson:
 
     def __init__(self, 
                  model, 
-                 n_iter=None, 
-                 n_steps=None, 
-                 coef_amp=None
+                 verbose=False
                  ):
         """Initialize the Tony Wilson iterative AO routine
 
@@ -173,15 +171,6 @@ class TonyWilson:
         #: int: Number of modes
         self.n_modes = None
 
-        #: int: Number of iterations
-        self.n_iter = n_iter
-
-        #: int: Number of steps
-        self.n_steps = n_steps
-
-        #: float: Coefficient amplitude
-        self.coef_amp = coef_amp
-
         #: bool: True if all iterations are done, False otherwise
         self.done_all = False
 
@@ -190,6 +179,8 @@ class TonyWilson:
 
         #: list: detailed report to save as JSON after
         self.report = []
+
+        self.verbose = verbose
 
         # TODO: I don't think these are used...
         self.laser = None
@@ -371,7 +362,7 @@ class TonyWilson:
         self.target_signal_id = 0
         self.total_frame_num = self.get_tw_frame_num()
 
-        print(f"Total frame num: {self.total_frame_num}")
+        # print(f"Total frame num: {self.total_frame_num}")
 
         if self.start_from == "flat":
             self.best_coefs = np.zeros(self.n_modes, dtype=np.float32)
@@ -395,8 +386,8 @@ class TonyWilson:
         bool
             True if the signal is done, False otherwise
         """
+        
         out_str = "in_func_signal\n"
-
         out_str += f"\tSignal:\t{self.signal_id}\n"
 
         step = self.signal_id % self.n_steps
@@ -427,6 +418,7 @@ class TonyWilson:
 
         try:
             curr_mirror_coefs = self.mirror_controller.get_modal_coefs()[0]
+            
             out_str += (
                 f"\tCoefs:\t[{' '.join([f'{c:.2f}' for c in curr_mirror_coefs])}]\n"
             )
@@ -445,7 +437,6 @@ class TonyWilson:
         if (applied_coefs == curr_mirror_coefs).all() or (applied_coefs == 0).all():
             self.signal_id += 1
 
-            out_str += "\tSending tw_frame_queue...\n"
             self.tw_frame_queue.put(
                 (
                     self.model.frame_id,
@@ -458,7 +449,8 @@ class TonyWilson:
         else:
             out_str += "\tMirror update failed...\n"
 
-        print(out_str)
+        if self.verbose:
+            print(out_str)
 
         return self.signal_id >= self.total_frame_num
 
@@ -470,8 +462,6 @@ class TonyWilson:
         bool
             True if the signal is done, False otherwise
         """
-        print("end_func_signal() called!!!")
-
         if self.model.stop_acquisition:
             return True
 
@@ -642,13 +632,14 @@ class TonyWilson:
                         self.done_all = True
                         out_str += "\tDone all!!!\n"
 
-        out_str += "\tSending tw_data_queue...\n"
         self.tw_data_queue.put((self.frames_done,))
 
-        print(out_str)
+        if self.verbose:
+            print(out_str)
+        elif self.done_itr:
+            print(f"Done iteration {itr + 1} / {self.n_iter} ...")
 
         if self.frames_done >= self.total_frame_num:
-            print(">>> in_func_data ended!!!")
             return frame_ids
 
     def build_report(self):
@@ -680,8 +671,6 @@ class TonyWilson:
         bool
             True if the data is done, False otherwise
         """
-        print("end_func_data() called!!!")
-
         if self.done_all:
             self.best_coefs = self.best_coefs_overall
             # self.model.stop_acquisition = True

--- a/src/navigate/model/features/adaptive_optics.py
+++ b/src/navigate/model/features/adaptive_optics.py
@@ -180,11 +180,9 @@ class TonyWilson:
         #: list: detailed report to save as JSON after
         self.report = []
 
+        #: bool: True if you want to print the full output string each step
         self.verbose = verbose
 
-        # TODO: I don't think these are used...
-        self.laser = None
-        self.laser_power = 0
         self.start_time = 0
 
         #: navigate.model.Model: Model object
@@ -221,21 +219,6 @@ class TonyWilson:
         self.metric = self.tw_settings["metric"]
 
         self.fit_func = self.tw_settings["fitfunc"]
-
-        # if start_from == "flat":
-        #     self.best_coefs = np.zeros(self.n_modes, dtype=np.float32)
-        # elif start_from == "current":
-        #     curr_expt_coefs = list(
-        #         self.model.configuration["experiment"]["MirrorParameters"][
-        #             "modes"
-        #         ].values()
-        #     )
-        #     self.best_coefs = np.asarray(curr_expt_coefs, dtype=np.float32)
-
-        # self.best_coefs_overall = deepcopy(self.best_coefs)
-        # self.best_metric = 0.0
-        # self.coef_sweep = None
-        # self.best_peaks = []
 
         # Queue
         self.tw_frame_queue = Queue()
@@ -276,10 +259,6 @@ class TonyWilson:
         if frame_num < 1:
             return
 
-        # Opens correct shutter and puts all signals to false
-        # self.model.prepare_acquisition()
-        # self.model.active_microscope.prepare_next_channel()
-
         self.model.addon_feature = [
             [
                 {"name": PrepareNextChannel},
@@ -292,28 +271,6 @@ class TonyWilson:
         ] = "customized"
 
         self.model.run_command("acquire")
-
-        # # load signal and data containers
-        # self.model.signal_container, self.model.data_container = load_features(
-        #     self.model, [[{"name": TonyWilson}]]
-        # )
-
-        # self.model.signal_thread = threading.Thread(
-        #     target=self.model.run_acquisition, name="TonyWilson Signal"
-        # )
-
-        # self.model.data_thread = threading.Thread(
-        #     target=self.model.run_data_process,
-        #     # args=(frame_num,),
-        #     kwargs={"data_func": self.image_writer.save_image},
-        #     name="TonyWilson Data",
-        # )
-
-        # print("\n**** STARTING TONY WILSON ****\n")
-
-        # # Start Threads
-        # self.model.signal_thread.start()
-        # self.model.data_thread.start()
 
     def get_tw_frame_num(self):
         """Calculate how many frames are needed: iterations x steps x num_coefs"""
@@ -361,8 +318,6 @@ class TonyWilson:
         self.signal_id = 0
         self.target_signal_id = 0
         self.total_frame_num = self.get_tw_frame_num()
-
-        # print(f"Total frame num: {self.total_frame_num}")
 
         if self.start_from == "flat":
             self.best_coefs = np.zeros(self.n_modes, dtype=np.float32)
@@ -673,9 +628,6 @@ class TonyWilson:
         """
         if self.done_all:
             self.best_coefs = self.best_coefs_overall
-            # self.model.stop_acquisition = True
-            # self.model.end_acquisition()
-            # print("Ending acquisition...")
             try:
                 stop_time = time.time()
                 print(f"Total runtime:\t{(stop_time - self.start_time):.3f} sec")

--- a/src/navigate/model/features/adaptive_optics.py
+++ b/src/navigate/model/features/adaptive_optics.py
@@ -156,7 +156,7 @@ def fourier_annulus(im, radius_1=0, radius_2=64):
 class TonyWilson:
     """Tony Wilson iterative AO routine"""
 
-    def __init__(self, model):
+    def __init__(self, model, n_iter=None, n_steps=None, coef_amp=None):
         """Initialize the Tony Wilson iterative AO routine
 
         Parameters
@@ -168,13 +168,13 @@ class TonyWilson:
         self.n_modes = None
 
         #: int: Number of iterations
-        self.n_iter = None
+        self.n_iter = n_iter
 
         #: int: Number of steps
-        self.n_steps = None
+        self.n_steps = n_steps
 
         #: float: Coefficient amplitude
-        self.coef_amp = None
+        self.coef_amp = coef_amp
 
         #: bool: True if all iterations are done, False otherwise
         self.done_all = False
@@ -352,9 +352,12 @@ class TonyWilson:
 
         self.done_all = False
 
-        self.n_iter = tw_settings["iterations"]
-        self.n_steps = tw_settings["steps"]
-        self.coef_amp = tw_settings["amplitude"]
+        if self.n_iter is None:
+            self.n_iter = tw_settings["iterations"]
+        if self.n_steps is None:
+            self.n_steps = tw_settings["steps"]
+        if self.coef_amp is None:
+            self.coef_amp = tw_settings["amplitude"]
 
         self.coef_sweep = np.linspace(
             -self.coef_amp, self.coef_amp, self.n_steps

--- a/src/navigate/model/features/adaptive_optics.py
+++ b/src/navigate/model/features/adaptive_optics.py
@@ -42,6 +42,7 @@ import numpy as np
 from scipy.optimize import curve_fit
 
 # Local imports
+from navigate.model.features.common_features import PrepareNextChannel
 from navigate.model.features.feature_container import load_features
 import navigate.model.analysis.image_contrast as img_contrast
 from navigate.model.features.image_writer import ImageWriter
@@ -156,7 +157,12 @@ def fourier_annulus(im, radius_1=0, radius_2=64):
 class TonyWilson:
     """Tony Wilson iterative AO routine"""
 
-    def __init__(self, model, n_iter=None, n_steps=None, coef_amp=None):
+    def __init__(self, 
+                 model, 
+                 n_iter=None, 
+                 n_steps=None, 
+                 coef_amp=None
+                 ):
         """Initialize the Tony Wilson iterative AO routine
 
         Parameters
@@ -193,6 +199,10 @@ class TonyWilson:
         #: navigate.model.Model: Model object
         self.model = model
 
+        self.tw_settings = self.model.configuration["experiment"][
+            "AdaptiveOpticsParameters"
+        ]["TonyWilson"]
+
         #: navigate.model.devices.mirrors.mirror_imop.ImagineOpticsMirror: Mirror object
         self.mirror_controller = self.model.active_microscope.mirror.mirror_controller
 
@@ -206,9 +216,7 @@ class TonyWilson:
 
         #: list: List of coefficients to change
         self.change_coef = []
-        modes_armed_dict = self.model.configuration["experiment"][
-            "AdaptiveOpticsParameters"
-        ]["TonyWilson"]["modes_armed"]
+        modes_armed_dict = self.tw_settings["modes_armed"]
 
         #: list: List of mode names
         self.mode_names = modes_armed_dict.keys()
@@ -217,17 +225,11 @@ class TonyWilson:
                 self.change_coef += [i]
         self.n_coefs = len(self.change_coef)
 
-        self.start_from = self.model.configuration["experiment"][
-            "AdaptiveOpticsParameters"
-        ]["TonyWilson"]["from"]
+        self.start_from = self.tw_settings["from"]
 
-        self.metric = self.model.configuration["experiment"][
-            "AdaptiveOpticsParameters"
-        ]["TonyWilson"]["metric"]
+        self.metric = self.tw_settings["metric"]
 
-        self.fit_func = self.model.configuration["experiment"][
-            "AdaptiveOpticsParameters"
-        ]["TonyWilson"]["fitfunc"]
+        self.fit_func = self.tw_settings["fitfunc"]
 
         # if start_from == "flat":
         #     self.best_coefs = np.zeros(self.n_modes, dtype=np.float32)
@@ -284,38 +286,47 @@ class TonyWilson:
             return
 
         # Opens correct shutter and puts all signals to false
-        self.model.prepare_acquisition()
-        self.model.active_microscope.prepare_next_channel()
+        # self.model.prepare_acquisition()
+        # self.model.active_microscope.prepare_next_channel()
 
-        # load signal and data containers
-        self.model.signal_container, self.model.data_container = load_features(
-            self.model, [[{"name": TonyWilson}]]
-        )
+        self.model.addon_feature = [
+            [
+                {"name": PrepareNextChannel},
+                {"name": TonyWilson}
+            ]
+        ]
 
-        self.model.signal_thread = threading.Thread(
-            target=self.model.run_acquisition, name="TonyWilson Signal"
-        )
+        self.model.configuration["experiment"]["MicroscopeState"][
+            "image_mode"
+        ] = "customized"
 
-        self.model.data_thread = threading.Thread(
-            target=self.model.run_data_process,
-            # args=(frame_num,),
-            kwargs={"data_func": self.image_writer.save_image},
-            name="TonyWilson Data",
-        )
+        self.model.run_command("acquire")
 
-        print("\n**** STARTING TONY WILSON ****\n")
+        # # load signal and data containers
+        # self.model.signal_container, self.model.data_container = load_features(
+        #     self.model, [[{"name": TonyWilson}]]
+        # )
 
-        # Start Threads
-        self.model.signal_thread.start()
-        self.model.data_thread.start()
+        # self.model.signal_thread = threading.Thread(
+        #     target=self.model.run_acquisition, name="TonyWilson Signal"
+        # )
+
+        # self.model.data_thread = threading.Thread(
+        #     target=self.model.run_data_process,
+        #     # args=(frame_num,),
+        #     kwargs={"data_func": self.image_writer.save_image},
+        #     name="TonyWilson Data",
+        # )
+
+        # print("\n**** STARTING TONY WILSON ****\n")
+
+        # # Start Threads
+        # self.model.signal_thread.start()
+        # self.model.data_thread.start()
 
     def get_tw_frame_num(self):
         """Calculate how many frames are needed: iterations x steps x num_coefs"""
-        settings = self.model.configuration["experiment"]["AdaptiveOpticsParameters"][
-            "TonyWilson"
-        ]
-        frames = settings["iterations"] * settings["steps"] * self.n_coefs
-        return frames
+        return self.tw_settings["iterations"] * self.tw_settings["steps"] * self.n_coefs
 
     # don't need this?
     def get_steps(self, ranges, step_size):
@@ -346,18 +357,11 @@ class TonyWilson:
         # Timing
         self.start_time = time.time()
 
-        tw_settings = self.model.configuration["experiment"][
-            "AdaptiveOpticsParameters"
-        ]["TonyWilson"]
-
         self.done_all = False
 
-        if self.n_iter is None:
-            self.n_iter = tw_settings["iterations"]
-        if self.n_steps is None:
-            self.n_steps = tw_settings["steps"]
-        if self.coef_amp is None:
-            self.coef_amp = tw_settings["amplitude"]
+        self.n_iter = self.tw_settings["iterations"]
+        self.n_steps = self.tw_settings["steps"]
+        self.coef_amp = self.tw_settings["amplitude"]
 
         self.coef_sweep = np.linspace(
             -self.coef_amp, self.coef_amp, self.n_steps

--- a/src/navigate/model/features/common_features.py
+++ b/src/navigate/model/features/common_features.py
@@ -202,7 +202,7 @@ class ProjectionMode:
         }
 
     def toggle_projection_mode(self):
-        
+
         self.microscope_state = self.model.configuration["experiment"]["MicroscopeState"]
         self.waveform_constants = self.model.configuration["waveform_constants"]
 
@@ -215,6 +215,13 @@ class ProjectionMode:
             self.setup_projection()
         else:
             self.disable_projection()
+
+        # debugging
+        print(f"------- galvo_stage (enabled = {self.enable}) --------\n")
+        mems = vars(self.galvo_stage)
+        for mem in mems:
+            print(f"{mem}:\t{mems[mem]}")
+        print("----------------------------------------------------\n")
 
         return True
 
@@ -272,9 +279,17 @@ class ProjectionMode:
 
         self.microscope_state["waveform_template"] = "Default"        
 
+        self.galvo_stage.waveform_dict = {}
+
         self.set_shear_amplitude(0)
 
-        self.galvo_stage.switch_mode("normal")
+        # self.galvo_stage.ao_task = None
+
+        self.galvo_stage.switch_mode(
+            "normal",
+            # exposure_times = self.exposure_times,
+            # sweep_times = self.sweep_times
+            )
 
 class WaitToContinue:
     """WaitToContinue class for synchronizing signal and data acquisition.

--- a/src/navigate/model/features/common_features.py
+++ b/src/navigate/model/features/common_features.py
@@ -172,6 +172,93 @@ class WaitForExternalTrigger:
 
         return result
 
+class ProjectionMode:
+
+    def __init__(self, model, axis='z', galvo_num=0):
+
+        self.model = model
+
+        self.microscope_state = None
+        self.waveform_constants = None
+
+        self.galvo_stage = model.active_microscope.stages[axis]
+        self.shear_galvo = model.active_microscope.galvo[f"galvo_{galvo_num}"]
+
+        self.galvo_num = galvo_num
+
+        self.exposure_times = None
+        self.sweep_times = None
+        self.channels = None
+
+        self.current_channel_in_list = 0
+
+        self.config_table = {
+            "signal": {
+                "init": self.model.pause_data_thread,
+                "main": self.setup_projection,
+                "cleanup": self.model.resume_data_thread
+            },
+            "node": {
+                "node_type": "multi_step", 
+                "device_related": True
+                }
+        }
+
+    def setup_projection(self):
+
+        from navigate.model.waveforms import remote_focus_ramp
+
+        self.microscope_state = self.model.configuration["experiment"]["MicroscopeState"]
+        self.waveform_constants = self.model.configuration["waveform_constants"]
+
+        self.microscope_state["waveform_template"] = "Confocal-Projection"
+
+        self.channels = self.microscope_state["selected_channels"]
+
+        (
+            self.exposure_times,
+            self.sweep_times
+        ) = self.model.active_microscope.get_exposure_sweep_times()
+
+        remote_focus_delay = float(self.waveform_constants["other_constants"][
+            "remote_focus_delay"
+            ]) / 1000
+        remote_focus_ramp_falling = float(self.waveform_constants["other_constants"][
+            "remote_focus_ramp_falling"
+            ]) / 1000
+        
+        z_range = self.microscope_state["scanrange"]        
+        shear_amp = self.microscope_state["shear_amp"]
+
+        waveform_dict = {}
+        for channel_key in self.microscope_state["channels"].keys():
+            
+            channel = self.microscope_state["channels"][channel_key]
+
+            if channel["is_selected"]:
+
+                waveform_dict[channel_key] = remote_focus_ramp(
+                    sample_rate = self.galvo_stage.sample_rate,
+                    exposure_time = self.exposure_times[channel_key],
+                    sweep_time = self.sweep_times[channel_key],
+                    remote_focus_delay = remote_focus_delay,
+                    fall = remote_focus_ramp_falling,
+                    camera_delay = self.galvo_stage.camera_delay,
+                    amplitude = eval(self.galvo_stage.volts_per_micron, {"x": 0.5 * (z_range)})
+                )
+        
+        self.galvo_stage.update_waveform(waveform_dict)
+
+        self.waveform_constants["galvo_constants"][f"Galvo {self.galvo_num}"][
+                self.microscope_state["microscope_name"]
+            ][
+                self.microscope_state["zoom"]
+            ]["amplitude"] = shear_amp
+
+        self.shear_galvo.adjust(
+            self.exposure_times,
+            self.sweep_times
+        )
 
 class WaitToContinue:
     """WaitToContinue class for synchronizing signal and data acquisition.

--- a/src/navigate/model/features/common_features.py
+++ b/src/navigate/model/features/common_features.py
@@ -177,11 +177,14 @@ class WaitForExternalTrigger:
 
 class ProjectionMode:
 
-    def __init__(self, model, axis='z', galvo_num=0, enable=True):
+    def __init__(self, model, z_range=None, shear_amp=None, axis='z', galvo_num=0, enable=True):
 
         self.model = model
 
         self.enable = enable
+
+        self.z_range = z_range
+        self.shear_amp = shear_amp
 
         self.microscope_state = None
         self.waveform_constants = None
@@ -238,8 +241,8 @@ class ProjectionMode:
             "remote_focus_ramp_falling"
             ]) / 1000
         
-        z_range = self.microscope_state["scanrange"]        
-        shear_amp = self.microscope_state["shear_amp"]
+        z_range = self.microscope_state["scanrange"] if self.z_range is None else self.z_range        
+        shear_amp = self.microscope_state["shear_amp"] if self.shear_amp is None else self.shear_amp
 
         waveform_dict = {}
         for channel_key in self.microscope_state["channels"].keys():

--- a/src/navigate/model/features/common_features.py
+++ b/src/navigate/model/features/common_features.py
@@ -219,13 +219,6 @@ class ProjectionMode:
         else:
             self.disable_projection()
 
-        # debugging
-        print(f"------- galvo_stage (enabled = {self.enable}) --------\n")
-        mems = vars(self.galvo_stage)
-        for mem in mems:
-            print(f"{mem}:\t{mems[mem]}")
-        print("----------------------------------------------------\n")
-
         return True
 
     def setup_projection(self):

--- a/src/navigate/model/features/common_features.py
+++ b/src/navigate/model/features/common_features.py
@@ -44,6 +44,9 @@ from multiprocessing.managers import ListProxy
 from .image_writer import ImageWriter
 from navigate.tools.common_functions import VariableWithLock
 
+
+from navigate.model.waveforms import remote_focus_ramp
+
 # Logger Setup
 p = __name__.split(".")[1]
 logger = logging.getLogger(p)
@@ -174,9 +177,11 @@ class WaitForExternalTrigger:
 
 class ProjectionMode:
 
-    def __init__(self, model, axis='z', galvo_num=0):
+    def __init__(self, model, axis='z', galvo_num=0, enable=True):
 
         self.model = model
+
+        self.enable = enable
 
         self.microscope_state = None
         self.waveform_constants = None
@@ -193,32 +198,31 @@ class ProjectionMode:
         self.current_channel_in_list = 0
 
         self.config_table = {
-            "signal": {
-                "init": self.model.pause_data_thread,
-                "main": self.setup_projection,
-                "cleanup": self.model.resume_data_thread
-            },
-            "node": {
-                "node_type": "multi_step", 
-                "device_related": True
-                }
+            "signal": {"main": self.toggle_projection_mode}
         }
 
-    def setup_projection(self):
-
-        from navigate.model.waveforms import remote_focus_ramp
-
+    def toggle_projection_mode(self):
+        
         self.microscope_state = self.model.configuration["experiment"]["MicroscopeState"]
         self.waveform_constants = self.model.configuration["waveform_constants"]
-
-        self.microscope_state["waveform_template"] = "Confocal-Projection"
-
-        self.channels = self.microscope_state["selected_channels"]
 
         (
             self.exposure_times,
             self.sweep_times
         ) = self.model.active_microscope.get_exposure_sweep_times()
+
+        if self.enable:
+            self.setup_projection()
+        else:
+            self.disable_projection()
+
+        return True
+
+    def setup_projection(self):
+
+        self.microscope_state["waveform_template"] = "Confocal-Projection"
+
+        self.channels = self.microscope_state["selected_channels"]
 
         remote_focus_delay = float(self.waveform_constants["other_constants"][
             "remote_focus_delay"
@@ -249,16 +253,28 @@ class ProjectionMode:
         
         self.galvo_stage.update_waveform(waveform_dict)
 
+        self.set_shear_amplitude(shear_amp)
+
+    def set_shear_amplitude(self, amp):
+            
         self.waveform_constants["galvo_constants"][f"Galvo {self.galvo_num}"][
-                self.microscope_state["microscope_name"]
-            ][
-                self.microscope_state["zoom"]
-            ]["amplitude"] = shear_amp
+        self.microscope_state["microscope_name"]
+        ][
+            self.microscope_state["zoom"]
+        ]["amplitude"] = amp
 
         self.shear_galvo.adjust(
             self.exposure_times,
             self.sweep_times
         )
+
+    def disable_projection(self):
+
+        self.microscope_state["waveform_template"] = "Default"        
+
+        self.set_shear_amplitude(0)
+
+        self.galvo_stage.switch_mode("normal")
 
 class WaitToContinue:
     """WaitToContinue class for synchronizing signal and data acquisition.

--- a/src/navigate/model/features/common_features.py
+++ b/src/navigate/model/features/common_features.py
@@ -177,7 +177,7 @@ class WaitForExternalTrigger:
 
 class ProjectionMode:
 
-    def __init__(self, model, z_range=None, shear_amp=None, axis='z', galvo_num=0, enable=True):
+    def __init__(self, model, axis='z', galvo_num=0, enable=True, z_range=None, shear_amp=None):
 
         self.model = model
 

--- a/src/navigate/model/features/feature_related_functions.py
+++ b/src/navigate/model/features/feature_related_functions.py
@@ -53,6 +53,7 @@ from navigate.model.features.common_features import (
     StackPause,  # noqa
     ZStackAcquisition,  # noqa
     FindTissueSimple2D,  # noqa
+    ProjectionMode, # noqa
 )
 from navigate.model.features.image_writer import ImageWriter  # noqa
 from navigate.model.features.restful_features import IlastikSegmentation  # noqa

--- a/src/navigate/model/model.py
+++ b/src/navigate/model/model.py
@@ -730,8 +730,16 @@ class Model:
             coefficients = self.active_microscope.mirror.set_from_wcs_file(path=args[0])
             self.update_mirror(coef=coefficients)
         elif command == "tony_wilson":
-            tony_wilson = TonyWilson(self)
-            tony_wilson.run(*args)
+            # tony_wilson = TonyWilson(self)
+            # tony_wilson.run(*args)
+            self.configuration["experiment"]["MicroscopeState"][
+                "image_mode"
+            ] = "customized"
+            self.addon_feature = [
+                    {"name": PrepareNextChannel},
+                    {"name": TonyWilson}
+                ]
+            self.run_command("acquire")            
 
         elif command == "load_feature":
             """

--- a/src/navigate/view/popups/adaptiveoptics_popup.py
+++ b/src/navigate/view/popups/adaptiveoptics_popup.py
@@ -361,13 +361,6 @@ class AdaptiveOpticsPopup:
             row=0, column=0, sticky=tk.NSEW, padx=(5, 5), pady=(5, 5)
         )
 
-        camera_var = tk.StringVar()
-        #: ttk.Combobox: Camera List
-        self.camera_list = ttk.Combobox(master=self.tab_cnn, textvariable=camera_var)
-        # self.camera_list["values"] = ("cam_0", "cam_1")
-        self.camera_list.grid(row=0, column=0, padx=10, pady=10)
-        # self.camera_list.current(0)
-
     def onFrameConfigure(self, event):
         """Reset the scroll region to encompass the inner frame.
 


### PR DESCRIPTION
I've added the ProjectionMode feature which can be inserted in a feature list to set the z-galvo to do a sweep per frame for projection mode. Setting the `enable` parameter to `True` turns it on, and `False` turns it off. 

I also cleaned up the TonyWilson adaptive optics feature: there were some bugs with hanging at the end when using the RUN button vs running in a feature list, and parameters not updating dynamically. It seems to work much better now.

Here is an example of a feature list which works well now:

```
[{"name": ProjectionMode,"args": ("z",0,True,50,-0.115,),},{"name": PrepareNextChannel,},{"name": TonyWilson,"args": (False,),},{"name": ProjectionMode,"args": ("z",0,False,None,None,),},{"name": ZStackAcquisition,"args": (False,False,"z-stack",False,),},{"name": WaitToContinue,},]
```

It's basically: Enable projection > Do projection AO > Switch back to stacking > Get a stack. Runs like a dream!