### PR TITLE
Provide Additional User Context

### DIFF
--- a/src/navigate/controller/sub_controllers/camera_view.py
+++ b/src/navigate/controller/sub_controllers/camera_view.py
@@ -1647,7 +1647,8 @@ class MIPViewController(BaseViewController):
         if self.image_mode in ["live", "single"]:
             return
 
-        if self.display_enabled.get() is False:
+        if not self.display_enabled.get():
+            self._clear_mip()
             return
 
         # Orthogonal maximum intensity projections.
@@ -1660,6 +1661,20 @@ class MIPViewController(BaseViewController):
         )
 
         super().try_to_display_image(image)
+
+    def _clear_mip(self) -> None:
+        """Clear the mip but keep canvas interactive."""
+        self.canvas.delete("all")
+        self.tk_image = None
+        self.canvas.create_text(
+            self.canvas_width // 2,
+            self.canvas_height // 2,
+            text="Maximum Intensity Projection Disabled\nRight Click to Enable",
+            font=("Arial", 14, "italic"),
+            fill="gray",
+            anchor="center",
+            justify="center",
+        )
 
     def display_image(self, image: np.ndarray) -> None:
         """Display an image using the LUT specified in the View.

--- a/src/navigate/controller/sub_controllers/histogram.py
+++ b/src/navigate/controller/sub_controllers/histogram.py
@@ -160,7 +160,6 @@ class HistogramController:
     def update_experiment(self) -> None:
         """Update the experiment.yaml file. Also communicate any changes to the menu
         controller."""
-        print("histogram controller updated the experiment.yaml file")
         # Get the state of the histogram enabled variable.
         histogram_state = self.histogram_enabled.get()
 
@@ -268,12 +267,19 @@ class HistogramController:
         """Clear the histogram but keep canvas interactive."""
         self.ax.cla()
         self.ax.text(
-            0.5,
-            0.5,
-            "Histogram Disabled\nRight Click to Enable",
-            fontstyle="italic",
+            x=0.5,
+            y=0.5,
+            s="Intensity Histogram Disabled\nRight Click to Enable",
+            fontdict={
+                "family": "Arial",
+                "size": 10,
+                "style": "italic",
+                "color": "gray",
+            },
+            # fontstyle="italic",
             ha="center",
             va="center",
+            bbox=dict(facecolor="white", edgecolor="none", boxstyle="round,pad=0.5"),
             transform=self.ax.transAxes,
         )
         self.ax.set_xticks([])

--- a/src/navigate/controller/sub_controllers/histogram.py
+++ b/src/navigate/controller/sub_controllers/histogram.py
@@ -276,7 +276,6 @@ class HistogramController:
                 "style": "italic",
                 "color": "gray",
             },
-            # fontstyle="italic",
             ha="center",
             va="center",
             bbox=dict(facecolor="white", edgecolor="none", boxstyle="round,pad=0.5"),


### PR DESCRIPTION
Now it should be more obvious when the MIP display is not enabled, who to use it.

You should be able to right-click on both the histogram and the MIP display and enable/disable it. MIP display only works in the z-stack acquisition mode. 