### PR TITLE
Refactor image saving and update save path formatting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     'pyusb==1.2.1',
     'pandas==1.3.5',
     'pandastable==0.12.2.post1',
-    'opencv-python==4.5.5.62',
+    'opencv-python==4.5.5.64',
     'numpy==1.22.0; sys_platform != "darwin"',
     'numpy==1.21.6; sys_platform == "darwin"',
     'scikit-image==0.19.1',

--- a/src/navigate/model/features/image_writer.py
+++ b/src/navigate/model/features/image_writer.py
@@ -262,16 +262,11 @@ class ImageWriter:
     def save_mip(self, p_idx: int, t_idx: int) -> None:
         """Save the maximum intensity projection image to disk as an 8-bit tiff."""
         for c_save_idx in range(self.data_source.shape_c):
-            mip_name = (
-                    "P"
-                    + str(p_idx).zfill(4)
-                    + "_"
-                    + "CH0"
-                    + str(c_save_idx)
-                    + "_"
-                    + str(t_idx).zfill(6)
-                    + ".tiff"
-            )
+
+            p = str(p_idx).zfill(4)
+            c = str(c_save_idx).zfill(2)
+            t = str(t_idx).zfill(6)
+            mip_name = f"P{p}_CH{c}_{t}.tiff"
 
             # Scale to 8-bit for display
             mip = self.mip[c_save_idx, :, :]

--- a/src/navigate/model/features/image_writer.py
+++ b/src/navigate/model/features/image_writer.py
@@ -246,21 +246,7 @@ class ImageWriter:
                 if (c_idx == self.data_source.shape_c - 1) and (
                     z_idx == self.data_source.shape_z - 1
                 ):
-                    for c_save_idx in range(self.data_source.shape_c):
-                        mip_name = (
-                            "P"
-                            + str(p_idx).zfill(4)
-                            + "_"
-                            + "CH0"
-                            + str(c_save_idx)
-                            + "_"
-                            + str(t_idx).zfill(6)
-                            + ".tif"
-                        )
-                        imsave(
-                            os.path.join(self.mip_directory, mip_name),
-                            self.mip[c_save_idx, :, :],
-                        )
+                    self.save_mip(p_idx, t_idx)
             except Exception as e:
                 from traceback import format_exc
 
@@ -272,6 +258,35 @@ class ImageWriter:
                 )
                 logger.debug(f"Error - ImageWriter: {e}")
                 return
+
+    def save_mip(self, p_idx: int, t_idx: int) -> None:
+        """Save the maximum intensity projection image to disk as an 8-bit tiff."""
+        for c_save_idx in range(self.data_source.shape_c):
+            mip_name = (
+                    "P"
+                    + str(p_idx).zfill(4)
+                    + "_"
+                    + "CH0"
+                    + str(c_save_idx)
+                    + "_"
+                    + str(t_idx).zfill(6)
+                    + ".tiff"
+            )
+
+            # Scale to 8-bit for display
+            mip = self.mip[c_save_idx, :, :]
+            min_val = mip.min()
+            max_val = mip.max()
+            if max_val > min_val:
+                mip_8bit = ((mip - min_val) / (max_val - min_val) * 255).astype(
+                    np.uint8)
+            else:
+                mip_8bit = np.zeros_like(mip, dtype=np.uint8)
+
+            imsave(
+                os.path.join(self.mip_directory, mip_name),
+                mip_8bit,
+            )
 
     def generate_image_name(self, current_channel, ext=".tif"):
         """Generates a string for the filename, e.g., CH00_000000.tif.

--- a/src/navigate/tools/file_functions.py
+++ b/src/navigate/tools/file_functions.py
@@ -91,7 +91,7 @@ def create_save_path(saving_settings: dict) -> str:
     cell_type_string = saving_settings["celltype"].replace(" ", "").lower()
     label_string = saving_settings["label"].replace(" ", "").lower()
     prefix_string = saving_settings["prefix"].replace(" ", "").lower()
-    date_string = str(datetime.now().date()).replace("-", "").lower()
+    date_string = str(datetime.now().date()).replace("-", "")
 
     # Create the save directory on disk.
     save_directory = str(

--- a/src/navigate/tools/file_functions.py
+++ b/src/navigate/tools/file_functions.py
@@ -86,31 +86,19 @@ def create_save_path(saving_settings: dict) -> str:
         Path to save data to.
     """
     root_directory = saving_settings["root_directory"]
-    user_string = saving_settings["user"]
-    tissue_string = saving_settings["tissue"]
-    cell_type_string = saving_settings["celltype"]
-    label_string = saving_settings["label"]
-    prefix_string = saving_settings["prefix"]
-    date_string = str(datetime.now().date())
-
-    # Make sure that there are no spaces in the variables
-    user_string = user_string.replace(" ", "-")
-    tissue_string = tissue_string.replace(" ", "-")
-    cell_type_string = cell_type_string.replace(" ", "-")
-    label_string = label_string.replace(" ", "-")
+    user_string = saving_settings["user"].replace(" ", "").lower()
+    tissue_string = saving_settings["tissue"].replace(" ", "").lower()
+    cell_type_string = saving_settings["celltype"].replace(" ", "").lower()
+    label_string = saving_settings["label"].replace(" ", "").lower()
+    prefix_string = saving_settings["prefix"].replace(" ", "").lower()
+    date_string = str(datetime.now().date()).replace("-", "").lower()
 
     # Create the save directory on disk.
     save_directory = str(
         os.path.join(
-            root_directory,
-            user_string,
-            tissue_string,
-            cell_type_string,
-            label_string,
-            date_string,
+            root_directory, user_string, f"{date_string}_{tissue_string}_{cell_type_string}_{label_string}"
         )
     )
-
     os.makedirs(save_directory, exist_ok=True)
 
     # Determine Number of Acquisitions in Directory

--- a/test/model/test_model.py
+++ b/test/model/test_model.py
@@ -126,10 +126,16 @@ def test_single_acquisition(model):
     model.run_command("acquire")
 
     image_id = show_img_pipe.recv()
-    n_images = 0
-    max_iters = 10
+
+    # If three channel acquisitions happen quickly, the synthetic camera may return
+    # something like [0, 1, 2] in a single call, and only one pipe message is sent
+    # for that batch.
+    n_images = image_id + 1
+    max_iters = 20
     while image_id != "stop" and max_iters > 0:
         image_id = show_img_pipe.recv()
+        if image_id == "stop":
+            break
         n_images += 1
         max_iters -= 1
 

--- a/test/tools/test_file_functions.py
+++ b/test/tools/test_file_functions.py
@@ -68,12 +68,7 @@ class CreateSavePathTestCase(unittest.TestCase):
         }
         expected_save_directory = os.path.join(
             self.save_root,
-            "John-Doe",
-            "Liver",
-            "Hepatocyte",
-            "Sample1",
-            self.date_string,
-            "Cell_001",
+            "johndoe/20260114_liver_hepatocyte_sample1/cell_001",
         )
         save_directory = create_save_path(saving_settings)
 
@@ -90,15 +85,19 @@ class CreateSavePathTestCase(unittest.TestCase):
         """Test 2: Testing with existing root directory and existing cell
         sub-directory."""
 
+        root_directory = self.save_root
+        user_string = "John Doe".replace(" ", "").lower()
+        tissue_string = "Liver".replace(" ", "").lower()
+        cell_type_string = "Hepatocyte".replace(" ", "").lower()
+        label_string = "Sample1".replace(" ", "").lower()
+        date_string = str(datetime.now().date()).replace("-", "")
+
         os.makedirs(
             os.path.join(
-                self.save_root,
-                "John-Doe",
-                "Liver",
-                "Hepatocyte",
-                "Sample1",
-                self.date_string,
-                "Cell_001",
+                root_directory,
+                user_string,
+                f"{date_string}_{tissue_string}_{cell_type_string}_{label_string}",
+                "Cell_001".lower(),
             )
         )
 
@@ -112,19 +111,17 @@ class CreateSavePathTestCase(unittest.TestCase):
         }
 
         save_directory = create_save_path(saving_settings)
+        print(save_directory)
 
         # Assert that the save directory is correct
         self.assertEqual(
             save_directory,
             os.path.join(
-                self.save_root,
-                "John-Doe",
-                "Liver",
-                "Hepatocyte",
-                "Sample1",
-                self.date_string,
-                "Cell_002",
-            ),
+                root_directory,
+                user_string,
+                f"{date_string}_{tissue_string}_{cell_type_string}_{label_string}",
+                "Cell_002".lower(),
+            )
         )
 
         # Assert that the save directory and cell directory are created
@@ -146,12 +143,7 @@ class CreateSavePathTestCase(unittest.TestCase):
         save_directory = create_save_path(saving_settings)
         expected_save_directory = os.path.join(
             self.save_root,
-            "John-Doe",
-            "Liver-Tissue",
-            "Hepatocyte-Cell-Type",
-            "Sample-1",
-            self.date_string,
-            "Cell_001",
+            "johndoe/20260114_livertissue_hepatocytecelltype_sample1/cell_001",
         )
 
         # Assert that the save directory is correct

--- a/test/tools/test_file_functions.py
+++ b/test/tools/test_file_functions.py
@@ -66,9 +66,14 @@ class CreateSavePathTestCase(unittest.TestCase):
             "label": "Sample1",
             "prefix": "Cell_",
         }
+
+        date_string = str(datetime.now().date()).replace("-", "")
+
         expected_save_directory = os.path.join(
             self.save_root,
-            "johndoe/20260114_liver_hepatocyte_sample1/cell_001",
+            "johndoe",
+            f"{date_string}_liver_hepatocyte_sample1",
+            "cell_001",
         )
         save_directory = create_save_path(saving_settings)
 
@@ -141,9 +146,11 @@ class CreateSavePathTestCase(unittest.TestCase):
         }
 
         save_directory = create_save_path(saving_settings)
+
+        date_string = str(datetime.now().date()).replace("-", "")
         expected_save_directory = os.path.join(
             self.save_root,
-            "johndoe/20260114_livertissue_hepatocytecelltype_sample1/cell_001",
+            f"johndoe/{date_string}_livertissue_hepatocytecelltype_sample1/cell_001",
         )
 
         # Assert that the save directory is correct

--- a/test/tools/test_file_functions.py
+++ b/test/tools/test_file_functions.py
@@ -150,7 +150,9 @@ class CreateSavePathTestCase(unittest.TestCase):
         date_string = str(datetime.now().date()).replace("-", "")
         expected_save_directory = os.path.join(
             self.save_root,
-            f"johndoe/{date_string}_livertissue_hepatocytecelltype_sample1/cell_001",
+            "johndoe",
+            f"{date_string}_livertissue_hepatocytecelltype_sample1",
+            "cell_001",
         )
 
         # Assert that the save directory is correct


### PR DESCRIPTION
Refactored the MIP image saving logic in ImageWriter to a dedicated save_mip method, which now saves 8-bit TIFFs with improved scaling. Updated create_save_path to generate lowercased, space-free directory names and a new directory structure that includes the date and metadata in a single folder name. Also updated opencv-python dependency version in pyproject.toml.