### PR TITLE
Add dither support to remote focus waveforms

### DIFF
--- a/src/navigate/config/config.py
+++ b/src/navigate/config/config.py
@@ -744,8 +744,10 @@ def verify_waveform_constants(manager, configuration):
                         waveform_dict[microscope_name][zoom],
                         laser,
                         {
-                            "amplitude": 0,
-                            "offset": 0,
+                            "amplitude": "0",
+                            "offset": "0",
+                            "dither_amplitude": "0",
+                            "dither_frequency": "0",
                             # "percent_smoothing": "0",
                             # "delay": config_dict["remote_focus"][
                             #     "delay"
@@ -756,6 +758,8 @@ def verify_waveform_constants(manager, configuration):
                     for k in [
                         "amplitude",
                         "offset",
+                        "dither_amplitude",
+                        "dither_frequency",
                         # "percent_smoothing",
                         # "delay",
                     ]:

--- a/src/navigate/config/waveform_constants.yml
+++ b/src/navigate/config/waveform_constants.yml
@@ -5,18 +5,24 @@
                 "488nm": {
                     "amplitude": "0.11",
                     "offset": "0.10",
+                    "dither_amplitude": "0",
+                    "dither_frequency": "0",
                     "percent_smoothing": "0",
                     "percent_delay": "0"
                 },
                 "562nm": {
                     "amplitude": "0.115",
                     "offset": "0.062",
+                    "dither_amplitude": "0",
+                    "dither_frequency": "0",
                     "percent_smoothing": "0",
                     "percent_delay": "0"
                 },
                 "642nm": {
                     "amplitude": "0",
                     "offset": "0",
+                    "dither_amplitude": "0",
+                    "dither_frequency": "0",
                     "percent_smoothing": "0",
                     "percent_delay": "0"
                 }
@@ -27,18 +33,24 @@
                 "488nm": {
                     "amplitude": "2.5",
                     "offset": "2.336",
+                    "dither_amplitude": "0",
+                    "dither_frequency": "0",
                     "percent_smoothing": "0",
                     "percent_delay": "0"
                 },
                 "562nm": {
                     "amplitude": "2.5",
                     "offset": "2.336",
+                    "dither_amplitude": "0",
+                    "dither_frequency": "0",
                     "percent_smoothing": "0",
                     "percent_delay": "0"
                 },
                 "642nm": {
                     "amplitude": "2.5",
                     "offset": "2.336",
+                    "dither_amplitude": "0",
+                    "dither_frequency": "0",
                     "percent_smoothing": "0",
                     "percent_delay": "0"
                 }
@@ -47,18 +59,24 @@
                 "488nm": {
                     "amplitude": "1",
                     "offset": "2.60",
+                    "dither_amplitude": "0",
+                    "dither_frequency": "0",
                     "percent_smoothing": "0",
                     "percent_delay": "0"
                 },
                 "562nm": {
                     "amplitude": "0.53",
                     "offset": "2.46",
+                    "dither_amplitude": "0",
+                    "dither_frequency": "0",
                     "percent_smoothing": "0",
                     "percent_delay": "0"
                 },
                 "642nm": {
                     "amplitude": "0.23",
                     "offset": "2.50",
+                    "dither_amplitude": "0",
+                    "dither_frequency": "0",
                     "percent_smoothing": "0",
                     "percent_delay": "0"
                 }
@@ -67,18 +85,24 @@
                 "488nm": {
                     "amplitude": "0.20",
                     "offset": "2.52",
+                    "dither_amplitude": "0",
+                    "dither_frequency": "0",
                     "percent_smoothing": "0",
                     "percent_delay": "0"
                 },
                 "562nm": {
                     "amplitude": "0.466",
                     "offset": "1.534",
+                    "dither_amplitude": "0",
+                    "dither_frequency": "0",
                     "percent_smoothing": "0",
                     "percent_delay": "0"
                 },
                 "642nm": {
                     "amplitude": "0.20",
                     "offset": "2.53",
+                    "dither_amplitude": "0",
+                    "dither_frequency": "0",
                     "percent_smoothing": "0",
                     "percent_delay": "0"
                 }
@@ -87,18 +111,24 @@
                 "488nm": {
                     "amplitude": "1",
                     "offset": "2.60",
+                    "dither_amplitude": "0",
+                    "dither_frequency": "0",
                     "percent_smoothing": "0",
                     "percent_delay": "0"
                 },
                 "562nm": {
                     "amplitude": "0.15",
                     "offset": "2.50",
+                    "dither_amplitude": "0",
+                    "dither_frequency": "0",
                     "percent_smoothing": "0",
                     "percent_delay": "0"
                 },
                 "642nm": {
                     "amplitude": "0.16",
                     "offset": "2.50",
+                    "dither_amplitude": "0",
+                    "dither_frequency": "0",
                     "percent_smoothing": "0",
                     "percent_delay": "0"
                 }
@@ -107,18 +137,24 @@
                 "488nm": {
                     "amplitude": "0.141",
                     "offset": "2.392",
+                    "dither_amplitude": "0",
+                    "dither_frequency": "0",
                     "percent_smoothing": "0",
                     "percent_delay": "0"
                 },
                 "562nm": {
                     "amplitude": "0.141",
                     "offset": "2.392",
+                    "dither_amplitude": "0",
+                    "dither_frequency": "0",
                     "percent_smoothing": "0",
                     "percent_delay": "0"
                 },
                 "642nm": {
                     "amplitude": "0.141",
                     "offset": "2.392",
+                    "dither_amplitude": "0",
+                    "dither_frequency": "0",
                     "percent_smoothing": "0",
                     "percent_delay": "0"
                 }
@@ -127,18 +163,24 @@
                 "488nm": {
                     "amplitude": "0.141",
                     "offset": "2.392",
+                    "dither_amplitude": "0",
+                    "dither_frequency": "0",
                     "percent_smoothing": "0",
                     "percent_delay": "0"
                 },
                 "562nm": {
                     "amplitude": "0.141",
                     "offset": "2.392",
+                    "dither_amplitude": "0",
+                    "dither_frequency": "0",
                     "percent_smoothing": "0",
                     "percent_delay": "0"
                 },
                 "642nm": {
                     "amplitude": "0.141",
                     "offset": "2.392",
+                    "dither_amplitude": "0",
+                    "dither_frequency": "0",
                     "percent_smoothing": "0",
                     "percent_delay": "0"
                 }
@@ -147,18 +189,24 @@
                 "488nm": {
                     "amplitude": "0.15",
                     "offset": "2.52",
+                    "dither_amplitude": "0",
+                    "dither_frequency": "0",
                     "percent_smoothing": "0",
                     "percent_delay": "0"
                 },
                 "562nm": {
                     "amplitude": "0.15",
                     "offset": "2.51",
+                    "dither_amplitude": "0",
+                    "dither_frequency": "0",
                     "percent_smoothing": "0",
                     "percent_delay": "0"
                 },
                 "642nm": {
                     "amplitude": "0.15",
                     "offset": "2.51",
+                    "dither_amplitude": "0",
+                    "dither_frequency": "0",
                     "percent_smoothing": "0",
                     "percent_delay": "0"
                 }

--- a/src/navigate/controller/sub_controllers/waveform_popup.py
+++ b/src/navigate/controller/sub_controllers/waveform_popup.py
@@ -126,6 +126,9 @@ class WaveformPopupController(GUIController):
         #: float: the maximum value of remote focus device
         self.laser_max = 1.0
 
+        #: float: the maximum dither amplitude for the remote focus device.
+        self.dither_amplitude_max = 1.0
+
         #: dict: Dictionary of galvo minimum values
         self.galvo_min = {}
 
@@ -153,6 +156,18 @@ class WaveformPopupController(GUIController):
             self.variables[laser + " Off"].trace_add(
                 "write",
                 self.update_remote_focus_settings(laser + " Off", laser, "offset"),
+            )
+            self.variables[laser + " Dither Amp"].trace_add(
+                "write",
+                self.update_remote_focus_settings(
+                    laser + " Dither Amp", laser, "dither_amplitude"
+                ),
+            )
+            self.variables[laser + " Dither Freq"].trace_add(
+                "write",
+                self.update_remote_focus_settings(
+                    laser + " Dither Freq", laser, "dither_frequency"
+                ),
             )
 
         # Changes to the galvo constants (amplitude, offset, etc.)
@@ -246,6 +261,13 @@ class WaveformPopupController(GUIController):
         self.laser_max = self.configuration_controller.remote_focus_dict["hardware"][
             "max"
         ]
+        self.dither_amplitude_max = max(abs(self.laser_min), abs(self.laser_max))
+        dither_frequency_max = (
+            self.parent_controller.configuration["configuration"]["microscopes"][
+                self.resolution
+            ]["daq"]["sample_rate"]
+            / 2
+        )
 
         precision = int(
             self.configuration_controller.remote_focus_dict["hardware"].get(
@@ -279,6 +301,26 @@ class WaveformPopupController(GUIController):
             self.widgets[laser + " Off"].widget.configure(increment=self.increment)
             self.widgets[laser + " Off"].widget.set_precision(precision)
             self.widgets[laser + " Off"].widget.trigger_focusout_validation()
+
+            self.widgets[laser + " Dither Amp"].widget.configure(from_=0)
+            self.widgets[laser + " Dither Amp"].widget.configure(
+                to=self.dither_amplitude_max
+            )
+            self.widgets[laser + " Dither Amp"].widget.configure(
+                increment=self.increment
+            )
+            self.widgets[laser + " Dither Amp"].widget.set_precision(precision)
+            self.widgets[laser + " Dither Amp"].widget.trigger_focusout_validation()
+
+            self.widgets[laser + " Dither Freq"].widget.configure(from_=0)
+            self.widgets[laser + " Dither Freq"].widget.configure(
+                to=dither_frequency_max
+            )
+            self.widgets[laser + " Dither Freq"].widget.configure(
+                increment=max(self.increment, 0.1)
+            )
+            self.widgets[laser + " Dither Freq"].widget.set_precision(precision)
+            self.widgets[laser + " Dither Freq"].widget.trigger_focusout_validation()
 
         for galvo, d in zip(self.galvos, self.galvo_dict):
             galvo_min = d["hardware"]["min"]
@@ -398,15 +440,20 @@ class WaveformPopupController(GUIController):
         # get magnification setting
         self.mag = self.widgets["Mag"].widget.get()
         for laser in self.lasers:
+            remote_focus_settings = self.resolution_info["remote_focus_constants"][
+                self.resolution
+            ][self.mag][laser]
             self.variables[laser + " Amp"].set(
-                self.resolution_info["remote_focus_constants"][self.resolution][
-                    self.mag
-                ][laser]["amplitude"]
+                remote_focus_settings.get("amplitude", 0)
             )
             self.variables[laser + " Off"].set(
-                self.resolution_info["remote_focus_constants"][self.resolution][
-                    self.mag
-                ][laser]["offset"]
+                remote_focus_settings.get("offset", 0)
+            )
+            self.variables[laser + " Dither Amp"].set(
+                remote_focus_settings.get("dither_amplitude", 0)
+            )
+            self.variables[laser + " Dither Freq"].set(
+                remote_focus_settings.get("dither_frequency", 0)
             )
 
         # do not tell the model to update galvo
@@ -496,9 +543,12 @@ class WaveformPopupController(GUIController):
         # and when changing magnification it will run 0.63x
         # before whatever mag is selected
         def func_laser(*args):
-            value = self.resolution_info["remote_focus_constants"][self.resolution][
-                self.mag
-            ][laser][remote_focus_name]
+            remote_focus_settings = self.resolution_info["remote_focus_constants"][
+                self.resolution
+            ][self.mag][laser]
+            value = remote_focus_settings.get(remote_focus_name, "0")
+            if remote_focus_name not in remote_focus_settings:
+                remote_focus_settings[remote_focus_name] = value
 
             # Will only run code if value in constants does not match whats in GUI
             # for Amp or Off AND in Live mode
@@ -517,13 +567,20 @@ class WaveformPopupController(GUIController):
                     value = float(variable_value)
                 except ValueError:
                     return
-                if value < self.laser_min or value > self.laser_max:
+                min_value = self.laser_min
+                max_value = self.laser_max
+                if remote_focus_name == "dither_amplitude":
+                    min_value = 0
+                    max_value = self.dither_amplitude_max
+                elif remote_focus_name == "dither_frequency":
+                    min_value = 0
+                    max_value = None
+
+                if value < min_value or (max_value is not None and value > max_value):
                     return
-                self.resolution_info["remote_focus_constants"][self.resolution][
-                    self.mag
-                ][laser][remote_focus_name] = variable_value
+                remote_focus_settings[remote_focus_name] = variable_value
                 logger.debug(
-                    f"Remote Focus Amplitude/Offset Changed:, {variable_value}"
+                    f"Remote Focus {remote_focus_name} Changed:, {variable_value}"
                 )
 
                 # Delay feature.
@@ -749,8 +806,14 @@ class WaveformPopupController(GUIController):
                 self.amplitude_dict[laser] = self.resolution_info[
                     "remote_focus_constants"
                 ][self.resolution][self.mag][laser]["amplitude"]
+                self.amplitude_dict[laser + " dither"] = self.resolution_info[
+                    "remote_focus_constants"
+                ][self.resolution][self.mag][laser].get("dither_amplitude", 0)
                 self.variables[laser + " Amp"].set(0)
+                self.variables[laser + " Dither Amp"].set(0)
                 self.widgets[laser + " Amp"].widget.config(state="disabled")
+                self.widgets[laser + " Dither Amp"].widget.config(state="disabled")
+                self.widgets[laser + " Dither Freq"].widget.config(state="disabled")
 
             for galvo in self.galvos:
                 self.amplitude_dict[galvo] = self.resolution_info["galvo_constants"][
@@ -800,7 +863,12 @@ class WaveformPopupController(GUIController):
             self.resolution_info["remote_focus_constants"][resolution][mag][laser][
                 "amplitude"
             ] = self.amplitude_dict[laser]
+            self.resolution_info["remote_focus_constants"][resolution][mag][laser][
+                "dither_amplitude"
+            ] = self.amplitude_dict[laser + " dither"]
             self.widgets[laser + " Amp"].widget.config(state="normal")
+            self.widgets[laser + " Dither Amp"].widget.config(state="normal")
+            self.widgets[laser + " Dither Freq"].widget.config(state="normal")
         for galvo in self.galvos:
             self.resolution_info["galvo_constants"][galvo][resolution][mag][
                 "amplitude"

--- a/src/navigate/model/devices/remote_focus/base.py
+++ b/src/navigate/model/devices/remote_focus/base.py
@@ -42,6 +42,7 @@ from navigate.model.waveforms import (
     remote_focus_ramp,
     smooth_waveform,
     remote_focus_ramp_triangular,
+    triangle_wave,
 )
 from navigate.tools.decorators import log_initialization
 
@@ -196,6 +197,20 @@ class RemoteFocusBase(ABC):
             waveform_constants["other_constants"]["percent_smoothing"]
         )
 
+        def get_remote_focus_setting(
+            remote_focus_settings: dict[str, Any], key: str, default: str = "0"
+        ) -> float:
+            value = remote_focus_settings.get(key, default)
+            if value in ("-", ".", ""):
+                remote_focus_settings[key] = default
+                value = default
+
+            try:
+                return float(value)
+            except (TypeError, ValueError):
+                remote_focus_settings[key] = default
+                return float(default)
+
         for channel_key in microscope_state["channels"].keys():
             # channel includes 'is_selected', 'laser', 'filter', 'camera_exposure'...
             channel = microscope_state["channels"][channel_key]
@@ -212,33 +227,26 @@ class RemoteFocusBase(ABC):
                 samples = int(self.sample_rate * self.sweep_time)
 
                 # Remote Focus Parameters
-                temp = waveform_constants["remote_focus_constants"][imaging_mode][zoom][
-                    laser
-                ]["amplitude"]
-                if temp == "-" or temp == ".":
-                    waveform_constants["remote_focus_constants"][imaging_mode][zoom][
-                        laser
-                    ]["amplitude"] = "0"
-
-                remote_focus_amplitude = float(
-                    waveform_constants["remote_focus_constants"][imaging_mode][zoom][
-                        laser
-                    ]["amplitude"]
+                remote_focus_settings = waveform_constants["remote_focus_constants"][
+                    imaging_mode
+                ][zoom][laser]
+                remote_focus_amplitude = get_remote_focus_setting(
+                    remote_focus_settings, "amplitude"
                 )
-
-                # Validation for when user puts a '-' in spinbox
-                temp = waveform_constants["remote_focus_constants"][imaging_mode][zoom][
-                    laser
-                ]["offset"]
-                if temp == "-" or temp == ".":
-                    waveform_constants["remote_focus_constants"][imaging_mode][zoom][
-                        laser
-                    ]["offset"] = "0"
-
-                remote_focus_offset = float(
-                    waveform_constants["remote_focus_constants"][imaging_mode][zoom][
-                        laser
-                    ]["offset"]
+                remote_focus_offset = get_remote_focus_setting(
+                    remote_focus_settings, "offset"
+                )
+                dither_amplitude = max(
+                    0.0,
+                    get_remote_focus_setting(
+                        remote_focus_settings, "dither_amplitude"
+                    ),
+                )
+                dither_frequency = max(
+                    0.0,
+                    get_remote_focus_setting(
+                        remote_focus_settings, "dither_frequency"
+                    ),
                 )
                 if offset is not None:
                     remote_focus_offset += offset
@@ -277,6 +285,18 @@ class RemoteFocusBase(ABC):
                         waveform=self.waveform_dict[channel_key],
                         percent_smoothing=percent_smoothing,
                     )[:samples]
+
+                if dither_amplitude > 0 and dither_frequency > 0:
+                    waveform_length = len(self.waveform_dict[channel_key])
+                    self.waveform_dict[channel_key] = self.waveform_dict[
+                        channel_key
+                    ] + triangle_wave(
+                        sample_rate=self.sample_rate,
+                        sweep_time=waveform_length / self.sample_rate,
+                        frequency=dither_frequency,
+                        amplitude=dither_amplitude,
+                        offset=0,
+                    )[:waveform_length]
 
                 # Clip any values outside the hardware limits
                 self.waveform_dict[channel_key][

--- a/src/navigate/model/waveforms.py
+++ b/src/navigate/model/waveforms.py
@@ -351,6 +351,44 @@ def sawtooth(
     return waveform
 
 
+def triangle_wave(
+    sample_rate=100000,
+    sweep_time=0.4,
+    frequency=10,
+    amplitude=1,
+    offset=0,
+    phase=0,
+):
+    """Returns a zero-centered triangle waveform.
+
+    Parameters
+    ----------
+    sample_rate : Integer
+        Unit - Hz
+    sweep_time : Float
+        Unit - Seconds
+    frequency : Float
+        Unit - Hz
+    amplitude : Float
+        Unit - Volts
+    offset : Float
+        Unit - Volts
+    phase : Float
+        Unit - Seconds
+
+    Returns
+    -------
+    waveform : np.array
+    """
+
+    samples = int(np.multiply(sample_rate, sweep_time))
+    t = np.linspace(0, sweep_time, samples)
+    waveform = signal.sawtooth(2 * np.pi * frequency * (t - phase), width=0.5)
+    waveform = amplitude * waveform + offset
+
+    return waveform
+
+
 def dc_value(sample_rate=100000, sweep_time=0.4, amplitude=1):
     """
     Returns a numpy array with a DC value

--- a/src/navigate/view/popups/waveform_parameter_popup_window.py
+++ b/src/navigate/view/popups/waveform_parameter_popup_window.py
@@ -201,7 +201,13 @@ class WaveformParameterPopupWindow:
 
         # Laser Frame
         laser_labels = self.configuration_controller.lasers_info
-        title_labels = ["Laser", "Amplitude", "Offset"]
+        title_labels = [
+            "Laser",
+            "Amplitude",
+            "Offset",
+            "Dither Amplitude",
+            "Dither Frequency",
+        ]
         # Loop for widgets
         for i in range(len(title_labels)):
             # Title labels
@@ -244,7 +250,38 @@ class WaveformParameterPopupWindow:
             )
 
             self.inputs[laser_labels[i] + " Off"].grid(
-                row=i + 1, column=2, sticky=tk.NSEW, pady=get_theme_padding_px((20, 0))
+                row=i + 1,
+                column=2,
+                sticky=tk.NSEW,
+                pady=get_theme_padding_px((20, 0)),
+                padx=get_theme_padding_px((0, 5)),
+            )
+
+            self.inputs[laser_labels[i] + " Dither Amp"] = LabelInput(
+                parent=self.remote_focus_frame,
+                input_class=ValidatedSpinbox,
+                input_var=tk.StringVar(),
+            )
+
+            self.inputs[laser_labels[i] + " Dither Amp"].grid(
+                row=i + 1,
+                column=3,
+                sticky=tk.NSEW,
+                pady=get_theme_padding_px((20, 0)),
+                padx=get_theme_padding_px((0, 5)),
+            )
+
+            self.inputs[laser_labels[i] + " Dither Freq"] = LabelInput(
+                parent=self.remote_focus_frame,
+                input_class=ValidatedSpinbox,
+                input_var=tk.StringVar(),
+            )
+
+            self.inputs[laser_labels[i] + " Dither Freq"].grid(
+                row=i + 1,
+                column=4,
+                sticky=tk.NSEW,
+                pady=get_theme_padding_px((20, 0)),
             )
 
         galvo_labels = list(

--- a/test/config/test_waveform_constants.py
+++ b/test/config/test_waveform_constants.py
@@ -53,7 +53,12 @@ class TestWaveformConstants(unittest.TestCase):
         with open(yaml_path) as file:
             data = yaml.safe_load(file)
 
-        expected_keys = ["amplitude", "offset"]
+        expected_keys = [
+            "amplitude",
+            "offset",
+            "dither_amplitude",
+            "dither_frequency",
+        ]
 
         microscope_names = data["remote_focus_constants"].keys()
         for microscope_name in microscope_names:

--- a/test/controller/sub_controllers/test_waveform_popup.py
+++ b/test/controller/sub_controllers/test_waveform_popup.py
@@ -50,6 +50,12 @@ def test_populate_experiment_values(waveform_popup_controller):
         for k in remote_focus_dict.keys():
             assert widgets[k + " Amp"].get() == remote_focus_dict[k]["amplitude"]
             assert widgets[k + " Off"].get() == remote_focus_dict[k]["offset"]
+            assert widgets[k + " Dither Amp"].get() == str(
+                remote_focus_dict[k].get("dither_amplitude", 0)
+            )
+            assert widgets[k + " Dither Freq"].get() == str(
+                remote_focus_dict[k].get("dither_frequency", 0)
+            )
 
         # galvo
         galvo_dict = waveform_constants["galvo_constants"]
@@ -97,6 +103,8 @@ def test_populate_experiment_values(waveform_popup_controller):
         temp = waveform_constants["remote_focus_constants"][resolution][zoom][k]
         temp["amplitude"] = amplitude
         temp["offset"] = offset
+        temp["dither_amplitude"] = round(random.random(), 2)
+        temp["dither_frequency"] = round(random.random() * 100, 2)
 
     # update galvo
     for g in waveform_constants["galvo_constants"].keys():

--- a/test/controller/sub_controllers/test_waveform_tab.py
+++ b/test/controller/sub_controllers/test_waveform_tab.py
@@ -1,0 +1,135 @@
+from types import SimpleNamespace
+
+import numpy as np
+
+
+class _DummyVar:
+    def trace_add(self, *_args):
+        return None
+
+
+class _DummyWidget(dict):
+    def bind(self, *_args, **_kwargs):
+        return None
+
+
+class _DummyInput:
+    def __init__(self, value=None):
+        self.value = value
+        self.variable = _DummyVar()
+        self.widget = _DummyWidget()
+
+    def set(self, value):
+        self.value = value
+
+    def get(self):
+        return self.value
+
+    def get_variable(self):
+        return self.variable
+
+
+class _DummyAxis:
+    def __init__(self):
+        self.lines = []
+        self.title = None
+        self.xlabel = None
+        self.ylabel = None
+
+    def clear(self):
+        self.lines = []
+
+    def plot(self, x, y, **kwargs):
+        self.lines.append((np.asarray(x), np.asarray(y), kwargs))
+
+    def set_title(self, value):
+        self.title = value
+
+    def set_xlabel(self, value):
+        self.xlabel = value
+
+    def set_ylabel(self, value):
+        self.ylabel = value
+
+    def legend(self):
+        return None
+
+
+class _DummyCanvas:
+    def draw_idle(self):
+        return None
+
+    def get_tk_widget(self):
+        return object()
+
+
+class _DummyNotebook:
+    def bind(self, *_args, **_kwargs):
+        return None
+
+    def select(self):
+        return "waveforms"
+
+    def tab(self, _tab_id, option):
+        assert option == "text"
+        return "Waveforms"
+
+
+def test_waveform_tab_uses_updated_remote_focus_waveform(monkeypatch):
+    from navigate.controller.sub_controllers.waveform_tab import WaveformTabController
+
+    def fake_initialize_plots(self):
+        self.view.plot_etl = _DummyAxis()
+        self.view.plot_galvo = _DummyAxis()
+
+    monkeypatch.setattr(
+        WaveformTabController,
+        "initialize_plots",
+        fake_initialize_plots,
+    )
+
+    view = SimpleNamespace(
+        canvas=_DummyCanvas(),
+        fig=SimpleNamespace(tight_layout=lambda: None),
+        is_docked=True,
+        master=_DummyNotebook(),
+        waveform_settings=SimpleNamespace(
+            inputs={
+                "sample_rate": _DummyInput(),
+                "waveform_template": _DummyInput(),
+            }
+        ),
+    )
+    parent_controller = SimpleNamespace(
+        configuration={
+            "configuration": {"microscopes": {"TestScope": {"daq": {"sample_rate": 1000}}}},
+            "experiment": {
+                "MicroscopeState": {
+                    "microscope_name": "TestScope",
+                    "waveform_template": "Default",
+                }
+            },
+            "waveform_templates": {"Default": {"repeat": 1, "expand": 1}},
+        },
+        event_listeners={},
+    )
+
+    controller = WaveformTabController(view, parent_controller)
+    dithered_remote_focus = np.array([0.0, 0.2, -0.1, 0.3], dtype=float)
+    waveform_dict = {
+        "remote_focus_waveform": {"channel_1": dithered_remote_focus},
+        "camera_waveform": {"channel_1": np.array([0.0, 1.0, 0.0, 1.0], dtype=float)},
+        "galvo_waveform": [
+            {"channel_1": np.array([0.5, 0.6, 0.7, 0.8], dtype=float)}
+        ],
+    }
+
+    controller.update_waveforms(waveform_dict)
+
+    etl_time, etl_signal, etl_kwargs = controller.view.plot_etl.lines[0]
+    np.testing.assert_array_equal(
+        etl_time, np.arange(len(dithered_remote_focus)) / controller.sample_rate
+    )
+    np.testing.assert_array_equal(etl_signal, dithered_remote_focus)
+    assert etl_kwargs["label"] == "CH1"
+    assert controller.view.plot_etl.title == "Remote Focus Waveform"

--- a/test/model/devices/remote_focus/test_rf_base_unit.py
+++ b/test/model/devices/remote_focus/test_rf_base_unit.py
@@ -75,8 +75,18 @@ def _build_config(
             "remote_focus_constants": {
                 "test_mode": {
                     "1x": {
-                        "488": {"amplitude": "2.5", "offset": "0.1"},
-                        "561": {"amplitude": "1.0", "offset": "0.0"},
+                        "488": {
+                            "amplitude": "2.5",
+                            "offset": "0.1",
+                            "dither_amplitude": "0",
+                            "dither_frequency": "0",
+                        },
+                        "561": {
+                            "amplitude": "1.0",
+                            "offset": "0.0",
+                            "dither_amplitude": "0",
+                            "dither_frequency": "0",
+                        },
                     }
                 }
             },
@@ -207,3 +217,47 @@ def test_adjust_triangle_branch_without_smoothing(base_module, monkeypatch):
     triangle_mock.assert_called_once()
     ramp_mock.assert_not_called()
     smooth_mock.assert_not_called()
+
+
+def test_adjust_adds_dither_after_smoothing(base_module, monkeypatch):
+    config = _build_config(percent_smoothing="25")
+    laser_constants = config["waveform_constants"]["remote_focus_constants"]["test_mode"][
+        "1x"
+    ]["488"]
+    laser_constants["dither_amplitude"] = "0.25"
+    laser_constants["dither_frequency"] = "4"
+
+    rf = _make_remote_focus(base_module, config)
+
+    def fake_ramp(**kwargs):
+        return np.array([0.1, 0.2, 0.3], dtype=float)
+
+    smooth_mock = MagicMock(
+        return_value=np.array([0.4, 0.5, 0.6, 0.7], dtype=float)
+    )
+    dither_kwargs = {}
+
+    def fake_triangle_wave(**kwargs):
+        dither_kwargs.update(kwargs)
+        return np.array([0.1, -0.1, 0.1], dtype=float)
+
+    monkeypatch.setattr(base_module, "remote_focus_ramp", fake_ramp)
+    monkeypatch.setattr(base_module, "smooth_waveform", smooth_mock)
+    monkeypatch.setattr(base_module, "triangle_wave", fake_triangle_wave)
+    monkeypatch.setattr(
+        base_module,
+        "remote_focus_ramp_triangular",
+        MagicMock(side_effect=AssertionError("triangle branch not expected")),
+    )
+
+    waveforms = rf.adjust(
+        exposure_times={"ch1": 0.1, "ch2": 0.05},
+        sweep_times={"ch1": 0.3, "ch2": 0.15},
+    )
+
+    np.testing.assert_allclose(waveforms["ch1"], np.array([0.5, 0.4, 0.7]))
+    assert dither_kwargs["sample_rate"] == 10
+    assert dither_kwargs["sweep_time"] == pytest.approx(0.3)
+    assert dither_kwargs["frequency"] == 4.0
+    assert dither_kwargs["amplitude"] == 0.25
+    assert dither_kwargs["offset"] == 0

--- a/test/model/test_waveforms.py
+++ b/test/model/test_waveforms.py
@@ -168,6 +168,23 @@ class TestWaveforms(unittest.TestCase):
                 np.max(data), np.abs(amplitude), delta=np.abs(amplitude) / 100
             )
 
+    def test_triangle_wave_amplitude(self):
+        sample_rate = 100000
+        sweep_time = 0.4
+        amplitude = 1.5
+        data = waveforms.triangle_wave(
+            sample_rate=sample_rate, sweep_time=sweep_time, amplitude=amplitude
+        )
+        self.assertAlmostEqual(np.max(data), amplitude, delta=amplitude / 100)
+        self.assertAlmostEqual(np.min(data), -amplitude, delta=amplitude / 100)
+
+    def test_triangle_wave_offset(self):
+        offset = 0.5
+        amplitude = 1.5
+        data = waveforms.triangle_wave(amplitude=amplitude, offset=offset)
+        self.assertAlmostEqual(np.max(data), amplitude + offset, delta=amplitude / 100)
+        self.assertAlmostEqual(np.min(data), offset - amplitude, delta=amplitude / 100)
+
     def test_square_amplitude(self):
         sample_rate = 100000
         sweep_time = 0.4


### PR DESCRIPTION
Introduce dither amplitude/frequency parameters for remote-focus channels and wire them through config, UI, model and tests.

- config: add default string keys ("dither_amplitude", "dither_frequency") in verify_waveform_constants and include entries in waveform_constants.yml.
- view: add Dither Amplitude and Dither Frequency inputs to WaveformParameterPopupWindow.
- controller: WaveformPopupController now tracks dither variables, traces, validation, UI configuration, and stores values with existing amplitude/offset settings; enables/disables dither controls when live mode toggles.
- model: RemoteFocusBase gains robust parsing helper get_remote_focus_setting to coerce and validate string inputs, reads dither settings, and if both dither amplitude and frequency are >0 overlays a triangle dither waveform onto the remote-focus waveform.
- waveforms: add triangle_wave() utility used to generate the dither signal.
- tests: update existing tests to expect the new keys and widget values, add test to ensure dither is applied after smoothing, and add a waveform-tab test to verify the updated remote-focus waveform is plotted.

Also includes related minor refactors and logging updates for remote-focus setting changes.