### PR TITLE
Remove frames_to_average from camera settings

### DIFF
--- a/src/navigate/config/config.py
+++ b/src/navigate/config/config.py
@@ -383,7 +383,6 @@ def verify_experiment_config(manager, configuration):
         "readout_direction": "Top-to-Bottom",
         "number_of_pixels": 10,
         "binning": "1x1",
-        "frames_to_average": 1,
         "databuffer_size": 100,
         "is_centered": True,
         "center_x": 1024,
@@ -460,7 +459,7 @@ def verify_experiment_config(manager, configuration):
             camera_setting_dict["readout_direction"] = "Top-to-Bottom"
 
         # databuffer_size, number_of_pixels
-        for k in ["databuffer_size", "number_of_pixels", "frames_to_average"]:
+        for k in ["databuffer_size", "number_of_pixels"]:
             try:
                 camera_setting_dict[k] = int(camera_setting_dict[k])
             except ValueError:

--- a/src/navigate/config/experiment.yml
+++ b/src/navigate/config/experiment.yml
@@ -17,7 +17,6 @@ CameraParameters:
   readout_direction: Top to Bottom
   number_of_pixels: 10
   binning: 1x1
-  frames_to_average: 1.0
   databuffer_size: 100
 AutoFocusParameters:
   coarse_range: 500

--- a/src/navigate/controller/sub_controllers/camera_settings.py
+++ b/src/navigate/controller/sub_controllers/camera_settings.py
@@ -526,15 +526,11 @@ class CameraSettingController(GUIController):
         # Binning settings
         self.roi_widgets["Binning"].set(self.camera_setting_dict["binning"])
 
-        # Camera Framerate Info - 'exposure_time', 'readout_time',
-        # 'framerate', 'frames_to_average'
+        # Camera Framerate Info - 'exposure_time', 'readout_time', 'framerate'
         # Exposure time is currently for just the first active channel
         channels = microscope_state_dict["channels"]
         exposure_time = channels[list(channels.keys())[0]]["camera_exposure_time"]
         self.framerate_widgets["exposure_time"].set(exposure_time)
-        self.framerate_widgets["frames_to_average"].set(
-            self.camera_setting_dict["frames_to_average"]
-        )
 
         # after initialization
         self.in_initialization = False
@@ -607,9 +603,6 @@ class CameraSettingController(GUIController):
             y_pixels = self.min_height
 
         self.camera_setting_dict["pixel_size"] = self.default_pixel_size
-        self.camera_setting_dict["frames_to_average"] = self.framerate_widgets[
-            "frames_to_average"
-        ].get()
 
         binning = [
             int(x) if x != "" else 1
@@ -816,7 +809,6 @@ class CameraSettingController(GUIController):
         else:
             self.mode_widgets["Readout"].widget["state"] = "disabled"
             self.mode_widgets["Pixels"].widget["state"] = "disabled"
-        self.framerate_widgets["frames_to_average"].widget["state"] = state
         if mode != "stop":
             self.roi_widgets["Width"].widget["state"] = "disabled"
             self.roi_widgets["Height"].widget["state"] = "disabled"

--- a/src/navigate/view/main_window_content/camera_tab.py
+++ b/src/navigate/view/main_window_content/camera_tab.py
@@ -236,7 +236,6 @@ class FramerateInfo(ttk.LabelFrame):
             "Exposure Time (ms)",
             "Readout Time (ms)",
             "Framerate (Hz)",
-            "Images to Average",
         ]
 
         #: list: List of all the names for the widget values.
@@ -244,14 +243,13 @@ class FramerateInfo(ttk.LabelFrame):
             "exposure_time",
             "readout_time",
             "max_framerate",
-            "frames_to_average",
         ]
 
         tk.Grid.columnconfigure(self, "all", weight=1)
         tk.Grid.rowconfigure(self, "all", weight=1)
 
         #: list: List of all the read only values for the widgets.
-        self.read_only = [True, True, True, False]
+        self.read_only = [True, True, True]
 
         #  Dropdown loop
         for i in range(len(self.labels)):

--- a/test/config/test_config.py
+++ b/test/config/test_config.py
@@ -301,7 +301,6 @@ class TestVerifyExperimentConfig(unittest.TestCase):
             "readout_direction": "Top-to-Bottom",
             "number_of_pixels": 10,
             "binning": "1x1",
-            "frames_to_average": 1,
             "databuffer_size": 100,
         }
 
@@ -588,7 +587,7 @@ class TestVerifyExperimentConfig(unittest.TestCase):
         assert experiment["CameraParameters"]["readout_direction"] == "Bottom-to-Top"
 
         # other parameters should be int
-        for k in ["number_of_pixels", "databuffer_size", "frames_to_average"]:
+        for k in ["number_of_pixels", "databuffer_size"]:
             for v in ["abc", -10, 0]:
                 experiment["CameraParameters"][k] = v
                 config.verify_experiment_config(self.manager, configuration)

--- a/test/config/test_experiment.py
+++ b/test/config/test_experiment.py
@@ -109,7 +109,6 @@ class TextExperimentFile(unittest.TestCase):
             "number_of_pixels": int,
             "binning": str,
             "pixel_size": float,
-            "frames_to_average": float,
             "databuffer_size": int,
         }
 

--- a/test/controller/sub_controllers/test_camera_settings.py
+++ b/test/controller/sub_controllers/test_camera_settings.py
@@ -253,10 +253,6 @@ class TestCameraSettingController:
             self.camera_settings.framerate_widgets["exposure_time"].get()
             == exposure_time
         )
-        assert (
-            self.camera_settings.framerate_widgets["frames_to_average"].get()
-            == camera_setting_dict["frames_to_average"]
-        )
         assert self.camera_settings.in_initialization is False
 
     @pytest.mark.parametrize("mode", ["Normal", "Light-Sheet"])
@@ -282,7 +278,6 @@ class TestCameraSettingController:
         width, height = random.randint(1, 2000), random.randint(1, 2000)
         self.camera_settings.roi_widgets["Width"].set(width)
         self.camera_settings.roi_widgets["Height"].set(height)
-        self.camera_settings.framerate_widgets["frames_to_average"].set(5)
 
         # Update experiment dict and assert
         self.camera_settings.update_experiment_values()
@@ -330,7 +325,6 @@ class TestCameraSettingController:
             self.camera_settings.camera_setting_dict["pixel_size"]
             == self.camera_settings.default_pixel_size
         )
-        assert self.camera_settings.camera_setting_dict["frames_to_average"] == 5
 
     @pytest.mark.parametrize("mode", ["Normal", "Light-Sheet"])
     def test_update_sensor_mode(self, mode):
@@ -482,14 +476,6 @@ class TestCameraSettingController:
                 str(self.camera_settings.mode_widgets["Pixels"].widget["state"])
                 == "disabled"
             )
-        assert (
-            str(
-                self.camera_settings.framerate_widgets["frames_to_average"].widget[
-                    "state"
-                ]
-            )
-            == state
-        )
         assert str(self.camera_settings.roi_widgets["Width"].widget["state"]) == state
         assert str(self.camera_settings.roi_widgets["Height"].widget["state"]) == state
         assert (


### PR DESCRIPTION
Eliminate the deprecated frames_to_average parameter across the project. Removed default and YAML entry, stopped validating/parsing it in config verification, removed related UI widget/label and controller handling, and updated tests to reflect its removal. Files touched: src/navigate/config/config.py, src/navigate/config/experiment.yml, src/navigate/controller/sub_controllers/camera_settings.py, src/navigate/view/main_window_content/camera_tab.py, and related tests.

Addresses #748 