### PR TITLE
Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     'PIPython==2.6.0.1',
     'nidaqmx==0.5.7',
     'tifffile==2021.11.2',
-    'scipy==1.7.3',
+    'scipy==1.11.3',
     'pyusb==1.2.1',
     'pandas==1.3.5',
     'pandastable==0.12.2.post1',
@@ -47,6 +47,10 @@ dependencies = [
 navigate = "navigate.main:main"
 
 [project.optional-dependencies]
+photometrics = [
+    "PyVCAM"
+    ]
+
 dev = [
     "pytest",
     "pytest-xvfb",


### PR DESCRIPTION
## Mutex Challenges with Photometrics
- Problem: Launching PyVCAM in our camera worker subprocess would hang at `pvc.open_camera()`; attempts to touch any std::mutex during camera startup blocked, so the camera never opened.
- Source: SciPy 1.7.3’s wheel initializes its BLAS dependencies while the Windows loader lock is held. That happens before PyVCAM loads, and the loader lock prevents PVCAM’s own mutexes from being acquired, so the worker deadlocks.
- Solution: Upgrade SciPy to ≥1.11.x (and ensure PyVCAM initialization happens only after that import). The newer builds avoid loader-lock work, so PyVCAM now opens normally in the subprocess.

Note: Added PyVCAM to the pyproject.toml file as an optional dependency. This has yet to be evaluated but is not expected to cause problems (then again, this was a very difficult problem to debug.

The file used for testing is attached here: [live_in_subprocess.txt](https://github.com/user-attachments/files/23206933/live_in_subprocess.txt)