### PR TITLE
Pause/resume on theta move; wait for stage target

### DIFF
--- a/src/navigate/model/features/common_features.py
+++ b/src/navigate/model/features/common_features.py
@@ -755,6 +755,19 @@ class MoveToNextPositionInMultiPositionTable:
         #: int: The stage distance threshold for pausing the data thread.
         self.stage_distance_threshold = 1000
 
+        #: float: Any theta movement larger than this value triggers a data-thread
+        #: pause to avoid imaging while rotating.
+        self.theta_move_tolerance = 0.01
+
+        #: float: Position tolerance for verifying stage-target completion.
+        self.stage_move_tolerance = 0.05
+
+        #: float: Max time (s) to wait for stage target verification.
+        self.stage_move_timeout = 30.0
+
+        #: float: Polling interval (s) for stage target verification.
+        self.stage_move_poll_interval = 0.01
+
         #: str: The microscope name/resolution name
         self.resolution_value = resolution_value
 
@@ -844,6 +857,31 @@ class MoveToNextPositionInMultiPositionTable:
                         )
         logger.debug(f"Using stage offset {self.offset}")
 
+    def _wait_for_stage_target(self, target_pos: dict) -> bool:
+        """Block until the stage reaches the requested target positions."""
+        timeout_time = time.monotonic() + self.stage_move_timeout
+        microscope = getattr(self.model, "active_microscope", None)
+        while time.monotonic() < timeout_time:
+            # z-stack/customized modes cache stage positions. Force hardware query so
+            # this check validates real motion completion.
+            if microscope is not None and hasattr(microscope, "ask_stage_for_position"):
+                microscope.ask_stage_for_position = True
+            current_pos = self.model.get_stage_position()
+            if all(
+                abs(current_pos.get(f"{axis}_pos", float("inf")) - target) <=
+                self.stage_move_tolerance
+                for axis, target in target_pos.items()
+            ):
+                return True
+            if getattr(self.model, "stop_acquisition", False):
+                return False
+            time.sleep(self.stage_move_poll_interval)
+        logger.warning(
+            "MoveToNextPositionInMultiPositionTable: timed out waiting for stage "
+            f"target {target_pos}."
+        )
+        return False
+
     def signal_func(self):
         """Move to the next position in the multi-position table and control the data
         thread.
@@ -898,9 +936,15 @@ class MoveToNextPositionInMultiPositionTable:
         delta_distances = [
             abs(pos_dict[axis] - pre_stage_pos[axis]) for axis in self.stage_axes
         ]
+        theta_moved = (
+            "theta" in pos_dict
+            and "theta" in pre_stage_pos
+            and abs(pos_dict["theta"] - pre_stage_pos["theta"])
+            > self.theta_move_tolerance
+        )
         should_pause_data_thread = any(
             distance > self.stage_distance_threshold for distance in delta_distances
-        )
+        ) or theta_moved
         if should_pause_data_thread:
             self.model.pause_data_thread()
 
@@ -912,6 +956,7 @@ class MoveToNextPositionInMultiPositionTable:
         abs_pos_dict = dict(map(lambda k: (f"{k}_abs", pos_dict[k]), pos_dict.keys()))
         logger.debug(f"MoveToNextPositionInMultiPosition: " f"{pos_dict}")
         self.model.move_stage(abs_pos_dict, wait_until_done=True)
+        self._wait_for_stage_target(pos_dict)
 
         logger.debug("MoveToNextPositionInMultiPosition: move done")
 
@@ -1128,6 +1173,10 @@ class ZStackAcquisition:
         #  different kinds of stage devices.
         #: int: The stage distance threshold for pausing the data thread.
         self.stage_distance_threshold = 1000
+
+        #: float: Any theta movement larger than this value triggers a data-thread
+        #: pause.
+        self.theta_move_tolerance = 0.01
 
         #: dict: A dictionary of the previous position in the multi-position table.
         self.pre_position = None
@@ -1381,18 +1430,22 @@ class ZStackAcquisition:
 
             if self.current_position_idx > 0:
                 delta_distances = [
-                    self.current_position[axis] - self.pre_position[axis]
+                    abs(self.current_position[axis] - self.pre_position[axis])
                     for axis in self.tiling_axes
                     if axis != "theta"
                 ]
                 delta_distances.append(
-                    self.current_position[self.primary_z_axis]
-                    - self.pre_position[self.primary_z_axis]
+                    abs(
+                        self.current_position[self.primary_z_axis]
+                        - self.pre_position[self.primary_z_axis]
+                    )
                     + self.z_stack_distance
                 )
                 delta_distances.append(
-                    self.current_position[self.primary_f_axis]
-                    - self.pre_position[self.primary_f_axis]
+                    abs(
+                        self.current_position[self.primary_f_axis]
+                        - self.pre_position[self.primary_f_axis]
+                    )
                     + self.f_stack_distance
                 )
             else:
@@ -1409,9 +1462,15 @@ class ZStackAcquisition:
             # self.model.resume_data_thread() after the stage has completed the move
             # to the next position.
 
+            theta_moved = (
+                self.current_position_idx > 0
+                and "theta" in self.tiling_axes
+                and abs(self.current_position["theta"] - self.pre_position["theta"])
+                > self.theta_move_tolerance
+            )
             self.should_pause_data_thread = any(
                 distance > self.stage_distance_threshold for distance in delta_distances
-            )
+            ) or theta_moved
             if self.should_pause_data_thread:
                 self.model.pause_data_thread()
                 data_thread_is_paused = True
@@ -1708,18 +1767,22 @@ class ASIZStackAcquisition(ZStackAcquisition):
 
         if self.current_position_idx > 0:
             delta_distances = [
-                self.current_position[axis] - self.pre_position[axis]
+                abs(self.current_position[axis] - self.pre_position[axis])
                 for axis in self.tiling_axes
                 if axis != "theta"
             ]
             delta_distances.append(
-                self.current_position[self.primary_z_axis]
-                - self.pre_position[self.primary_z_axis]
+                abs(
+                    self.current_position[self.primary_z_axis]
+                    - self.pre_position[self.primary_z_axis]
+                )
                 + self.z_stack_distance
             )
             delta_distances.append(
-                self.current_position[self.primary_f_axis]
-                - self.pre_position[self.primary_f_axis]
+                abs(
+                    self.current_position[self.primary_f_axis]
+                    - self.pre_position[self.primary_f_axis]
+                )
                 + self.f_stack_distance
             )
         else:
@@ -1733,9 +1796,15 @@ class ASIZStackAcquisition(ZStackAcquisition):
         # if it is too far, then we can call self.model.pause_data_thread() and
         # self.model.resume_data_thread() after the stage has completed the move
         # to the next position.
+        theta_moved = (
+            self.current_position_idx > 0
+            and "theta" in self.tiling_axes
+            and abs(self.current_position["theta"] - self.pre_position["theta"])
+            > self.theta_move_tolerance
+        )
         self.should_pause_data_thread = any(
             distance > self.stage_distance_threshold for distance in delta_distances
-        )
+        ) or theta_moved
         if self.should_pause_data_thread:
             self.model.pause_data_thread()
             logger.info("Data thread paused.")

--- a/src/navigate/model/microscope.py
+++ b/src/navigate/model/microscope.py
@@ -923,6 +923,7 @@ class Microscope:
                 self.ret_pos_dict[f"{axis}_pos"] = pos_dict[axis_key]
         else:
             self.ask_stage_for_position = True
+
         if len(pos_dict.keys()) == 1:
             axis_key = list(pos_dict.keys())[0]
             axis = axis_key[: axis_key.index("_")]

--- a/test/model/test_stage_move_pause_behavior.py
+++ b/test/model/test_stage_move_pause_behavior.py
@@ -1,0 +1,146 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from navigate.model.features.common_features import (
+    MoveToNextPositionInMultiPositionTable,
+    ZStackAcquisition,
+)
+
+
+class MoveModelStub:
+    def __init__(self):
+        self.configuration = {
+            "multi_positions": [
+                ["X", "Y", "Z", "THETA", "F"],
+                [0.0, 0.0, 0.0, 0.0, 0.0],
+                [0.0, 0.0, 0.0, 10.0, 0.0],
+            ]
+        }
+        self.active_microscope_name = "Mesoscale"
+        self.active_microscope = SimpleNamespace(
+            stages={
+                "x": object(),
+                "y": object(),
+                "z": object(),
+                "theta": object(),
+                "f": object(),
+            },
+            zoom=SimpleNamespace(zoomvalue="N/A"),
+            central_focus=None,
+            ask_stage_for_position=False,
+        )
+        self.stop_acquisition = False
+        self._stage_position = {
+            "x_pos": 0.0,
+            "y_pos": 0.0,
+            "z_pos": 0.0,
+            "theta_pos": 0.0,
+            "f_pos": 0.0,
+        }
+        self.pause_calls = 0
+        self.resume_calls = 0
+        self.move_calls = []
+
+    def get_stage_position(self):
+        return dict(self._stage_position)
+
+    def pause_data_thread(self):
+        self.pause_calls += 1
+
+    def resume_data_thread(self):
+        self.resume_calls += 1
+
+    def move_stage(self, pos_dict, wait_until_done=False):
+        self.move_calls.append((pos_dict, wait_until_done))
+        for axis_key, value in pos_dict.items():
+            axis = axis_key.split("_")[0]
+            self._stage_position[f"{axis}_pos"] = value
+        return True
+
+
+def _build_zstack_feature(model, positions):
+    feature = ZStackAcquisition(model)
+    feature.stage_axes = ["x", "y", "z", "theta", "f"]
+    feature.primary_z_axis = "z"
+    feature.primary_f_axis = "f"
+    feature.secondary_stack_settings = {}
+    feature.tiling_axes = ["x", "y", "theta"]
+    feature.current_channel_in_list = 0
+    feature.defocus = None
+    feature.start_z_position = 0
+    feature.start_focus = 0
+    feature.z_stack_distance = 0
+    feature.f_stack_distance = 0
+    feature.stage_distance_threshold = 1000
+    feature.need_to_move_new_position = True
+    feature.need_to_move_z_position = False
+    feature.current_position_idx = 1
+    feature.positions = positions
+    feature.axes_index = [0, 1, 2, 3, 4]
+    feature.current_position = dict(zip(feature.stage_axes, positions[0]))
+    feature.pre_position = feature.current_position
+    return feature
+
+
+def test_move_to_next_position_pauses_when_theta_changes():
+    model = MoveModelStub()
+    feature = MoveToNextPositionInMultiPositionTable(model)
+    feature.pre_signal_func()
+
+    # First move keeps theta fixed.
+    feature.signal_func()
+    assert model.pause_calls == 0
+    assert model.resume_calls == 0
+
+    # Second move rotates theta and should pause/resume data thread.
+    feature.signal_func()
+    assert model.pause_calls == 1
+    assert model.resume_calls == 1
+    assert model.move_calls[-1][1] is True
+    assert model.move_calls[-1][0]["theta_abs"] == 10.0
+
+
+def test_zstack_pauses_when_theta_changes():
+    model = SimpleNamespace(
+        stop_acquisition=False,
+        frame_id=0,
+        pause_data_thread=MagicMock(),
+        resume_data_thread=MagicMock(),
+        move_stage=MagicMock(return_value=True),
+        mark_saving_flags=MagicMock(),
+        active_microscope=SimpleNamespace(central_focus=None),
+    )
+    feature = _build_zstack_feature(
+        model,
+        positions=[
+            [0.0, 0.0, 0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 10.0, 0.0],
+        ],
+    )
+
+    feature.signal_func()
+    assert model.pause_data_thread.call_count == 1
+    assert model.resume_data_thread.call_count == 1
+
+
+def test_zstack_pauses_for_large_negative_translation():
+    model = SimpleNamespace(
+        stop_acquisition=False,
+        frame_id=0,
+        pause_data_thread=MagicMock(),
+        resume_data_thread=MagicMock(),
+        move_stage=MagicMock(return_value=True),
+        mark_saving_flags=MagicMock(),
+        active_microscope=SimpleNamespace(central_focus=None),
+    )
+    feature = _build_zstack_feature(
+        model,
+        positions=[
+            [2001.0, 0.0, 0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0, 0.0],
+        ],
+    )
+
+    feature.signal_func()
+    assert model.pause_data_thread.call_count == 1
+    assert model.resume_data_thread.call_count == 1


### PR DESCRIPTION
Add theta_move_tolerance and stage move verification to avoid imaging while rotating. Implement _wait_for_stage_target with timeout and polling, and call it after stage moves. Use absolute deltas where appropriate and include theta movement in pause/resume decisions for MoveToNextPositionInMultiPositionTable, ZStackAcquisition and ASIZStackAcquisition. Ensure Microscope sets ask_stage_for_position before single-axis queries. Add unit tests (test_stage_move_pause_behavior.py) to cover theta-triggered pauses and large translations.