### PR TITLE
Fix ni filter wheel toggle issue

### DIFF
--- a/src/navigate/model/devices/filter_wheel/ni.py
+++ b/src/navigate/model/devices/filter_wheel/ni.py
@@ -55,7 +55,7 @@ logger = logging.getLogger(p)
 class NIFilterWheel(FilterWheelBase, NIDevice):
     """DAQFilterWheel - Class for controlling filter wheels with a DAQ."""
 
-    filter_wheel_value = None
+    filter_wheel_value = {}
 
     def __init__(
         self,
@@ -84,6 +84,8 @@ class NIFilterWheel(FilterWheelBase, NIDevice):
         self.wait_until_done_delay = self.device_config["filter_wheel_delay"]
 
         self.filter_wheel_task = None
+        if self.filter_wheel_number not in type(self).filter_wheel_value:
+            type(self).filter_wheel_value[self.filter_wheel_number] = None
 
     def __str__(self) -> str:
         """String representation of the class."""
@@ -121,7 +123,7 @@ class NIFilterWheel(FilterWheelBase, NIDevice):
             Waits duration of time necessary for filter wheel to change positions.
         """
         if self.check_if_filter_in_filter_dictionary(filter_name) is True:
-            if type(self).filter_wheel_value == filter_name:
+            if type(self).filter_wheel_value[self.filter_wheel_number] == filter_name:
                 return
             try:
                 # Create the nidaqmx Task, and add the DO channel.
@@ -149,7 +151,7 @@ class NIFilterWheel(FilterWheelBase, NIDevice):
             except Exception as e:
                 logger.exception(f"Error setting filter: {traceback.format_exc()}")
 
-            type(self).filter_wheel_value = filter_name
+            type(self).filter_wheel_value[self.filter_wheel_number] = filter_name
 
     def close(self) -> None:
         """Close the DAQ Filter Wheel

--- a/src/navigate/model/devices/filter_wheel/ni.py
+++ b/src/navigate/model/devices/filter_wheel/ni.py
@@ -55,6 +55,8 @@ logger = logging.getLogger(p)
 class NIFilterWheel(FilterWheelBase, NIDevice):
     """DAQFilterWheel - Class for controlling filter wheels with a DAQ."""
 
+    filter_wheel_value = None
+
     def __init__(
         self,
         microscope_name: str,
@@ -119,6 +121,8 @@ class NIFilterWheel(FilterWheelBase, NIDevice):
             Waits duration of time necessary for filter wheel to change positions.
         """
         if self.check_if_filter_in_filter_dictionary(filter_name) is True:
+            if type(self).filter_wheel_value == filter_name:
+                return
             try:
                 # Create the nidaqmx Task, and add the DO channel.
                 self.filter_wheel_task = nidaqmx.Task()
@@ -142,6 +146,10 @@ class NIFilterWheel(FilterWheelBase, NIDevice):
                 self.filter_wheel_task.close()
             except DaqError as e:
                 logger.debug(e)
+            except Exception as e:
+                logger.exception(f"Error setting filter: {traceback.format_exc()}")
+
+            type(self).filter_wheel_value = filter_name
 
     def close(self) -> None:
         """Close the DAQ Filter Wheel

--- a/test/model/devices/filter_wheel/test_ni.py
+++ b/test/model/devices/filter_wheel/test_ni.py
@@ -49,7 +49,18 @@ class TestNIFilterWheel(unittest.TestCase):
                         "filter_wheel": [{
                             "available_filters": {
                                     "filter_1": "Channel/line0",
-                                    "filter_2": "Channel/line1",
+                                    "filter_2": "Channel/line0",
+                                },
+                            "hardware": {
+                                "type": "NI",
+                                "wheel_number": 1,
+                            },
+                            "filter_wheel_delay": 0.5,
+                        },
+                        {
+                            "available_filters": {
+                                    "filter_3": "Channel/line1",
+                                    "filter_4": "Channel/line1",
                                 },
                             "hardware": {
                                 "type": "NI",
@@ -68,11 +79,19 @@ class TestNIFilterWheel(unittest.TestCase):
             configuration=configuration,
             device_id=0,
         )
+
+        self.filter_wheel_2 = NIFilterWheel(
+            microscope_name="TestScope",
+            device_connection=self.mock_device_connection,
+            configuration=configuration,
+            device_id=1,
+        )
+
     @patch('navigate.model.devices.filter_wheel.ni.nidaqmx.Task')
     def test_set_filter_valid(self, mock_task):
         self.filter_wheel.set_filter("filter_1")
         assert mock_task.called_once()
-        self.assertEqual(self.filter_wheel.filter_wheel_value, "filter_1")
+        self.assertEqual(self.filter_wheel.filter_wheel_value[1], "filter_1")
 
         # set to the same value again, should not call write
         mock_task.reset_mock()
@@ -81,7 +100,7 @@ class TestNIFilterWheel(unittest.TestCase):
 
         # set to a different value
         self.filter_wheel.set_filter("filter_2")
-        self.assertEqual(self.filter_wheel.filter_wheel_value, "filter_2")
+        self.assertEqual(self.filter_wheel.filter_wheel_value[1], "filter_2")
         assert mock_task.called_once()
 
         # set to the same value again, should not call write
@@ -92,3 +111,16 @@ class TestNIFilterWheel(unittest.TestCase):
     def test_set_filter_invalid(self):
         with self.assertRaises(ValueError):
             self.filter_wheel.set_filter(-1)
+
+    @patch('navigate.model.devices.filter_wheel.ni.nidaqmx.Task')
+    def test_multiple_filter_wheels_independent(self, mock_task):
+        self.filter_wheel.set_filter("filter_1")
+        self.filter_wheel_2.set_filter("filter_3")
+
+        self.assertEqual(self.filter_wheel.filter_wheel_value[1], "filter_1")
+        self.assertEqual(self.filter_wheel_2.filter_wheel_value[2], "filter_3")
+
+        self.filter_wheel_2.set_filter("filter_4")
+        self.assertEqual(self.filter_wheel.filter_wheel_value[1], "filter_1")
+        self.assertEqual(self.filter_wheel_2.filter_wheel_value[2], "filter_4")
+

--- a/test/model/devices/filter_wheel/test_ni.py
+++ b/test/model/devices/filter_wheel/test_ni.py
@@ -1,0 +1,94 @@
+# Copyright (c) 2021-2025  The University of Texas Southwestern Medical Center.
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted for academic and research use only (subject to the
+# limitations in the disclaimer below) provided that the following conditions are met:
+
+#      * Redistributions of source code must retain the above copyright notice,
+#      this list of conditions and the following disclaimer.
+
+#      * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+
+#      * Neither the name of the copyright holders nor the names of its
+#      contributors may be used to endorse or promote products derived from this
+#      software without specific prior written permission.
+
+# NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE GRANTED BY
+# THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+# CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+# PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+# BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+# IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# Standard Library Imports
+import unittest
+from unittest.mock import Mock, patch
+
+
+from navigate.model.devices.filter_wheel.ni import NIFilterWheel
+
+class TestNIFilterWheel(unittest.TestCase):
+    def setUp(self):
+        # self.mock_task = Mock()
+        self.mock_device_connection = Mock()
+        # self.mock_device_connection.create_task.return_value = self.mock_task
+
+        configuration = {
+            "configuration": {
+                "microscopes": {
+                    "TestScope": {
+                        "filter_wheel": [{
+                            "available_filters": {
+                                    "filter_1": "Channel/line0",
+                                    "filter_2": "Channel/line1",
+                                },
+                            "hardware": {
+                                "type": "NI",
+                                "wheel_number": 2,
+                            },
+                            "filter_wheel_delay": 0.5,
+                        }]
+                    }
+                }
+            }
+        }
+
+        self.filter_wheel = NIFilterWheel(
+            microscope_name="TestScope",
+            device_connection=self.mock_device_connection,
+            configuration=configuration,
+            device_id=0,
+        )
+    @patch('navigate.model.devices.filter_wheel.ni.nidaqmx.Task')
+    def test_set_filter_valid(self, mock_task):
+        self.filter_wheel.set_filter("filter_1")
+        assert mock_task.called_once()
+        self.assertEqual(self.filter_wheel.filter_wheel_value, "filter_1")
+
+        # set to the same value again, should not call write
+        mock_task.reset_mock()
+        self.filter_wheel.set_filter("filter_1")
+        mock_task.write.assert_not_called()
+
+        # set to a different value
+        self.filter_wheel.set_filter("filter_2")
+        self.assertEqual(self.filter_wheel.filter_wheel_value, "filter_2")
+        assert mock_task.called_once()
+
+        # set to the same value again, should not call write
+        mock_task.reset_mock()
+        self.filter_wheel.set_filter("filter_2")
+        mock_task.write.assert_not_called()
+
+    def test_set_filter_invalid(self):
+        with self.assertRaises(ValueError):
+            self.filter_wheel.set_filter(-1)


### PR DESCRIPTION
NI-DAQ–controlled filter wheels rotate/toggle on every 5 V edge trigger. If the wheel is already at the requested position, sending another trigger will shift it to the wrong position. This PR caches the current position and suppresses triggers when the wheel is already at the target slot.