### PR TITLE
M2000 jogwheel speed

### DIFF
--- a/src/navigate/model/devices/APIs/asi/asi_MS2000_controller.py
+++ b/src/navigate/model/devices/APIs/asi/asi_MS2000_controller.py
@@ -193,7 +193,24 @@ class MS2000Controller(TigerController):
         # sleep to avoid error, empirically found this made it work
         time.sleep(0.1)
 
+    def set_jog_speed(self, axes: list, jsspd: int):
+        """Set jog wheel speed.
+        
+        Parameters
+        ----------
+        axes: list
+            List of axes to set
+        jsspd: int
+            Jog wheel speed (0.1 - 100)
+        """
+        cmd = 'JSSPD ' + ' '.join(f"{ax.upper()}={jsspd}" for ax in axes)
+        
+        # send JSSPD command to MS2000 controller: set jog wheel speed
+        self.send_command(cmd)
 
+        # get response (:A if successful)
+        self.read_response()
+        
     def set_max_speed(self, axis: str, speed: float) -> None:
         """Set the speed on a specific axis. Speed is in mm/s.
 

--- a/src/navigate/model/devices/APIs/asi/asi_MS2000_controller.py
+++ b/src/navigate/model/devices/APIs/asi/asi_MS2000_controller.py
@@ -95,21 +95,21 @@ class MS2000Controller(TigerController):
         write_timeout : int
             Write timeout in seconds
         """
-        self.serial_port.port = self.com_port
-        self.serial_port.baudrate = self.baud_rate
-        self.serial_port.parity = PARITY_NONE
-        self.serial_port.bytesize = EIGHTBITS
-        self.serial_port.stopbits = STOPBITS_ONE
-        self.serial_port.xonoff = False
-        self.serial_port.rtscts = False
-        self.serial_port.dsrdtr = False
-        self.serial_port.write_timeout = write_timeout
-        self.serial_port.timeout = read_timeout
+        self.serial.port = self.com_port
+        self.serial.baudrate = self.baud_rate
+        self.serial.parity = PARITY_NONE
+        self.serial.bytesize = EIGHTBITS
+        self.serial.stopbits = STOPBITS_ONE
+        self.serial.xonoff = False
+        self.serial.rtscts = False
+        self.serial.dsrdtr = False
+        self.serial.write_timeout = write_timeout
+        self.serial.timeout = read_timeout
 
         # set the size of the rx and tx buffers before calling open
-        self.serial_port.set_buffer_size(rx_size, tx_size)
+        self.serial.set_buffer_size(rx_size, tx_size)
         try:
-            self.serial_port.open()
+            self.serial.open()
         except SerialException:
             self.report_to_console(
                 f"SerialException: can't connect to {self.com_port} at "
@@ -118,8 +118,8 @@ class MS2000Controller(TigerController):
 
         if self.is_open():
             # clear the rx and tx buffers
-            self.serial_port.reset_input_buffer()
-            self.serial_port.reset_output_buffer()
+            self.serial.reset_input_buffer()
+            self.serial.reset_output_buffer()
             # report connection status to user
             self.report_to_console("Connected to the serial port.")
             self.report_to_console(
@@ -177,15 +177,15 @@ class MS2000Controller(TigerController):
         # always reset the buffers before a new command is sent
         self.safe_to_write.wait()
         self.safe_to_write.clear()
-        self.serial_port.read_all()
-        self.serial_port.reset_input_buffer()
-        self.serial_port.reset_output_buffer()
+        self.serial.read_all()
+        self.serial.reset_input_buffer()
+        self.serial.reset_output_buffer()
 
         # send the serial command to the controller
         self.report_to_console(cmd)
         command = bytes(f"{cmd}\r", encoding="ascii")
         try:
-            self.serial_port.write(command)
+            self.serial.write(command)
         except SerialTimeoutException as e:
             print(f"MS2000 Controller -- SerialTimeoutException: {e}")
             pass
@@ -210,7 +210,7 @@ class MS2000Controller(TigerController):
 
         # get response (:A if successful)
         self.read_response()
-        
+
     def set_max_speed(self, axis: str, speed: float) -> None:
         """Set the speed on a specific axis. Speed is in mm/s.
 

--- a/src/navigate/model/devices/stage/asi.py
+++ b/src/navigate/model/devices/stage/asi.py
@@ -627,6 +627,15 @@ class MS2000Stage(ASIStage):
             for ax in self.asi_axes.keys():
                 self.asi_controller.set_backlash(ax, 0.02)
 
+            # Set wheel jog speed
+            jsspd = configuration["configuration"]["microscopes"][microscope_name][
+                "stage"]["hardware"][device_id].get("jsspd", None)
+            if jsspd is not None:
+                self.asi_controller.set_jog_speed(
+                    axes=self.asi_axes, 
+                    jsspd=int(jsspd)
+                    )
+
             # Speed optimizations - Set speed to 90% of maximum on each axis
             self.set_speed(percent=0.9)
 


### PR DESCRIPTION
There was an annoying quirk of the MS2000 controller where it would reset the jog wheel speed to some very slow value on startup every time.

I added some "jsspd" parameter where you can set it in the config file and then configure it on startup.

There was also a bug in the most recent develop where `self.serial_port` was renamed to `self.serial` but this was not updated in the MS2000 API, so I fixed that as well.