### PR TITLE
Fix expansion daq issue

### DIFF
--- a/src/navigate/model/devices/daq/ni.py
+++ b/src/navigate/model/devices/daq/ni.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2021-2024  The University of Texas Southwestern Medical Center.
 # All rights reserved.
-
+import gc
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted for academic and research use only (subject to the
 # limitations in the disclaimer below) provided that the following conditions are met:
@@ -41,6 +41,7 @@ from typing import Union, Dict, Any
 import nidaqmx
 import nidaqmx.constants
 import nidaqmx.task
+from nidaqmx.system import System
 import numpy as np
 
 # Local Imports
@@ -510,6 +511,7 @@ class NIDAQ(DAQBase):
 
         self.analog_output_tasks = {}
 
+
     def enable_microscope(self, microscope_name: str) -> None:
         """Enable microscope.
 
@@ -607,3 +609,26 @@ class NIDAQ(DAQBase):
 
         self.is_updating_analog_task = False
         self.wait_to_run_lock.release()
+
+    def reset(self, device_name: str = None) -> None:
+        """Reset the DAQ device.
+
+        Parameters
+        ----------
+        device_name : str
+            Name of the device to reset. If None, reset all devices.
+        """
+        for k in list(self.analog_output_tasks.keys()):
+            del self.analog_output_tasks[k]
+        del self.camera_trigger_task
+        del self.master_trigger_task
+        gc.collect()
+
+        system = System.local()
+        for device in system.devices:
+            if device_name is None or device.name == device_name:
+                try:
+                    device.reset_device()
+                    logger.info(f"Reset device: {device.name}")
+                except Exception:
+                    logger.debug(f"Could not reset device: {traceback.format_exc()}")

--- a/src/navigate/model/devices/daq/ni.py
+++ b/src/navigate/model/devices/daq/ni.py
@@ -1,6 +1,5 @@
 # Copyright (c) 2021-2024  The University of Texas Southwestern Medical Center.
 # All rights reserved.
-import gc
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted for academic and research use only (subject to the
 # limitations in the disclaimer below) provided that the following conditions are met:
@@ -36,6 +35,7 @@ from threading import Lock
 import traceback
 import time
 from typing import Union, Dict, Any
+import gc
 
 # Third Party Imports
 import nidaqmx
@@ -111,14 +111,17 @@ class NIDAQ(DAQBase):
         #: int: trigger reset count
         self.trigger_reset_count = None
 
-
     def __str__(self) -> str:
         """String representation of the class."""
         return "NIDAQ"
 
     def __del__(self) -> None:
         """Destructor."""
-        for task in [self.camera_trigger_task, self.master_trigger_task, self.laser_switching_task]:
+        for task in [
+            self.camera_trigger_task,
+            self.master_trigger_task,
+            self.laser_switching_task,
+        ]:
             if task:
                 try:
                     task.stop()
@@ -133,8 +136,9 @@ class NIDAQ(DAQBase):
                         task.stop()
                         task.close()
                     except Exception:
-                        logger.exception(f"Error stopping task: {traceback.format_exc()}")
-
+                        logger.exception(
+                            f"Error stopping task: {traceback.format_exc()}"
+                        )
 
     def set_external_trigger(self, external_trigger=None) -> None:
         """Set trigger mode.
@@ -446,7 +450,7 @@ class NIDAQ(DAQBase):
         # Specify ports, timing, and triggering
         self.set_external_trigger(self.external_trigger)
 
-    def run_acquisition(self, wait_until_done : bool = True) -> None:
+    def run_acquisition(self, wait_until_done: bool = True) -> None:
         """Run DAQ Acquisition.
 
         Run the tasks for triggering, analog and counter outputs.
@@ -495,7 +499,10 @@ class NIDAQ(DAQBase):
         except nidaqmx.DaqError:
             pass
 
-        if self.trigger_reset_count is not None and self.trigger_count >= self.trigger_reset_count:
+        if (
+            self.trigger_reset_count is not None
+            and self.trigger_count >= self.trigger_reset_count
+        ):
             self.stop_acquisition()
             self.prepare_acquisition(self.current_channel_key)
 
@@ -523,10 +530,12 @@ class NIDAQ(DAQBase):
             self.wait_to_run_lock.release()
 
         self.analog_output_tasks = {}
-        if self.trigger_reset_count is not None and self.trigger_count >= self.trigger_reset_count:
+        if (
+            self.trigger_reset_count is not None
+            and self.trigger_count >= self.trigger_reset_count
+        ):
             self.reset()
             self.trigger_count = 0
-
 
     def enable_microscope(self, microscope_name: str) -> None:
         """Enable microscope.
@@ -540,9 +549,9 @@ class NIDAQ(DAQBase):
             self.microscope_name = microscope_name
             self.analog_outputs = {}
             self.analog_output_tasks = {}
-            self.trigger_reset_count = self.configuration["configuration"]["microscopes"][
-                microscope_name
-            ]["daq"].get("trigger_reset_count", None)
+            self.trigger_reset_count = self.configuration["configuration"][
+                "microscopes"
+            ][microscope_name]["daq"].get("trigger_reset_count", None)
 
         self.camera_delay = (
             float(self.waveform_constants["other_constants"].get("camera_delay", 5))
@@ -639,8 +648,11 @@ class NIDAQ(DAQBase):
         """
         for k in list(self.analog_output_tasks.keys()):
             del self.analog_output_tasks[k]
-        del self.camera_trigger_task
-        del self.master_trigger_task
+
+        if hasattr(self, "camera_trigger_task"):
+            del self.camera_trigger_task
+        if hasattr(self, "master_trigger_task"):
+            del self.master_trigger_task
         gc.collect()
 
         system = System.local()

--- a/src/navigate/model/devices/daq/ni.py
+++ b/src/navigate/model/devices/daq/ni.py
@@ -105,6 +105,13 @@ class NIDAQ(DAQBase):
         #: bool: Flag for waiting to run.
         self.wait_to_run_lock = Lock()
 
+        #: int: trigger count
+        self.trigger_count = 0
+
+        #: int: trigger reset count
+        self.trigger_reset_count = None
+
+
     def __str__(self) -> str:
         """String representation of the class."""
         return "NIDAQ"
@@ -465,6 +472,8 @@ class NIDAQ(DAQBase):
         if wait_until_done:
             self.wait_acquisition_done()
 
+        self.trigger_count += 1
+
     def wait_acquisition_done(self) -> None:
         """Wait acquisition tasks done"""
 
@@ -485,6 +494,10 @@ class NIDAQ(DAQBase):
                 self.master_trigger_task.stop()
         except nidaqmx.DaqError:
             pass
+
+        if self.trigger_reset_count is not None and self.trigger_count >= self.trigger_reset_count:
+            self.stop_acquisition()
+            self.prepare_acquisition(self.current_channel_key)
 
     def stop_acquisition(self) -> None:
         """Stop Acquisition.
@@ -510,6 +523,9 @@ class NIDAQ(DAQBase):
             self.wait_to_run_lock.release()
 
         self.analog_output_tasks = {}
+        if self.trigger_reset_count is not None and self.trigger_count >= self.trigger_reset_count:
+            self.reset()
+            self.trigger_count = 0
 
 
     def enable_microscope(self, microscope_name: str) -> None:
@@ -524,6 +540,9 @@ class NIDAQ(DAQBase):
             self.microscope_name = microscope_name
             self.analog_outputs = {}
             self.analog_output_tasks = {}
+            self.trigger_reset_count = self.configuration["configuration"]["microscopes"][
+                microscope_name
+            ]["daq"].get("trigger_reset_count", None)
 
         self.camera_delay = (
             float(self.waveform_constants["other_constants"].get("camera_delay", 5))

--- a/src/navigate/model/microscope.py
+++ b/src/navigate/model/microscope.py
@@ -801,7 +801,7 @@ class Microscope:
             self.daq.stop_acquisition()
             self.daq_waveform_write_count += 1
             if self.daq_waveform_write_count >= 100:
-                self.daq.reset()
+                # self.daq.reset()
                 self.daq_waveform_write_count = 0
 
         # Filter Wheel Settings.

--- a/src/navigate/model/microscope.py
+++ b/src/navigate/model/microscope.py
@@ -194,6 +194,8 @@ class Microscope:
         #: dict: Dictionary of data acquisition devices.
         self.daq = devices_dict["daq"].get(daq_type, None)
 
+        self.daq_waveform_write_count = 0
+
         # Load and start all devices
         for device_name in self.configuration["configuration"]["microscopes"][
             self.microscope_name
@@ -797,6 +799,10 @@ class Microscope:
         # stop daq task first, give daq some rest time for new tasks
         if update_daq_task_flag:
             self.daq.stop_acquisition()
+            self.daq_waveform_write_count += 1
+            if self.daq_waveform_write_count >= 100:
+                self.daq.reset()
+                self.daq_waveform_write_count = 0
 
         # Filter Wheel Settings.
         for k in self.filter_wheel:

--- a/src/navigate/model/microscope.py
+++ b/src/navigate/model/microscope.py
@@ -194,8 +194,6 @@ class Microscope:
         #: dict: Dictionary of data acquisition devices.
         self.daq = devices_dict["daq"].get(daq_type, None)
 
-        self.daq_waveform_write_count = 0
-
         # Load and start all devices
         for device_name in self.configuration["configuration"]["microscopes"][
             self.microscope_name
@@ -799,10 +797,6 @@ class Microscope:
         # stop daq task first, give daq some rest time for new tasks
         if update_daq_task_flag:
             self.daq.stop_acquisition()
-            self.daq_waveform_write_count += 1
-            if self.daq_waveform_write_count >= 100:
-                # self.daq.reset()
-                self.daq_waveform_write_count = 0
 
         # Filter Wheel Settings.
         for k in self.filter_wheel:


### PR DESCRIPTION
This PR introduces a self-reset mechanism for the DAQ, addressing two major issues encountered in the expansion microscope:

1. Insufficient memory/resources error when writing new waveforms into the DAQ while running with PerZ.

2. Camera timeout errors when acquiring large stacks or multiple positions with moderate-to-large stack sizes.

To enable DAQ self-reset, add the following entry in the configuration.yaml file under the daq section:

`trigger_reset_count: 500`

The exact value of trigger_reset_count should be adjusted based on the machine.