### PR TITLE
Display update

### DIFF
--- a/src/navigate/controller/sub_controllers/camera_view.py
+++ b/src/navigate/controller/sub_controllers/camera_view.py
@@ -202,9 +202,6 @@ class BaseViewController(GUIController, ABaseViewController):
         #: event: The resize event ID.
         self.resize_event_id = None
 
-        #: np.ndarray: The saturated pixels in the image.
-        self.saturated_pixels = None
-
         #: list: The selected channels being acquired.
         self.selected_channels = None
 
@@ -447,7 +444,6 @@ class BaseViewController(GUIController, ABaseViewController):
     def apply_lut(self, image: np.ndarray) -> np.ndarray:
         """Applies a LUT to an image.
 
-        Red is reserved for saturated pixels.
         self.color_values = ['gray', 'gradient', 'rainbow']
 
         Parameters
@@ -464,18 +460,6 @@ class BaseViewController(GUIController, ABaseViewController):
 
         # Convert RGBA to RGB Image.
         image = image[:, :, :3]
-
-        # Specify the saturated values in the red channel
-        if np.any(self.saturated_pixels):
-            # TODO: Evaluate if this is functional.
-            # Saturated pixels is an array of True or
-            # False statements same size as the image.
-
-            # Pull out the red image from the RGBA
-            # Set saturated pixels to 1, put back into array.
-            red_image = image[:, :, 2]
-            red_image[self.saturated_pixels] = 1
-            image[:, :, 2] = red_image
 
         # Scale back to an 8-bit image.
         image = image * (2**self.bit_depth - 1)
@@ -780,23 +764,6 @@ class BaseViewController(GUIController, ABaseViewController):
 
         return zoom_image
 
-    def detect_saturation(self, image: np.ndarray) -> None:
-        """Look for any pixels at the maximum intensity allowable for the camera.
-
-        Note
-        ----
-        The camera is set to 16-bit depth, so the maximum intensity is 2^16 - 1. If
-        another camera is used, this function should be updated to reflect the maximum
-        intensity value.
-
-        Parameters
-        ----------
-        image : np.ndarray
-            Image data.
-        """
-        saturation_value = 2**16 - 1
-        self.saturated_pixels = image[image > saturation_value]
-
     def down_sample_image(self, image: np.ndarray) -> np.ndarray:
         """Down-sample the data for image display according to widget size.
 
@@ -935,14 +902,13 @@ class BaseViewController(GUIController, ABaseViewController):
     def process_image(self) -> None:
         """Process the image to be displayed.
 
-        Applies digital zoom, detects saturation, down-samples the image, scales the
+        Applies digital zoom, down-samples the image, scales the
         image intensity, adds a crosshair, applies the lookup table, and populates the
         image.
         """
         if self.image is None:
             return
         image = self.digital_zoom()
-        self.detect_saturation(image)
         image = self.down_sample_image(image)
         image = self.transpose_image(image)
         image = self.scale_image_intensity(image)
@@ -975,9 +941,7 @@ class BaseViewController(GUIController, ABaseViewController):
             top_height = self.parent_controller.view.top_frame.winfo_height()
             w_width = self.parent_controller.view.winfo_width()
             w_height = self.parent_controller.view.winfo_height()
-            width = max(
-                w_width - left_width - 16, 560 + self.view.lut.winfo_width()
-            )
+            width = max(w_width - left_width - 16, 560 + self.view.lut.winfo_width())
             height = max(w_height - top_height - 50, 670)
         else:
             width = event.width
@@ -1012,7 +976,7 @@ class BaseViewController(GUIController, ABaseViewController):
                     widget_height += widget.winfo_height() + 5
                     if widget.winfo_height() < 30:
                         widget_height += 30
-                    
+
         self.canvas_height = (
             height - widget_height - (50 if self.view.is_docked else -5)
         )

--- a/src/navigate/controller/sub_controllers/camera_view.py
+++ b/src/navigate/controller/sub_controllers/camera_view.py
@@ -780,7 +780,9 @@ class BaseViewController(GUIController, ABaseViewController):
             Down-sampled image data.
         """
         sx, sy = self.canvas_width, self.canvas_height
-        down_sampled_image = cv2.resize(image, (sx, sy))
+        down_sampled_image = cv2.resize(
+            src=image, dsize=(sx, sy), interpolation=cv2.INTER_NEAREST
+        )
         return down_sampled_image
 
     def scale_image_intensity(self, image: np.ndarray) -> np.ndarray:
@@ -796,7 +798,7 @@ class BaseViewController(GUIController, ABaseViewController):
         image : np.ndarray
             Scaled image data.
         """
-        if self.autoscale is True:
+        if self.autoscale:
             self.max_counts = np.max(image)
             self.min_counts = np.min(image)
         else:

--- a/src/navigate/controller/sub_controllers/camera_view.py
+++ b/src/navigate/controller/sub_controllers/camera_view.py
@@ -152,7 +152,10 @@ class BaseViewController(GUIController, ABaseViewController):
         self.canvas_width_scale = 4
 
         #: str: The colormap for the image.
-        self.colormap = plt.get_cmap("gist_gray")
+        # self.colormap = plt.get_cmap("gist_gray")
+
+        #: np.ndarray: Precomputed lookup table for the image colormap.
+        self.colormap = self._generate_lut("gist_gray")
 
         #: str: The mode of the camera view controller.
         self.mode = "stop"
@@ -372,7 +375,8 @@ class BaseViewController(GUIController, ABaseViewController):
         else:
             cmap_name = target.color.get()
             self._snr_selected = True if cmap_name == "RdBu_r" else False
-            self.colormap = plt.get_cmap(cmap_name)
+            # self.colormap = plt.get_cmap(cmap_name)
+            self.colormap = self._generate_lut(cmap_name)
             self.process_image()
             logger.debug(f"Updating the LUT, {cmap_name}")
 
@@ -441,28 +445,43 @@ class BaseViewController(GUIController, ABaseViewController):
         """
         pass
 
-    def apply_lut(self, image: np.ndarray) -> np.ndarray:
-        """Applies a LUT to an image.
+    @staticmethod
+    def _generate_lut(cmap_name: str) -> np.ndarray:
+        """Create an OpenCV-compatible color lookup table.
 
-        self.color_values = ['gray', 'gradient', 'rainbow']
+        Parameters
+        ----------
+        cmap_name : str
+            Name of the Matplotlib colormap.
+
+        Returns
+        -------
+        numpy.ndarray
+            Lookup table shaped for ``cv2.applyColorMap`` in BGR order.
+        """
+        cmap = plt.get_cmap(cmap_name)
+        lut = (cmap(np.linspace(0, 1, 256))[:, :3] * 255).astype(np.uint8)
+
+        # Convert RGB to BGR for OpenCV
+        lut = lut[:, ::-1]
+        return lut.reshape(256, 1, 3)
+
+    def apply_lut(self, image: np.ndarray) -> np.ndarray:
+        """Apply a LUT to an image.
 
         Parameters
         ----------
         image : np.ndarray
-            Image data.
+            Image data normalized to [0, 1].
 
         Returns
         -------
         image : np.ndarray
-            Image data with LUT applied.
+            RGB image data with LUT applied.
         """
-        image = self.colormap(image)
-
-        # Convert RGBA to RGB Image.
-        image = image[:, :, :3]
-
-        # Scale back to an 8-bit image.
-        image = image * (2**self.bit_depth - 1)
+        image_uint8 = (image * 255).astype(np.uint8)
+        image = cv2.applyColorMap(image_uint8, self.colormap)
+        image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
         return image
 
     def identify_channel_index_and_slice(self) -> tuple:

--- a/test/controller/sub_controllers/test_camera_view.py
+++ b/test/controller/sub_controllers/test_camera_view.py
@@ -287,7 +287,7 @@ class TestCameraViewController:
     def test_process_image(self):
         self.camera_view.image = np.random.randint(0, 256, (600, 800))
         self.camera_view.digital_zoom = MagicMock()
-        self.camera_view.detect_saturation = MagicMock()
+        # self.camera_view.detect_saturation = MagicMock()
         self.camera_view.down_sample_image = MagicMock()
         self.camera_view.scale_image_intensity = MagicMock()
         self.camera_view.add_crosshair = MagicMock()
@@ -297,7 +297,7 @@ class TestCameraViewController:
         self.camera_view.process_image()
 
         self.camera_view.digital_zoom.assert_called()
-        self.camera_view.detect_saturation.assert_called()
+        # self.camera_view.detect_saturation.assert_called()
         self.camera_view.down_sample_image.assert_called()
         self.camera_view.scale_image_intensity.assert_called()
         self.camera_view.add_crosshair.assert_called()
@@ -406,7 +406,7 @@ class TestCameraViewController:
     def test_left_click(self, onoff):
         self.camera_view.add_crosshair = MagicMock()
         self.camera_view.digital_zoom = MagicMock()
-        self.camera_view.detect_saturation = MagicMock()
+        # self.camera_view.detect_saturation = MagicMock()
         self.camera_view.down_sample_image = MagicMock()
         self.camera_view.transpose_image = MagicMock()
         self.camera_view.scale_image_intensity = MagicMock()
@@ -469,8 +469,8 @@ class TestCameraViewController:
         self.camera_view.resize(event)
 
         # monkeypatch cv2.resize
-        def mocked_resize(img, size):
-            return np.ones((size[0], size[1]))
+        def mocked_resize(src, dsize, interpolation=1):
+            return np.ones((dsize[0], dsize[1]))
 
         monkeypatch.setattr(cv2, "resize", mocked_resize)
 
@@ -625,7 +625,7 @@ class TestCameraViewController:
             self.microscope_state, {"img_x_pixels": 50, "img_y_pixels": 100}
         )
         self.camera_view.digital_zoom = MagicMock()
-        self.camera_view.detect_saturation = MagicMock()
+        # self.camera_view.detect_saturation = MagicMock()
         self.camera_view.down_sample_image = MagicMock()
         self.camera_view.scale_image_intensity = MagicMock()
         self.camera_view.apply_lut = MagicMock()
@@ -701,16 +701,6 @@ class TestCameraViewController:
     def test_update_LUT(self):
         # Same as apply LUT TODO
         pass
-
-    def test_detect_saturation(self):
-        test_image = np.random.randint(0, 2**16, size=(100, 100))
-        test_image[:50, :50] = 2**16 - 1  # set top left corner to saturation value
-
-        # Call the function to detect saturation
-        self.camera_view.detect_saturation(test_image)
-
-        # Assert that the saturated pixels were correctly detected
-        assert np.all(self.camera_view.saturated_pixels == 2**16 - 1)
 
     def test_toggle_min_max_button(self):
 


### PR DESCRIPTION
This pull request refactors how color lookup tables (LUTs) are handled in the `CameraViewController`, improving image processing performance. The main changes include replacing Matplotlib colormap objects with precomputed LUTs compatible with OpenCV, removing the saturated pixel detection logic, and streamlining image scaling and resizing methods.

**Colormap and LUT handling:**
* Replaced usage of Matplotlib colormap objects with a new `_generate_lut` method that creates OpenCV-compatible LUTs, ensuring efficient color mapping and compatibility with OpenCV functions. (`colormap` initialization and `update_lut` now use `_generate_lut` instead of `plt.get_cmap`) [[1]](diffhunk://#diff-825e4087e6c566efb6c7c6096f72c9f4ae1a6092aff41baa6040f5533336045eL155-R158) [[2]](diffhunk://#diff-825e4087e6c566efb6c7c6096f72c9f4ae1a6092aff41baa6040f5533336045eL378-R379) [[3]](diffhunk://#diff-825e4087e6c566efb6c7c6096f72c9f4ae1a6092aff41baa6040f5533336045eL447-R484)
* Refactored `apply_lut` to use OpenCV's `applyColorMap` and `cvtColor` for applying LUTs to images, replacing the previous manual RGBA-to-RGB conversion and saturated pixel marking.

**Saturated pixel detection removal:**
* Removed the `saturated_pixels` attribute and the `detect_saturation` method, as well as related logic in `process_image`. Wasn't functional. [[1]](diffhunk://#diff-825e4087e6c566efb6c7c6096f72c9f4ae1a6092aff41baa6040f5533336045eL205-L207) [[2]](diffhunk://#diff-825e4087e6c566efb6c7c6096f72c9f4ae1a6092aff41baa6040f5533336045eL783-L799) [[3]](diffhunk://#diff-825e4087e6c566efb6c7c6096f72c9f4ae1a6092aff41baa6040f5533336045eL938-L945)

**Image resizing and scaling improvements:**
* Updated `down_sample_image` to use OpenCV's `resize` with explicit nearest-neighbor interpolation for the fastest down-sampling results.