### PR TITLE
ZStack imaging with two speed modes

### DIFF
--- a/src/navigate/controller/sub_controllers/channels_tab.py
+++ b/src/navigate/controller/sub_controllers/channels_tab.py
@@ -280,6 +280,9 @@ class ChannelsTabController(GUIController):
             if self.microscope_state_dict["stack_cycling_mode"] == "per_z"
             else "Per Stack"
         )
+        if self.microscope_state_dict.get("speed", "") not in ["Auto", "Fixed"]:
+            self.stack_acq_vals["speed"].set("Auto")
+
         self.channel_setting_controller.populate_experiment_values(
             self.microscope_state_dict["channels"]
         )
@@ -396,7 +399,7 @@ class ChannelsTabController(GUIController):
             "step_size",
         ]:
             self.stack_acq_widgets[widget_name].widget["state"] = state
-        for widget_name in ["cycling", "z_device", "f_device"]:
+        for widget_name in ["cycling", "z_device", "f_device", "speed"]:
             self.stack_acq_widgets[widget_name].widget["state"] = (
                 "readonly" if state == "normal" else "disabled"
             )
@@ -879,6 +882,8 @@ class ChannelsTabController(GUIController):
 
         self.microscope_state_dict["primary_z_axis"] = primary_z_axis
         self.microscope_state_dict["primary_f_axis"] = primary_f_axis
+
+        self.microscope_state_dict["speed"] = self.stack_acq_vals["speed"].get()
 
         secondary_stack_settings= {}
         variable_dict = self.view.stack_acq_frame.additional_stack_setting_variables

--- a/src/navigate/model/devices/daq/ni.py
+++ b/src/navigate/model/devices/daq/ni.py
@@ -438,7 +438,7 @@ class NIDAQ(DAQBase):
         # Specify ports, timing, and triggering
         self.set_external_trigger(self.external_trigger)
 
-    def run_acquisition(self) -> None:
+    def run_acquisition(self, wait_until_done : bool = True) -> None:
         """Run DAQ Acquisition.
 
         Run the tasks for triggering, analog and counter outputs.
@@ -461,6 +461,26 @@ class NIDAQ(DAQBase):
                 [False, True, True, True, False], auto_start=True
             )
 
+        if wait_until_done:
+            try:
+                self.camera_trigger_task.wait_until_done(timeout=10000)
+                for task in self.analog_output_tasks.values():
+                    if self.trigger_mode == "self-trigger":
+                        task.wait_until_done()
+                    task.stop()
+            except Exception:
+                # when triggered from external triggers, sometimes the camera trigger task
+                # is done but not actually done, there will a DAQ WARNING message
+                logger.debug(f"Wait until tasks done failed - {traceback.format_exc()}")
+                pass
+            try:
+                self.camera_trigger_task.stop()
+                if self.trigger_mode == "self-trigger":
+                    self.master_trigger_task.stop()
+            except nidaqmx.DaqError:
+                pass
+
+    def wait_acquisition_done(self) -> None:
         try:
             self.camera_trigger_task.wait_until_done(timeout=10000)
             for task in self.analog_output_tasks.values():

--- a/src/navigate/model/devices/daq/ni.py
+++ b/src/navigate/model/devices/daq/ni.py
@@ -462,25 +462,11 @@ class NIDAQ(DAQBase):
             )
 
         if wait_until_done:
-            try:
-                self.camera_trigger_task.wait_until_done(timeout=10000)
-                for task in self.analog_output_tasks.values():
-                    if self.trigger_mode == "self-trigger":
-                        task.wait_until_done()
-                    task.stop()
-            except Exception:
-                # when triggered from external triggers, sometimes the camera trigger task
-                # is done but not actually done, there will a DAQ WARNING message
-                logger.debug(f"Wait until tasks done failed - {traceback.format_exc()}")
-                pass
-            try:
-                self.camera_trigger_task.stop()
-                if self.trigger_mode == "self-trigger":
-                    self.master_trigger_task.stop()
-            except nidaqmx.DaqError:
-                pass
+            self.wait_acquisition_done()
 
     def wait_acquisition_done(self) -> None:
+        """Wait acquisition tasks done"""
+
         try:
             self.camera_trigger_task.wait_until_done(timeout=10000)
             for task in self.analog_output_tasks.values():

--- a/src/navigate/model/devices/daq/synthetic.py
+++ b/src/navigate/model/devices/daq/synthetic.py
@@ -138,6 +138,7 @@ class SyntheticDAQ(DAQBase):
             self.wait_acquisition_done()
 
     def wait_acquisition_done(self):
+        """Wait for a short time to generate an image"""
         time.sleep(0.01)
         if self.trigger_mode == "self-trigger":
             for microscope_name in self.camera:

--- a/src/navigate/model/devices/daq/synthetic.py
+++ b/src/navigate/model/devices/daq/synthetic.py
@@ -123,7 +123,7 @@ class SyntheticDAQ(DAQBase):
         if self.wait_to_run_lock.locked():
             self.wait_to_run_lock.release()
 
-    def run_acquisition(self):
+    def run_acquisition(self, wait_until_done=True):
         """Run DAQ Acquisition.
 
         Run the tasks for triggering, analog and counter outputs.
@@ -134,6 +134,10 @@ class SyntheticDAQ(DAQBase):
         if self.is_updating_analog_task:
             self.wait_to_run_lock.acquire()
             self.wait_to_run_lock.release()
+        if wait_until_done:
+            self.wait_acquisition_done()
+
+    def wait_acquisition_done(self):
         time.sleep(0.01)
         if self.trigger_mode == "self-trigger":
             for microscope_name in self.camera:

--- a/src/navigate/model/features/common_features.py
+++ b/src/navigate/model/features/common_features.py
@@ -1476,6 +1476,9 @@ class ZStackAcquisition:
                 dict(stack_pos),
                 wait_until_done=False,
             )  # Update position
+
+            if not self.model.is_data_thread_on:
+                self.model.grab_image(getattr(self.model.image_writer, "save_image", None))
             return True
 
         return False

--- a/src/navigate/model/features/common_features.py
+++ b/src/navigate/model/features/common_features.py
@@ -1474,7 +1474,7 @@ class ZStackAcquisition:
                 stack_pos.append((f"{axis}_abs", self.restore_z + offset))
             self.model.move_stage(
                 dict(stack_pos),
-                wait_until_done=False,
+                wait_until_done=not self.model.is_data_thread_on,
             )  # Update position
 
             if not self.model.is_data_thread_on:

--- a/src/navigate/model/microscope.py
+++ b/src/navigate/model/microscope.py
@@ -794,6 +794,10 @@ class Microscope:
         channel = self.configuration["experiment"]["MicroscopeState"]["channels"][
             channel_key
         ]
+        # stop daq task first, give daq some rest time for new tasks
+        if update_daq_task_flag:
+            self.daq.stop_acquisition()
+
         # Filter Wheel Settings.
         for k in self.filter_wheel:
             self.filter_wheel[k].set_filter(channel[k])
@@ -819,7 +823,6 @@ class Microscope:
         # choose to not update the waveform is very useful when running ZStack
         # if there is a NI Galvo stage in the system.
         if update_daq_task_flag:
-            self.daq.stop_acquisition()
             self.daq.prepare_acquisition(channel_key)
 
         # Add Defocus term

--- a/src/navigate/model/model.py
+++ b/src/navigate/model/model.py
@@ -594,6 +594,8 @@ class Model:
                     logger=self.logger,
                 )
             else:
+                if self.imaging_mode == "z-stack":
+                    self.is_data_thread_on = False
                 self.signal_thread = ThreadWithWarning(
                     target=self.run_acquisition,
                     warning_queue=self.event_queue,
@@ -623,7 +625,8 @@ class Model:
                 self.data_thread = threading.Thread(target=self.run_data_process)
             self.data_thread.name = f"{self.imaging_mode} Data"
             self.signal_thread.start()
-            self.data_thread.start()
+            if self.is_data_thread_on:
+                self.data_thread.start()
             for m in self.virtual_microscopes:
                 image_writer = (
                     ImageWriter(
@@ -806,7 +809,7 @@ class Model:
                 self.signal_container.end_flag = True
             if self.signal_thread:
                 self.signal_thread.join()
-            if self.data_thread:
+            if self.is_data_thread_on and self.data_thread:
                 self.data_thread.join()
 
             self.end_acquisition()
@@ -1143,6 +1146,8 @@ class Model:
             self.stop_send_signal = False
             self.injected_flag.value = False
             self.is_live = False
+            self.start_grab_image_flag = False
+            self.is_data_thread_on = True
 
         plugin_obj = self.plugin_acquisition_modes.get(self.imaging_mode, None)
         if plugin_obj and hasattr(plugin_obj, "prepare_acquisition_model"):
@@ -1192,7 +1197,11 @@ class Model:
         # Run the acquisition
         try:
             self.active_microscope.turn_on_laser()
-            self.active_microscope.daq.run_acquisition()
+            self.active_microscope.daq.run_acquisition(wait_until_done=self.is_data_thread_on)
+            if not self.is_data_thread_on:
+                if self.start_grab_image_flag:
+                    self.grab_image(getattr(self.image_writer, "save_image", None))
+                self.active_microscope.daq.wait_acquisition_done()
         except:  # noqa
             self.active_microscope.daq.stop_acquisition()
             if self.active_microscope.current_channel == 0:
@@ -1216,6 +1225,54 @@ class Model:
             self.signal_container.run(wait_response=True)
 
         self.frame_id = (self.frame_id + 1) % self.number_of_frames
+        self.start_grab_image_flag = True
+
+    def grab_image(
+        self, data_func: Optional[callable] = None
+    ) -> None:
+        wait_num = self.camera_wait_iterations
+
+        while not self.stop_acquisition:
+            frame_ids = self.active_microscope.camera.get_new_frame()
+            self.logger.info(f"Running data process, getting frames {frame_ids}")
+            # if there is at least one frame available
+            if not frame_ids:
+                self.logger.debug(
+                    f"Frame not received. Waiting {wait_num}"
+                    f"/{self.camera_wait_iterations} iterations"
+                )
+                wait_num -= 1
+                if wait_num <= 0:
+                    error_statement = (
+                        "Acquisition aborted due to camera time out "
+                        "error. Please verify that the external "
+                        "trigger is connected and configured properly."
+                    )
+
+                    self.logger.debug(error_statement)
+                    print(error_statement)
+                    break
+                continue
+
+            wait_num = self.camera_wait_iterations
+
+            # ImageWriter to save images
+            if data_func:
+                data_func(frame_ids)
+
+            if hasattr(self, "data_container") and not self.data_container.end_flag:
+                if self.data_container.is_closed:
+                    self.logger.info("Data container is closed.")
+                    self.stop_acquisition = True
+                    break
+
+                self.data_container.run(frame_ids)
+
+            # show image
+            self.logger.info(f"Image delivered to controller: {frame_ids[0]}")
+            self.show_img_pipe.send(frame_ids[-1])
+
+            break
 
     def run_live_acquisition(self) -> None:
         """Stream live image to the GUI.
@@ -1264,6 +1321,10 @@ class Model:
                 self.logger.info("Signal container is closed.")
                 self.stop_acquisition = True
                 return
+        if not self.is_data_thread_on:
+            if self.start_grab_image_flag:
+                self.grab_image(getattr(self.image_writer, "save_image", None))
+            self.show_img_pipe.send("stop")
         if self.imaging_mode != "live":
             self.stop_acquisition = True
 

--- a/src/navigate/model/model.py
+++ b/src/navigate/model/model.py
@@ -601,7 +601,10 @@ class Model:
                 )
             else:
                 if self.imaging_mode == "z-stack":
-                    self.is_data_thread_on = False
+                    speed_mode = self.configuration["experiment"][
+                        "MicroscopeState"
+                    ].get("speed", "Auto")
+                    self.is_data_thread_on = speed_mode == "Auto"
                 self.signal_thread = ThreadWithWarning(
                     target=self.run_acquisition,
                     warning_queue=self.event_queue,
@@ -633,6 +636,8 @@ class Model:
             self.signal_thread.start()
             if self.is_data_thread_on:
                 self.data_thread.start()
+
+            # TODO: virtual microscopes only work with data thread on currently.
             for m in self.virtual_microscopes:
                 image_writer = (
                     ImageWriter(
@@ -904,10 +909,10 @@ class Model:
         self.microscopes[microscope_name].stop_stage()
         ret_pos_dict = self.microscopes[microscope_name].get_stage_position()
         return ret_pos_dict
-    
+
     def update_stage_limits(self, microscope_name: str) -> None:
         """Update stage limits
-        
+
         PaParameters
         ----------
         microscope_name : str
@@ -1205,7 +1210,9 @@ class Model:
         # Run the acquisition
         try:
             self.active_microscope.turn_on_laser()
-            self.active_microscope.daq.run_acquisition(wait_until_done=self.is_data_thread_on)
+            self.active_microscope.daq.run_acquisition(
+                wait_until_done=self.is_data_thread_on
+            )
             if not self.is_data_thread_on:
                 if self.available_image_count > 0:
                     self.grab_image(getattr(self.image_writer, "save_image", None))
@@ -1236,9 +1243,14 @@ class Model:
 
         self.frame_id = (self.frame_id + 1) % self.number_of_frames
 
-    def grab_image(
-        self, data_func: Optional[callable] = None
-    ) -> None:
+    def grab_image(self, data_func: Optional[callable] = None) -> None:
+        """Grab one image from the camera.
+        
+        Parameters
+        ----------
+        data_func : Optional[callable]
+            Function to run on the acquired data. Default is None.
+        """
         wait_num = self.camera_wait_iterations
 
         while not self.stop_acquisition:

--- a/src/navigate/model/model.py
+++ b/src/navigate/model/model.py
@@ -251,6 +251,12 @@ class Model:
         #: bool: Submit a request to pause the data thread?
         self.ask_to_pause_data_thread = False
 
+        #: bool: Is there a data thread?
+        self.is_data_thread_on = False
+
+        #: int: Available image frames
+        self.available_image_count = 0
+
         #: int: Number of frames in the data buffer.
         self.number_of_frames = self.configuration["experiment"]["CameraParameters"][
             "databuffer_size"
@@ -1048,7 +1054,8 @@ class Model:
         None
             Execution pauses until resume_data_thread() is called.
         """
-
+        if not self.is_data_thread_on:
+            return
         self.pause_data_ready_lock.acquire()
         self.ask_to_pause_data_thread = True
         self.pause_data_ready_lock.acquire()
@@ -1063,7 +1070,8 @@ class Model:
         None
             Execution continues after pause.
         """
-
+        if not self.is_data_thread_on:
+            return
         self.ask_to_pause_data_thread = False
         self.pause_data_event.set()
         if self.pause_data_ready_lock.locked():
@@ -1146,7 +1154,7 @@ class Model:
             self.stop_send_signal = False
             self.injected_flag.value = False
             self.is_live = False
-            self.start_grab_image_flag = False
+            self.available_image_count = 0
             self.is_data_thread_on = True
 
         plugin_obj = self.plugin_acquisition_modes.get(self.imaging_mode, None)
@@ -1199,7 +1207,7 @@ class Model:
             self.active_microscope.turn_on_laser()
             self.active_microscope.daq.run_acquisition(wait_until_done=self.is_data_thread_on)
             if not self.is_data_thread_on:
-                if self.start_grab_image_flag:
+                if self.available_image_count > 0:
                     self.grab_image(getattr(self.image_writer, "save_image", None))
                 self.active_microscope.daq.wait_acquisition_done()
         except:  # noqa
@@ -1221,11 +1229,12 @@ class Model:
             # Ensure the laser is turned off
             self.active_microscope.turn_off_lasers()
 
+        self.available_image_count += 1
+
         if hasattr(self, "signal_container"):
             self.signal_container.run(wait_response=True)
 
         self.frame_id = (self.frame_id + 1) % self.number_of_frames
-        self.start_grab_image_flag = True
 
     def grab_image(
         self, data_func: Optional[callable] = None
@@ -1271,6 +1280,8 @@ class Model:
             # show image
             self.logger.info(f"Image delivered to controller: {frame_ids[0]}")
             self.show_img_pipe.send(frame_ids[-1])
+
+            self.available_image_count -= len(frame_ids)
 
             break
 
@@ -1322,11 +1333,14 @@ class Model:
                 self.stop_acquisition = True
                 return
         if not self.is_data_thread_on:
-            if self.start_grab_image_flag:
+            if self.available_image_count > 0:
                 self.grab_image(getattr(self.image_writer, "save_image", None))
             self.show_img_pipe.send("stop")
         if self.imaging_mode != "live":
             self.stop_acquisition = True
+
+        if not self.is_data_thread_on:
+            self.end_acquisition()
 
     def reset_feature_list(self) -> None:
         """Reset live mode feature list."""

--- a/src/navigate/view/main_window_content/channels_tab.py
+++ b/src/navigate/view/main_window_content/channels_tab.py
@@ -527,6 +527,18 @@ class StackAcquisitionFrame(ttk.Labelframe):
             row=6, column=0, columnspan=2, sticky="NSEW", padx=6, pady=5
         )
 
+        self.inputs["speed"] = LabelInput(
+            parent=self.stack_frame,
+            label="Speed Mode".ljust(30),
+            input_class=ttk.Combobox,
+            input_var=tk.StringVar(),
+            input_args={"width": 8, "values": ["Auto", "Fixed"]}
+        )
+        self.inputs["speed"].state(["disabled", "readonly"])
+        self.inputs["speed"].grid(
+            row=7, column=0, columnspan=2, sticky="NSEW", padx=5, pady=5
+        )
+
         self.cubic_frame = ttk.Frame(self.stack_frame)
         self.cubic_frame.grid(
             row=3,


### PR DESCRIPTION
Fixes slow ZStack imaging caused by inefficient thread scheduling on some computers.

This PR introduces two speed modes:

**Auto**: Relies on the system to schedule threads.

**Fixed**: Runs a single thread that explicitly handles the trigger and data sequences in a controlled manner.

Here is a screenshot of the speed modes selector in the GUI:

<img width="667" height="322" alt="speed-modes" src="https://github.com/user-attachments/assets/36c69960-5d84-4e28-92de-5ab403eee223" />
