### PR TITLE
Refactor Tecan pump driver and tests for integration with Navigate device layer

### DIFF
--- a/src/navigate/model/devices/pump/tecan.py
+++ b/src/navigate/model/devices/pump/tecan.py
@@ -34,6 +34,7 @@ import logging
 from typing import Any, Dict
 
 # Third Party imports
+from serial import Serial
 
 # Local imports
 from navigate.model.utils.exceptions import UserVisibleException
@@ -41,7 +42,8 @@ from navigate.model.utils.exceptions import UserVisibleException
 # Initialize logger
 logger = logging.getLogger(__name__)
 
-class XCaliburPump():
+
+class XCaliburPump:
     """
     Driver for the Tecan Cavro XCalibur syringe pump.
     Uses ASCII DT protocol over RS-232 via USB-Serial adapter.
@@ -59,8 +61,8 @@ class XCaliburPump():
         "9": "Plunger overload - blocked or overpressured",
         "10": "Valve overload - valve blocked or slipping",
         "11": "Plunger move not allowed - valve in wrong position",
-        "15": "Command overflow - too many characters in buffer"
-    }  
+        "15": "Command overflow - too many characters in buffer",
+    }
 
     def __init__(
         self,
@@ -68,42 +70,77 @@ class XCaliburPump():
         device_connection: Any,
         configuration: Dict[str, Any],
         device_id: int = 0,
-    ):
-            """
-            Initialize the XCaliburPump.
+    ) -> None:
+        """
+        Initialize the XCaliburPump.
 
-            Parameters
-            ----------
-            microscope_name : str
-                Name of the microscope system using this device.
-            device_connection : Serial
-                Pre-established serial connection (created via `connect()` class method).
-            configuration : dict
-                Device-specific configuration dictionary from YAML.
-            device_id : int, optional
-                Identifier if multiple pumps of same type are used.
-            """
-            self.device_name = microscope_name
-            self.serial = device_connection
-            self.configuration = configuration
-            self.device_id = device_id
+        Parameters
+        ----------
+        microscope_name : str
+            Name of the microscope system using this device.
+        device_connection : Serial
+            Pre-established serial connection (created via `connect()` class method).
+        configuration : dict
+            Device-specific configuration dictionary from YAML.
+        device_id : int, optional
+            Identifier if multiple pumps of same type are used.
+        """
+        #: str: Name of the microscope system using this device.
+        self.device_name = microscope_name
 
-            # Safe fallback values. Ensures the code will work before the pump section is added to configuration file.
-            self.min_speed_code = configuration.get("min_speed_code", 0)
-            self.max_speed_code = configuration.get("max_speed_code", 40)
-            self.fine_positioning = configuration.get("fine_positioning", False)
+        #: Serial: Pre-established serial connection to the pump.
+        self.serial = device_connection
 
-            # Optionally store port/baudrate for logging/debugging
-            self.port = getattr(self.serial, "port", "Unknown")
-            self.baudrate = getattr(self.serial, "baudrate", "Unknown")
-            self.timeout = getattr(self.serial, "timeout", "Unknown")
-    
+        #: dict: Configuration dictionary from YAML.
+        self.configuration = configuration
+
+        #: int: Identifier for this pump instance (if multiple pumps are used).
+        self.device_id = device_id
+
+        # Safe fallback values. Ensures the code will work before the pump section is
+        # added to configuration file.
+        #: int: Minimum speed code for plunger movement. Default is 0.
+        self.min_speed_code = configuration.get("min_speed_code", 0)
+
+        #: int: Maximum speed code for plunger movement. Default is 40.
+        self.max_speed_code = configuration.get("max_speed_code", 40)
+
+        #: bool: Whether the pump is in fine positioning mode.
+        self.fine_positioning = configuration.get("fine_positioning", False)
+
+        # Optionally store port/baudrate for logging/debugging
+        #: str: Serial port name (e.g., '/dev/ttyUSB0').
+        self.port = getattr(self.serial, "port", "Unknown")
+
+        #: int: Baudrate for the serial connection (e.g., 9600).
+        self.baudrate = getattr(self.serial, "baudrate", "Unknown")
+
+        #: str: Timeout for the serial connection (e.g., 0.25 seconds).
+        self.timeout = getattr(self.serial, "timeout", "Unknown")
+
     @classmethod
-    def connect(cls, port, baudrate=9600, timeout=0.25):
-        from serial import Serial
+    def connect(cls, port: str, baudrate: int = 9600, timeout: float = 0.25) -> Serial:
+        """
+        Create a new Serial connection to the pump.
+
+        Parameters
+        ----------
+        port : str
+            The serial port to connect to (e.g., '/dev/ttyUSB0').
+        baudrate : int, optional
+            The baud rate for the serial connection (default is 9600).
+        timeout : float, optional
+            The timeout for read operations (default is 0.25 seconds).
+
+        Returns
+        -------
+        Serial
+            An open Serial object connected to the specified port.
+        """
+
         return Serial(port=port, baudrate=baudrate, timeout=timeout)
 
-    def initialize_pump(self):
+    def initialize_pump(self) -> None:
         """
         Send the 'ZR' (Zero and Reset) command to initialize the pump state.
 
@@ -117,7 +154,7 @@ class XCaliburPump():
         response = self.read_response()
         self.parse_response(response)
 
-    def disconnect(self):
+    def disconnect(self) -> None:
         """
         Close the serial connection to the pump.
         """
@@ -125,9 +162,11 @@ class XCaliburPump():
             self.serial.close()
             logger.info(f"[{self.device_name}] Serial connection closed")
         else:
-            logger.warning(f"[{self.device_name}] Serial already closed or uninitialized")
-    
-    def send_command(self, command: str):
+            logger.warning(
+                f"[{self.device_name}] Serial already closed or uninitialized"
+            )
+
+    def send_command(self, command: str) -> bytes:
         """
         Send a command string to the pump, appending carriage return.
 
@@ -159,9 +198,11 @@ class XCaliburPump():
             logger.debug(f"[{self.device_name}] Sent: {repr(full_command)}")
             return full_command
         except Exception as e:
-            raise UserVisibleException(f"[{self.device_name}] Error sending command {repr(command)}: {e}")
-        
-    def read_response(self, expected_bytes=32) -> str:
+            raise UserVisibleException(
+                f"[{self.device_name}] Error sending command {repr(command)}: {e}"
+            )
+
+    def read_response(self, expected_bytes: int = 32) -> str:
         """
         Read a response from the pump after sending a command.
 
@@ -190,15 +231,17 @@ class XCaliburPump():
         try:
             response = self.serial.read(expected_bytes)
             if not response:
-                raise UserVisibleException(f"[{self.device_name}] No response received (timeout or disconnected)")
+                raise UserVisibleException(
+                    f"[{self.device_name}] No response received (timeout or disconnected)"
+                )
             decoded = response.decode("ascii").strip()
             logger.debug(f"[{self.device_name}] Received: {repr(decoded)}")
-            
+
             return decoded
-        
+
         except Exception as e:
             raise UserVisibleException(f"[{self.device_name}] Error during read: {e}")
-        
+
     def parse_response(self, response: str) -> str:
         """
         Parse the response string from the pump and extract the status code.
@@ -222,30 +265,38 @@ class XCaliburPump():
             If the response is malformed or indicates a hardware error.
         """
         if not response.startswith("/"):
-            raise UserVisibleException(f"[{self.device_name}] Malformed response (missing start '/'): {repr(response)}")
+            raise UserVisibleException(
+                f"[{self.device_name}] Malformed response (missing start '/'): {repr(response)}"
+            )
 
         if len(response) < 3:
-            raise UserVisibleException(f"[{self.device_name}] Incomplete response: {repr(response)}")
+            raise UserVisibleException(
+                f"[{self.device_name}] Incomplete response: {repr(response)}"
+            )
 
         status_code = response[2]
 
         if status_code != "0":
             # Try to find error in dict of all known errors.
-            error_message = self.ERROR_CODES.get(status_code, f"Unknown error code: {status_code}")
-            
-            raise UserVisibleException(f"[{self.device_name}] Pump error /{status_code}: {error_message}")
+            error_message = self.ERROR_CODES.get(
+                status_code, f"Unknown error code: {status_code}"
+            )
+
+            raise UserVisibleException(
+                f"[{self.device_name}] Pump error /{status_code}: {error_message}"
+            )
 
         logger.info(f"[{self.device_name}] Status OK (/0)")
         return status_code
-    
-    def get_status(self):
+
+    def get_status(self) -> str:
         """Send the '?' command to query current pump status."""
         self.send_command("?")
         logger.info(f"[{self.device_name}] Queried current pump status")
 
         return self.read_response()
 
-    def move_absolute(self, position: int):
+    def move_absolute(self, position: int) -> None:
         """
         Move the syringe plunger to an absolute position.
 
@@ -273,7 +324,7 @@ class XCaliburPump():
         self.send_command(f"A{position}")
         self.parse_response(self.read_response())
 
-    def move_relative(self, steps: int):
+    def move_relative(self, steps: int) -> None:
         """
         Move the syringe plunger by a relative number of steps.
 
@@ -300,7 +351,7 @@ class XCaliburPump():
         self.send_command(f"M{steps}")
         self.parse_response(self.read_response())
 
-    def set_speed(self, speed: int):
+    def set_speed(self, speed: int) -> None:
         """
         Set the pump plunger speed using a predefined speed code.
 
@@ -332,7 +383,7 @@ class XCaliburPump():
         self.send_command(f"S{speed}")
         self.parse_response(self.read_response())
 
-    def valve_input(self):
+    def valve_input(self) -> None:
         """Move valve to input position (aspiration setup).
 
         Raises
@@ -343,9 +394,9 @@ class XCaliburPump():
         self.send_command("I")
         self.parse_response(self.read_response())
 
-    def valve_output(self):
+    def valve_output(self) -> None:
         """Move valve to output position (dispensing setup).
-        
+
         Raises
         ------
         UserVisibleException
@@ -355,9 +406,9 @@ class XCaliburPump():
         self.send_command("O")
         self.parse_response(self.read_response())
 
-    def valve_bypass(self):
+    def valve_bypass(self) -> None:
         """Move valve to bypass position (input connected directly to output).
-        
+
         Raises
         ------
         UserVisibleException
@@ -366,9 +417,9 @@ class XCaliburPump():
         self.send_command("B")
         self.parse_response(self.read_response())
 
-    def valve_extra(self):
+    def valve_extra(self) -> None:
         """Move valve to extra port (3-port distribution valve only).
-        
+
         Raises
         ------
         UserVisibleException
@@ -377,7 +428,7 @@ class XCaliburPump():
         self.send_command("E")
         self.parse_response(self.read_response())
 
-    def set_fine_positioning_mode(self, enable: bool = True):
+    def set_fine_positioning_mode(self, enable: bool = True) -> None:
         """
         Enable or disable fine positioning mode and update internal state.
 
@@ -395,15 +446,23 @@ class XCaliburPump():
             If the pump rejects the configuration command or fails to apply it.
         """
         mode = "1" if enable else "0"
-        self.send_command(f"N{mode}") # # Load fine positioning mode (1 = on, 0 = off) into the pump's command buffer.
+        # Load fine positioning mode (1 = on, 0 = off) into the pump's command buffer.
+        self.send_command(f"N{mode}")
         self.parse_response(self.read_response())
-        
-        self.send_command("R") # Execute the buffered configuration command to apply the mode change.
+
+        # Execute the buffered configuration command to apply the mode change.
+        self.send_command("R")
         self.parse_response(self.read_response())
 
         self.fine_positioning = enable
         logger.info(f"[{self.device_name}] Fine positioning set to: {enable}")
 
-    def get_max_position(self):
-        """Return the maximum allowed plunger position based on positioning mode."""
+    def get_max_position(self) -> int:
+        """Return the maximum allowed plunger position based on positioning mode.
+
+        Returns
+        -------
+        int
+            Maximum plunger position in microsteps or encoder units.
+        """
         return 24000 if self.fine_positioning else 3000

--- a/src/navigate/model/devices/pump/tecan.py
+++ b/src/navigate/model/devices/pump/tecan.py
@@ -1,0 +1,409 @@
+# Copyright (c) 2021-2025  The University of Texas Southwestern Medical Center.
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted for academic and research use only (subject to the
+# limitations in the disclaimer below) provided that the following conditions are met:
+
+#      * Redistributions of source code must retain the above copyright notice,
+#      this list of conditions and the following disclaimer.
+
+#      * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+
+#      * Neither the name of the copyright holders nor the names of its
+#      contributors may be used to endorse or promote products derived from this
+#      software without specific prior written permission.
+
+# NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE GRANTED BY
+# THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+# CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+# PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+# BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+# IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# Standard Library Imports
+import logging
+from typing import Any, Dict
+
+# Third Party imports
+
+# Local imports
+from navigate.model.utils.exceptions import UserVisibleException
+
+# Initialize logger
+logger = logging.getLogger(__name__)
+
+class XCaliburPump():
+    """
+    Driver for the Tecan Cavro XCalibur syringe pump.
+    Uses ASCII DT protocol over RS-232 via USB-Serial adapter.
+    """
+
+    ERROR_CODES = {
+        "0": "No error",
+        "1": "Initialization error - pump failed to initialize",
+        "2": "Invalid command",
+        "3": "Invalid operand - bad parameter value",
+        "4": "Invalid command sequence - check protocol structure",
+        "5": "Fluid detection - leak sensor triggered",
+        "6": "EEPROM failure - hardware fault",
+        "7": "Device not initialized - run ZR command",
+        "9": "Plunger overload - blocked or overpressured",
+        "10": "Valve overload - valve blocked or slipping",
+        "11": "Plunger move not allowed - valve in wrong position",
+        "15": "Command overflow - too many characters in buffer"
+    }  
+
+    def __init__(
+        self,
+        microscope_name: str,
+        device_connection: Any,
+        configuration: Dict[str, Any],
+        device_id: int = 0,
+    ):
+            """
+            Initialize the XCaliburPump.
+
+            Parameters
+            ----------
+            microscope_name : str
+                Name of the microscope system using this device.
+            device_connection : Serial
+                Pre-established serial connection (created via `connect()` class method).
+            configuration : dict
+                Device-specific configuration dictionary from YAML.
+            device_id : int, optional
+                Identifier if multiple pumps of same type are used.
+            """
+            self.device_name = microscope_name
+            self.serial = device_connection
+            self.configuration = configuration
+            self.device_id = device_id
+
+            # Safe fallback values. Ensures the code will work before the pump section is added to configuration file.
+            self.min_speed_code = configuration.get("min_speed_code", 0)
+            self.max_speed_code = configuration.get("max_speed_code", 40)
+            self.fine_positioning = configuration.get("fine_positioning", False)
+
+            # Optionally store port/baudrate for logging/debugging
+            self.port = getattr(self.serial, "port", "Unknown")
+            self.baudrate = getattr(self.serial, "baudrate", "Unknown")
+            self.timeout = getattr(self.serial, "timeout", "Unknown")
+    
+    @classmethod
+    def connect(cls, port, baudrate=9600, timeout=0.25):
+        from serial import Serial
+        return Serial(port=port, baudrate=baudrate, timeout=timeout)
+
+    def initialize_pump(self):
+        """
+        Send the 'ZR' (Zero and Reset) command to initialize the pump state.
+
+        This is typically called at startup to ensure the pump is in a known
+        idle state and the plunger position is zeroed.
+
+        It's not strictly required before all commands, but it's good practice,
+        especially after power-on or fault conditions.
+        """
+        self.send_command("ZR")
+        response = self.read_response()
+        self.parse_response(response)
+
+    def disconnect(self):
+        """
+        Close the serial connection to the pump.
+        """
+        if self.serial and self.serial.is_open:
+            self.serial.close()
+            logger.info(f"[{self.device_name}] Serial connection closed")
+        else:
+            logger.warning(f"[{self.device_name}] Serial already closed or uninitialized")
+    
+    def send_command(self, command: str):
+        """
+        Send a command string to the pump, appending carriage return.
+
+        Parameters
+        ----------
+        command : str
+            The ASCII command to send (without carriage return).
+
+        Returns
+        -------
+        bytes
+            The raw command sent, encoded as bytes.
+
+        Raises
+        ------
+        UserVisibleException
+            If the serial connection is not established or the write fails.
+        """
+        if not self.serial:
+            raise UserVisibleException(f"[{self.device_name}] Serial object is None")
+
+        if not self.serial.is_open:
+            raise UserVisibleException(f"[{self.device_name}] Serial port not open")
+
+        full_command = (command + "\r").encode("ascii")
+
+        try:
+            self.serial.write(full_command)
+            logger.debug(f"[{self.device_name}] Sent: {repr(full_command)}")
+            return full_command
+        except Exception as e:
+            raise UserVisibleException(f"[{self.device_name}] Error sending command {repr(command)}: {e}")
+        
+    def read_response(self, expected_bytes=32) -> str:
+        """
+        Read a response from the pump after sending a command.
+
+        Parameters
+        ----------
+        expected_bytes : int
+            How many bytes to attempt to read (or until timeout).
+
+        Returns
+        -------
+        str
+            The decoded response string.
+
+        Raises
+        ------
+        UserVisibleException
+            If the serial connection is not open, the response is empty,
+            or a decoding error occurs.
+        """
+        if not self.serial:
+            raise UserVisibleException(f"[{self.device_name}] Serial object is None")
+
+        if not self.serial.is_open:
+            raise UserVisibleException(f"[{self.device_name}] Serial port not open")
+
+        try:
+            response = self.serial.read(expected_bytes)
+            if not response:
+                raise UserVisibleException(f"[{self.device_name}] No response received (timeout or disconnected)")
+            decoded = response.decode("ascii").strip()
+            logger.debug(f"[{self.device_name}] Received: {repr(decoded)}")
+            
+            return decoded
+        
+        except Exception as e:
+            raise UserVisibleException(f"[{self.device_name}] Error during read: {e}")
+        
+    def parse_response(self, response: str) -> str:
+        """
+        Parse the response string from the pump and extract the status code.
+
+        The status code indicates whether the command was accepted (/0),
+        or rejected due to a specific error (e.g. /1 = invalid command, /3 = not initialized).
+
+        Parameters
+        ----------
+        response : str
+            Full raw response string from the pump (e.g., "/00").
+
+        Returns
+        -------
+        str
+            Status code as a string ("0" = success, "1" = error, etc.)
+
+        Raises
+        ------
+        UserVisibleException
+            If the response is malformed or indicates a hardware error.
+        """
+        if not response.startswith("/"):
+            raise UserVisibleException(f"[{self.device_name}] Malformed response (missing start '/'): {repr(response)}")
+
+        if len(response) < 3:
+            raise UserVisibleException(f"[{self.device_name}] Incomplete response: {repr(response)}")
+
+        status_code = response[2]
+
+        if status_code != "0":
+            # Try to find error in dict of all known errors.
+            error_message = self.ERROR_CODES.get(status_code, f"Unknown error code: {status_code}")
+            
+            raise UserVisibleException(f"[{self.device_name}] Pump error /{status_code}: {error_message}")
+
+        logger.info(f"[{self.device_name}] Status OK (/0)")
+        return status_code
+    
+    def get_status(self):
+        """Send the '?' command to query current pump status."""
+        self.send_command("?")
+        logger.info(f"[{self.device_name}] Queried current pump status")
+
+        return self.read_response()
+
+    def move_absolute(self, position: int):
+        """
+        Move the syringe plunger to an absolute position.
+
+        Sends the 'A' (move Absolute) command to the pump,
+        instructing it to move the plunger to the specified absolute position.
+
+        Parameters
+        ----------
+        position : int
+            Target plunger position, in pump-specific units (e.g., microsteps or encoder units).
+            Must be within the valid motion range defined by the pump configuration.
+
+        Raises
+        ------
+        UserVisibleException
+            If the specified position is out of bounds or if the pump returns an error status.
+        """
+        max_pos = self.get_max_position()
+        if not (0 <= position <= max_pos):
+            raise UserVisibleException(
+                f"[{self.device_name}] Position {position} is out of bounds "
+                f"(0–{max_pos}) for {'fine' if self.fine_positioning else 'standard'} mode"
+            )
+
+        self.send_command(f"A{position}")
+        self.parse_response(self.read_response())
+
+    def move_relative(self, steps: int):
+        """
+        Move the syringe plunger by a relative number of steps.
+
+        This sends the 'M' (move Relative) command to the pump. The motion will be
+        accepted as long as the resulting absolute position remains within the allowed
+        range (0 to 3000 in standard mode, 0 to 24000 in fine positioning mode).
+
+        Notes
+        -----
+        This method does not perform bounds checking. If the relative move would
+        result in an invalid plunger position, the pump will reject the command and
+        return an appropriate error status (e.g., plunger overtravel).
+
+        Parameters
+        ----------
+        steps : int
+            Number of increments to move. Positive = forward, negative = backward.
+
+        Raises
+        ------
+        UserVisibleException
+            If the pump rejects the command or serial communication fails.
+        """
+        self.send_command(f"M{steps}")
+        self.parse_response(self.read_response())
+
+    def set_speed(self, speed: int):
+        """
+        Set the pump plunger speed using a predefined speed code.
+
+        Sends the 'S' (Speed) command to configure the speed at which the
+        plunger moves during subsequent operations. The speed is specified as
+        an integer code between 0 and 40, which the pump firmware maps to a
+        specific plunger velocity and stroke time.
+
+        Speed code 0 corresponds to the fastest movement (6000 pulses/sec),
+        and code 40 to the slowest (10 pulses/sec). These codes are defined by
+        the internal firmware and can be constrained during driver initialization
+        using 'min_speed_code' and 'max_speed_code'.
+
+        Parameters
+        ----------
+        speed : int
+            Speed code to set. Must be within the range defined by
+            'self.min_speed_code' and 'self.max_speed_code'.
+
+        Raises
+        ------
+        UserVisibleException
+            If the speed code is out of bounds or the command is rejected.
+        """
+        if not (self.min_speed_code <= speed <= self.max_speed_code):
+            raise UserVisibleException(
+                f"Speed code {speed} out of bounds ({self.min_speed_code}-{self.max_speed_code})"
+            )
+        self.send_command(f"S{speed}")
+        self.parse_response(self.read_response())
+
+    def valve_input(self):
+        """Move valve to input position (aspiration setup).
+
+        Raises
+        ------
+        UserVisibleException
+            If the valve command fails or the pump returns an error.
+        """
+        self.send_command("I")
+        self.parse_response(self.read_response())
+
+    def valve_output(self):
+        """Move valve to output position (dispensing setup).
+        
+        Raises
+        ------
+        UserVisibleException
+            If the valve command fails or the pump returns an error.
+
+        """
+        self.send_command("O")
+        self.parse_response(self.read_response())
+
+    def valve_bypass(self):
+        """Move valve to bypass position (input connected directly to output).
+        
+        Raises
+        ------
+        UserVisibleException
+            If the valve command fails or the pump returns an error.
+        """
+        self.send_command("B")
+        self.parse_response(self.read_response())
+
+    def valve_extra(self):
+        """Move valve to extra port (3-port distribution valve only).
+        
+        Raises
+        ------
+        UserVisibleException
+            If the valve command fails or the pump returns an error.
+        """
+        self.send_command("E")
+        self.parse_response(self.read_response())
+
+    def set_fine_positioning_mode(self, enable: bool = True):
+        """
+        Enable or disable fine positioning mode and update internal state.
+
+        The pump must be initialized and idle before calling this method.
+
+        Parameters
+        ----------
+        enable : bool
+            If True, enables fine positioning mode (N1).
+            If False, disables it (N0 - standard mode).
+
+        Raises
+        ------
+        UserVisibleException
+            If the pump rejects the configuration command or fails to apply it.
+        """
+        mode = "1" if enable else "0"
+        self.send_command(f"N{mode}") # # Load fine positioning mode (1 = on, 0 = off) into the pump's command buffer.
+        self.parse_response(self.read_response())
+        
+        self.send_command("R") # Execute the buffered configuration command to apply the mode change.
+        self.parse_response(self.read_response())
+
+        self.fine_positioning = enable
+        logger.info(f"[{self.device_name}] Fine positioning set to: {enable}")
+
+    def get_max_position(self):
+        """Return the maximum allowed plunger position based on positioning mode."""
+        return 24000 if self.fine_positioning else 3000

--- a/test/model/devices/pump/test_tecan.py
+++ b/test/model/devices/pump/test_tecan.py
@@ -39,12 +39,15 @@ from unittest.mock import patch
 from navigate.model.devices.pump.tecan import XCaliburPump
 from navigate.model.utils.exceptions import UserVisibleException
 
+
 class FakeSerial:
     def __init__(self, port, baudrate, timeout):
-        self.commands = []           # Record of all sent commands (as bytes).
-        self.is_open = True          # Pretend the serial port is open.
-        self.last_command = None     # Stores the last command sent (as string, no \r).
-        self.command_responses = {}  # Maps command strings (e.g., "S5") to fake byte responses.
+        self.commands = []  # Record of all sent commands (as bytes).
+        self.is_open = True  # Pretend the serial port is open.
+        self.last_command = None  # Stores the last command sent (as string, no \r).
+        self.command_responses = (
+            {}
+        )  # Maps command strings (e.g., "S5") to fake byte responses.
 
         self.port = port
         self.baudrate = baudrate
@@ -63,12 +66,12 @@ class FakeSerial:
         - Updates last_command with the stripped string version (used for read lookup).
         - Appends the raw byte-formatted command to the commands list to keep track of which order the commands are sent.
         """
-        
+
         self.last_command = data.decode("ascii").strip()
         self.commands.append(data)
 
     def read(self, n: int) -> bytes:
-        """ 
+        """
         Simulate receiving a response from the pump.
 
         If a response has been predefined for the last command (e.g., to simulate an error or custom reply),
@@ -78,7 +81,8 @@ class FakeSerial:
         """
         if self.last_command in self.command_responses:
             return self.command_responses[self.last_command]
-        return b"/00" # If no command has been sent yet, return the "success" response as fallback.
+        return b"/00"  # If no command has been sent yet, return the "success" response as fallback.
+
 
 @pytest.fixture
 def fake_pump():
@@ -106,8 +110,9 @@ def fake_pump():
         device_connection=fake_serial,
         configuration=config,
     )
-    
+
     return pump
+
 
 def test_set_speed_command_rejected(fake_pump):
     """
@@ -115,7 +120,7 @@ def test_set_speed_command_rejected(fake_pump):
 
     This test configures the FakeSerial to return error code '/03' (Invalid Operand)
     in response to a speed code that is within the allowed local range. This models a case
-    where the driver sends a syntactically valid command (e.g., 'S4'), but the pump 
+    where the driver sends a syntactically valid command (e.g., 'S4'), but the pump
     firmware rejects the operand value due to internal state or configuration.
 
     The test verifies that the driver:
@@ -123,16 +128,24 @@ def test_set_speed_command_rejected(fake_pump):
     - Parses the response.
     - Raises a RuntimeError with an appropriate error message.
     """
-    valid_speed = fake_pump.max_speed_code - 1 # Within bounds.
+    valid_speed = fake_pump.max_speed_code - 1  # Within bounds.
 
-    fake_pump.serial.command_responses["S" + str(valid_speed)] = b"/03" # Simulate command-response.
+    fake_pump.serial.command_responses["S" + str(valid_speed)] = (
+        b"/03"  # Simulate command-response.
+    )
 
     # Make sure the pre-defined response raises the correct error.
-    with pytest.raises(UserVisibleException, match="Pump error /3: Invalid operand - bad parameter value"):
-        fake_pump.set_speed(valid_speed) 
+    with pytest.raises(
+        UserVisibleException,
+        match="Pump error /3: Invalid operand - bad parameter value",
+    ):
+        fake_pump.set_speed(valid_speed)
 
-@patch("serial.Serial")
-def test_connect_and_initialize_success(mock_serial_class): # Argument passed automatically from patch (mocked version of Serial).
+
+@patch("navigate.model.devices.pump.tecan.Serial")
+def test_connect_and_initialize_success(
+    mock_serial_class,
+):  # Argument passed automatically from patch (mocked version of Serial).
     """
     Simulate a successful connection using FakeSerial via patching.
     """
@@ -163,8 +176,11 @@ def test_connect_and_initialize_success(mock_serial_class): # Argument passed au
     assert fake_serial.commands[-1] == b"ZR\r"
     assert fake_serial.is_open
 
+
 @patch("serial.Serial")
-def test_initialization_error(mock_serial_class): # Argument passed automatically from patch (mocked version of Serial).
+def test_initialization_error(
+    mock_serial_class,
+):  # Argument passed automatically from patch (mocked version of Serial).
     """
     Simulate a pump that fails to initialize (command 'ZR', response '/01').
 
@@ -187,7 +203,9 @@ def test_initialization_error(mock_serial_class): # Argument passed automaticall
     )
 
     # Expect a RuntimeError due to /01 response.
-    with pytest.raises(UserVisibleException, match="Pump error /1: Initialization error"):
+    with pytest.raises(
+        UserVisibleException, match="Pump error /1: Initialization error"
+    ):
         pump.initialize_pump()
 
     # Check that the correct command was sent.
@@ -197,6 +215,7 @@ def test_initialization_error(mock_serial_class): # Argument passed automaticall
 # NOTE: We do not wrap or handle exceptions in XCaliburPump.connect().
 # Errors like Serial(port=...) failures are allowed to propagate.
 # Therefore, no test is needed for connect() error handling.
+
 
 def test_send_command_raises_if_serial_is_none():
     """
@@ -213,6 +232,7 @@ def test_send_command_raises_if_serial_is_none():
 
     with pytest.raises(UserVisibleException, match="Serial object is None"):
         pump.send_command("ZR")
+
 
 def test_move_absolute_success_standard_and_fine_modes(fake_pump):
     """
@@ -245,6 +265,7 @@ def test_move_absolute_success_standard_and_fine_modes(fake_pump):
     fake_pump.move_absolute(position_fine)
     assert fake_pump.serial.commands[-1] == f"A{position_fine}\r".encode()
 
+
 def test_move_absolute_out_of_bounds_raises(fake_pump):
     """
     Verify that move_absolute() raises UserVisibleException when given a position
@@ -259,6 +280,7 @@ def test_move_absolute_out_of_bounds_raises(fake_pump):
     fake_pump.fine_positioning = True
     with pytest.raises(UserVisibleException, match="out of bounds"):
         fake_pump.move_absolute(24000 + 1)
+
 
 def test_set_fine_positioning_mode_toggle(fake_pump):
     """
@@ -293,6 +315,7 @@ def test_set_fine_positioning_mode_toggle(fake_pump):
     assert fake_pump.fine_positioning is False
     assert fake_pump.serial.commands[-2] == b"N0\r"
     assert fake_pump.serial.commands[-1] == b"R\r"
+
 
 # TODO: Once pump is integrated into Model/Controller, test that
 # UserVisibleException raised by pump results in a warning event.

--- a/test/model/devices/pump/test_tecan.py
+++ b/test/model/devices/pump/test_tecan.py
@@ -1,0 +1,298 @@
+# Copyright (c) 2021-2025  The University of Texas Southwestern Medical Center.
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted for academic and research use only (subject to the
+# limitations in the disclaimer below) provided that the following conditions are met:
+
+#      * Redistributions of source code must retain the above copyright notice,
+#      this list of conditions and the following disclaimer.
+
+#      * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+
+#      * Neither the name of the copyright holders nor the names of its
+#      contributors may be used to endorse or promote products derived from this
+#      software without specific prior written permission.
+
+# NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE GRANTED BY
+# THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+# CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+# PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+# BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+# IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# Standard Library Imports
+import pytest
+from unittest.mock import patch
+
+# Third Party Imports
+
+# Local Imports
+from navigate.model.devices.pump.tecan import XCaliburPump
+from navigate.model.utils.exceptions import UserVisibleException
+
+class FakeSerial:
+    def __init__(self, port, baudrate, timeout):
+        self.commands = []           # Record of all sent commands (as bytes).
+        self.is_open = True          # Pretend the serial port is open.
+        self.last_command = None     # Stores the last command sent (as string, no \r).
+        self.command_responses = {}  # Maps command strings (e.g., "S5") to fake byte responses.
+
+        self.port = port
+        self.baudrate = baudrate
+        self.timeout = timeout
+
+    def open(self):
+        self.is_open = True
+
+    def close(self):
+        self.is_open = False
+
+    def write(self, data: bytes):
+        """
+        Simulate sending a command to the pump.
+
+        - Updates last_command with the stripped string version (used for read lookup).
+        - Appends the raw byte-formatted command to the commands list to keep track of which order the commands are sent.
+        """
+        
+        self.last_command = data.decode("ascii").strip()
+        self.commands.append(data)
+
+    def read(self, n: int) -> bytes:
+        """ 
+        Simulate receiving a response from the pump.
+
+        If a response has been predefined for the last command (e.g., to simulate an error or custom reply),
+        that specific response is returned.
+
+        Otherwise, a default success response (b"/00") is returned to simulate normal operation.
+        """
+        if self.last_command in self.command_responses:
+            return self.command_responses[self.last_command]
+        return b"/00" # If no command has been sent yet, return the "success" response as fallback.
+
+@pytest.fixture
+def fake_pump():
+    """
+    Fixture that returns an XCaliburPump with a mocked serial connection.
+    """
+
+    # Pick some speeds within the known bounds 0-40.
+    min_speed_code = 2
+    max_speed_code = 19
+    port = "FAKE"
+    baudrate = 9600
+    timeout = 0.5
+
+    fake_serial = FakeSerial(port=port, baudrate=baudrate, timeout=timeout)
+
+    config = {
+        "min_speed_code": min_speed_code,
+        "max_speed_code": max_speed_code,
+        "fine_positioning": False,
+    }
+
+    pump = XCaliburPump(
+        microscope_name="TestPump",
+        device_connection=fake_serial,
+        configuration=config,
+    )
+    
+    return pump
+
+def test_set_speed_command_rejected(fake_pump):
+    """
+    Simulate a firmware-level rejection of a valid speed code.
+
+    This test configures the FakeSerial to return error code '/03' (Invalid Operand)
+    in response to a speed code that is within the allowed local range. This models a case
+    where the driver sends a syntactically valid command (e.g., 'S4'), but the pump 
+    firmware rejects the operand value due to internal state or configuration.
+
+    The test verifies that the driver:
+    - Sends the command correctly.
+    - Parses the response.
+    - Raises a RuntimeError with an appropriate error message.
+    """
+    valid_speed = fake_pump.max_speed_code - 1 # Within bounds.
+
+    fake_pump.serial.command_responses["S" + str(valid_speed)] = b"/03" # Simulate command-response.
+
+    # Make sure the pre-defined response raises the correct error.
+    with pytest.raises(UserVisibleException, match="Pump error /3: Invalid operand - bad parameter value"):
+        fake_pump.set_speed(valid_speed) 
+
+@patch("serial.Serial")
+def test_connect_and_initialize_success(mock_serial_class): # Argument passed automatically from patch (mocked version of Serial).
+    """
+    Simulate a successful connection using FakeSerial via patching.
+    """
+    # Create a custom FakeSerial instance to return instead of MagicMock.
+    fake_serial = FakeSerial(port="FAKE", baudrate=9600, timeout=0.5)
+    fake_serial.command_responses["ZR"] = b"/00"  # Simulate valid response.
+
+    # Tell the mock object what to return instead of Serial.
+    mock_serial_class.return_value = fake_serial
+
+    # Simulate the connect call that is done when all device connections are set up.
+    # Will be the same as fake_serial if successful.
+    serial_connection = XCaliburPump.connect(port="FAKE", baudrate=9600, timeout=0.5)
+
+    mock_serial_class.assert_called_once_with(port="FAKE", baudrate=9600, timeout=0.5)
+
+    # Create the pump and call connect - now it will receive the FakeSerial.
+    pump = XCaliburPump(
+        microscope_name="TestPump",
+        device_connection=serial_connection,
+        configuration={},
+    )
+
+    pump.initialize_pump()
+
+    # Assertions
+    assert pump.serial == fake_serial
+    assert fake_serial.commands[-1] == b"ZR\r"
+    assert fake_serial.is_open
+
+@patch("serial.Serial")
+def test_initialization_error(mock_serial_class): # Argument passed automatically from patch (mocked version of Serial).
+    """
+    Simulate a pump that fails to initialize (command 'ZR', response '/01').
+
+    Verifies that:
+    - The 'ZR' command is sent.
+    - The driver raises RuntimeError when pump reports an init failure.
+    """
+    # Create a custom FakeSerial instance to return instead of MagicMock.
+    fake_serial = FakeSerial(port="FAKE", baudrate=9600, timeout=0.5)
+    fake_serial.command_responses["ZR"] = b"/01"  # Simulate "fail" response.
+
+    # Make sure Serial() returns this custom fake.
+    mock_serial_class.return_value = fake_serial
+
+    # Create the pump.
+    pump = XCaliburPump(
+        microscope_name="TestPump",
+        device_connection=fake_serial,
+        configuration={},
+    )
+
+    # Expect a RuntimeError due to /01 response.
+    with pytest.raises(UserVisibleException, match="Pump error /1: Initialization error"):
+        pump.initialize_pump()
+
+    # Check that the correct command was sent.
+    assert pump.serial.commands[-1] == b"ZR\r"
+
+
+# NOTE: We do not wrap or handle exceptions in XCaliburPump.connect().
+# Errors like Serial(port=...) failures are allowed to propagate.
+# Therefore, no test is needed for connect() error handling.
+
+def test_send_command_raises_if_serial_is_none():
+    """
+    Verifies that send_command() raises if self.serial is None.
+    """
+    fake_serial = FakeSerial(port="FAKE", baudrate=9600, timeout=0.5)
+
+    pump = XCaliburPump(
+        microscope_name="TestPump",
+        device_connection=fake_serial,
+        configuration={},
+    )
+    pump.serial = None  # Simulate uninitialized or failed connection
+
+    with pytest.raises(UserVisibleException, match="Serial object is None"):
+        pump.send_command("ZR")
+
+def test_move_absolute_success_standard_and_fine_modes(fake_pump):
+    """
+    Test that move_absolute() sends the correct command and succeeds in both
+    standard and fine positioning modes, assuming valid position input.
+
+    Verifies that:
+    - The correct 'A{pos}' command is sent.
+    - The pump responds with success.
+    - No exception is raised.
+    """
+    # --- Standard mode ---
+    fake_pump.fine_positioning = False
+    position_std = 3000  # Max allowed position in standard (non-fine) mode.
+
+    # Predefine the pump's response to this specific absolute move command.
+    fake_pump.serial.command_responses[f"A{position_std}"] = b"/00"
+
+    # Send the move_absolute command (which internally sends 'A{position}' + parses response).
+    fake_pump.move_absolute(position_std)
+
+    # Verify that the correct byte-encoded command was sent to the serial interface.
+    assert fake_pump.serial.commands[-1] == f"A{position_std}\r".encode()
+
+    # --- Fine positioning mode ---
+    fake_pump.fine_positioning = True
+    position_fine = 24000  # Max allowed position in fine mode.
+    fake_pump.serial.command_responses[f"A{position_fine}"] = b"/00"
+
+    fake_pump.move_absolute(position_fine)
+    assert fake_pump.serial.commands[-1] == f"A{position_fine}\r".encode()
+
+def test_move_absolute_out_of_bounds_raises(fake_pump):
+    """
+    Verify that move_absolute() raises UserVisibleException when given a position
+    outside the valid range for the current positioning mode.
+    """
+    # Standard mode: max is 3000.
+    fake_pump.fine_positioning = False
+    with pytest.raises(UserVisibleException, match="out of bounds"):
+        fake_pump.move_absolute(3000 + 1)
+
+    # Fine mode: max is 24000.
+    fake_pump.fine_positioning = True
+    with pytest.raises(UserVisibleException, match="out of bounds"):
+        fake_pump.move_absolute(24000 + 1)
+
+def test_set_fine_positioning_mode_toggle(fake_pump):
+    """
+    Verify that set_fine_positioning_mode() sends the correct 'N' and 'R' commands,
+    handles responses properly, and updates the fine_positioning attribute.
+    """
+
+    # Mock responses for enabling fine positioning.
+    # "N1" loads the fine mode into the buffer; "R" applies the change.
+    # Both return "/00" to simulate success.
+    fake_pump.serial.command_responses["N1"] = b"/00"
+    fake_pump.serial.command_responses["R"] = b"/00"
+
+    # Enable fine positioning mode.
+    fake_pump.set_fine_positioning_mode(True)
+
+    # Check that the internal state was updated.
+    assert fake_pump.fine_positioning is True
+
+    # Confirm that the correct commands were sent in the correct order
+    # inside set_fine_positioning_mode().
+    assert fake_pump.serial.commands[-2] == b"N1\r"
+    assert fake_pump.serial.commands[-1] == b"R\r"
+
+    # Now test disabling fine positioning mode.
+    # "N0" loads standard mode; "R" applies it. Again, simulate success.
+    fake_pump.serial.command_responses["N0"] = b"/00"
+    fake_pump.serial.command_responses["R"] = b"/00"
+
+    fake_pump.set_fine_positioning_mode(False)
+
+    assert fake_pump.fine_positioning is False
+    assert fake_pump.serial.commands[-2] == b"N0\r"
+    assert fake_pump.serial.commands[-1] == b"R\r"
+
+# TODO: Once pump is integrated into Model/Controller, test that
+# UserVisibleException raised by pump results in a warning event.


### PR DESCRIPTION
This PR updates the `XCaliburPump` implementation to make it compatible with the Navigate device layer and naming conventions.

---

## Changes based on integration feedback

- **File naming**: Renamed to `tecan.py` to match manufacturer name.
- **Class naming**: Renamed to `XCaliburPump` to match device model.
- **Constructor updated**: Now follows the standard device interface.
- **Connection interface**: Added required `@classmethod connect(...)` for serial devices.
- **Error handling**: Replaced `RuntimeError`, `ValueError`, etc., with `UserVisibleException`.

---

## Tests

- Test suite updated to match refactored interface.
- Uses `pytest` and mocks Serial with a custom FakeSerial class.

---

## Notes

- This PR **replaces the previous one** (#1122), which was accidentally broken by an incorrect force-push.
- This branch contains only the intended files:
  - `tecan.py`
  - `test_tecan.py`
  with no unrelated history or experimental code.