### PR TITLE
Remove unnecessary sleep and add performance TODO

### DIFF
--- a/src/navigate/model/devices/stage/synthetic.py
+++ b/src/navigate/model/devices/stage/synthetic.py
@@ -157,8 +157,6 @@ class SyntheticStage(StageBase):
 
         for axis in abs_pos_dict:
             setattr(self, f"{axis}_pos", abs_pos_dict[axis])
-        if wait_until_done is True:
-            time.sleep(0.025)
 
         return True
 

--- a/src/navigate/model/devices/stage/synthetic.py
+++ b/src/navigate/model/devices/stage/synthetic.py
@@ -125,9 +125,6 @@ class SyntheticStage(StageBase):
         if axis_abs == -1e50:
             return False
 
-        if wait_until_done:
-            time.sleep(0.025)
-
         # Move the stage
         setattr(self, f"{axis}_pos", axis_abs)
         return True

--- a/src/navigate/model/microscope.py
+++ b/src/navigate/model/microscope.py
@@ -892,6 +892,11 @@ class Microscope:
         success : bool
             True if stage is successfully moved, False otherwise.
         """
+
+        # TODO: Calling the proxy dictionary costs ~3 ms, and is performed for every step
+        # in the z-stack. To optimize performance, we should retrieve the image mode
+        # once and avoid repeated dictionary lookups.
+
         if self.configuration["experiment"]["MicroscopeState"]["image_mode"] in (
             "z-stack",
             "customized",


### PR DESCRIPTION
Removed a redundant time.sleep call in SyntheticStage's move_absolute method to improve performance. Added a TODO comment in Microscope to highlight the cost of repeated dictionary lookups for image_mode during z-stack acquisition, suggesting future optimization.