### PR TITLE
Fix BDV N5 setup over-allocation

### DIFF
--- a/src/navigate/model/data_sources/bdv_data_source.py
+++ b/src/navigate/model/data_sources/bdv_data_source.py
@@ -166,6 +166,20 @@ class BigDataViewerDataSource(PyramidalDataSource):
         # find current channel
         c, z, t, pos = self._cztp_indices(self._current_frame, self.metadata.per_stack)
 
+        # Extend the file only when we are actually about to write into a new
+        # position. Doing this after the previous frame causes an extra,
+        # unwritten position worth of setups to be serialized at the end of a
+        # complete acquisition.
+        if pos >= self.positions:
+            old_positions = self.positions
+            self.setup(
+                self.shape_c * old_positions,
+                self.shape_c * (pos + 1),
+                create_flag=False,
+            )
+            self.positions = pos + 1
+            self.metadata.positions = self.positions
+
         if not (z or c or t or pos):
             self.setup()
 
@@ -195,15 +209,9 @@ class BigDataViewerDataSource(PyramidalDataSource):
 
         self._current_frame += 1
 
-        # Check if this was the last frame to write
-        c, z, t, pos = self._cztp_indices(self._current_frame, self.metadata.per_stack)
-        if (z == 0) and (c == 0) and ((t >= self.shape_t) or (pos >= self.positions)):
-            self.setup(
-                self.shape_c * self.positions,
-                self.shape_c * (pos + 1),
-                create_flag=False,
-            )
-            self.positions = pos + 1
+    def _setup_id(self, c, p):
+        """Get the setup id for a channel and position."""
+        return p * self.shape_c + c
 
     def _h5_ds_name(self, t, c, p):
         """Get the HDF5 dataset name for the given timepoint, channel, and position.
@@ -223,7 +231,7 @@ class BigDataViewerDataSource(PyramidalDataSource):
             The dataset name.
         """
         time_group_name = f"t{t:05}"
-        setup_group_name = f"s{(c*self.positions+p):02}"
+        setup_group_name = f"s{self._setup_id(c, p):02}"
         ds_name = "/".join([time_group_name, setup_group_name, "???", "cells"])
         return ds_name
 
@@ -245,7 +253,7 @@ class BigDataViewerDataSource(PyramidalDataSource):
             The dataset name.
         """
         time_group_name = f"timepoint{t}"
-        setup_group_name = f"setup{(c*self.positions+p)}"
+        setup_group_name = f"setup{self._setup_id(c, p)}"
         ds_name = "/".join([setup_group_name, time_group_name, "s???"])
         return ds_name
 

--- a/src/navigate/model/metadata_sources/bdv_metadata.py
+++ b/src/navigate/model/metadata_sources/bdv_metadata.py
@@ -88,6 +88,10 @@ class BigDataViewerMetadata(XMLMetadata):
         #: npt.NDArray: Rotation transform matrix.
         self.rotate_transform = np.eye(3, 4)
 
+    def _setup_id(self, c: int, p: int) -> int:
+        """Get the setup id for a channel and position."""
+        return p * self.shape_c + c
+
     def get_affine_parameters(self, configuration):
         """Get the affine transform parameters from the configuration file.
 
@@ -309,18 +313,18 @@ class BigDataViewerMetadata(XMLMetadata):
             {"name": "angle", "Angle": []},
         ]
 
-        # The actual loop that populates ViewSetup
-        view_id = 0
         for c in range(self.shape_c):
-            # We also take care of the Channel attributes here
             ch = {"id": {"text": str(c)}, "name": {"text": str(c)}}
             bdv_dict["SequenceDescription"]["ViewSetups"]["Attributes"][1][
                 "Channel"
             ].append(ch)
 
-            for pos in range(self.positions):
-                tile_id = tile_ids[pos] if pos < len(tile_ids) else pos
-                angle_id = angle_ids[pos] if pos < len(angle_ids) else 0
+        # The actual loop that populates ViewSetup
+        for pos in range(self.positions):
+            tile_id = tile_ids[pos] if pos < len(tile_ids) else pos
+            angle_id = angle_ids[pos] if pos < len(angle_ids) else 0
+            for c in range(self.shape_c):
+                view_id = self._setup_id(c, pos)
                 d = {
                     "id": {"text": view_id},
                     "name": {"text": view_id},
@@ -340,7 +344,6 @@ class BigDataViewerMetadata(XMLMetadata):
                 }
 
                 bdv_dict["SequenceDescription"]["ViewSetups"]["ViewSetup"].append(d)
-                view_id += 1
 
         # Finish up the Tile Attributes outside the channels loop so we have
         # one per tile
@@ -372,7 +375,7 @@ class BigDataViewerMetadata(XMLMetadata):
         for t in range(self.shape_t):
             for p in range(self.positions):
                 for c in range(self.shape_c):
-                    view_id = c * self.positions + p
+                    view_id = self._setup_id(c, p)
                     mat = np.zeros((3, 4), dtype=float)
                     for z in range(self.shape_z):
                         matrix_id = (

--- a/test/model/data_sources/test_bdv_data_source.py
+++ b/test/model/data_sources/test_bdv_data_source.py
@@ -1,4 +1,5 @@
 import os
+import xml.etree.ElementTree as ET
 
 import pytest
 import numpy as np
@@ -23,7 +24,16 @@ def recurse_dtype(group):
             print("Unknown how to handle:", key, subgroup_type)
 
 
-def bdv_ds(fn, multiposition, per_stack, z_stack, stop_early, size):
+def bdv_ds(
+    fn,
+    multiposition,
+    per_stack,
+    z_stack,
+    stop_early,
+    size,
+    z_steps=2,
+    timepoints=2,
+):
     from test.model.dummy import DummyModel
     from navigate.model.data_sources.bdv_data_source import BigDataViewerDataSource
 
@@ -32,10 +42,10 @@ def bdv_ds(fn, multiposition, per_stack, z_stack, stop_early, size):
         f"z_stack: {z_stack} stop_early: {stop_early}"
     )
 
-    # Set up model with a random number of z-steps to modulate the shape
+    # Set up model with explicit dimensions so test outcomes do not depend on
+    # random shape choices.
     model = DummyModel()
-    z_steps = np.random.randint(1, 3)
-    timepoints = np.random.randint(1, 3)
+    rng = np.random.default_rng(0)
 
     x_size, y_size = size
     model.configuration["experiment"]["CameraParameters"]["x_pixels"] = x_size
@@ -88,12 +98,12 @@ def bdv_ds(fn, multiposition, per_stack, z_stack, stop_early, size):
         f"x: {ds.shape_x} y: {ds.shape_y} z: {ds.shape_z} c: {ds.shape_c} "
         f"t: {ds.shape_t} positions: {ds.positions} per_stack: {ds.metadata.per_stack}"
     )
-    data = (np.random.rand(n_images, ds.shape_y, ds.shape_x) * 2**16).astype("uint16")
+    data = (rng.random((n_images, ds.shape_y, ds.shape_x)) * 2**16).astype("uint16")
     dbytes = np.sum(
         ds.shapes.prod(1) * ds.shape_t * ds.shape_c * ds.positions * 2
     )  # 2 bytes per pixel (16-bit)
     assert dbytes == ds.nbytes
-    data_positions = (np.random.rand(n_images, 5) * 50e3).astype(float)
+    data_positions = (rng.random((n_images, 5)) * 50e3).astype(float)
     for i in range(n_images):
         ds.write(
             data[i, ...].squeeze(),
@@ -103,7 +113,7 @@ def bdv_ds(fn, multiposition, per_stack, z_stack, stop_early, size):
             theta=data_positions[i, 3],
             f=data_positions[i, 4],
         )
-        if stop_early and np.random.rand() > 0.5:
+        if stop_early and i >= max(0, n_images // 2 - 1):
             break
 
     return ds
@@ -127,6 +137,66 @@ def close_bdv_ds(ds, file_name=None):
     except PermissionError:
         # Windows seems to think these files are still open
         pass
+
+
+def dynamic_setup_values(file_name, ext):
+    with h5py.File(file_name, "r") as image:
+        return [
+            int(image[f"t00000/s{setup_id:02}/0/cells"][0, 0, 0])
+            for setup_id in range(4)
+        ]
+
+
+@pytest.mark.parametrize("ext", ["h5", "n5"])
+def test_bdv_dynamic_position_growth_preserves_setup_mapping(tmp_path, ext):
+    from navigate.model.data_sources.bdv_data_source import BigDataViewerDataSource
+
+    file_name = tmp_path / f"dynamic.{ext}"
+    ds = BigDataViewerDataSource(str(file_name))
+    ds.set_metadata({"c": 2, "z": 1, "t": 1, "p": 1, "is_dynamic": True})
+
+    for value, x_position in [(10, 0), (20, 0), (30, 100), (40, 100)]:
+        ds.write(
+            np.array([[value]], dtype="uint16"),
+            x=x_position,
+            y=0,
+            z=0,
+            theta=0,
+            f=0,
+        )
+    ds.close()
+
+    if ext == "h5":
+        assert dynamic_setup_values(str(file_name), ext) == [10, 20, 30, 40]
+    else:
+        assert all(
+            (
+                file_name
+                / f"setup{setup_id}"
+                / "timepoint0"
+                / "s0"
+                / "0"
+                / "0"
+                / "0"
+            ).is_file()
+            for setup_id in range(4)
+        )
+
+    root = ET.parse(file_name.with_suffix(".xml")).getroot()
+    view_setups = {
+        int(setup.findtext("id")): (
+            int(setup.findtext("attributes/channel")),
+            int(setup.findtext("attributes/tile")),
+        )
+        for setup in root.findall("./SequenceDescription/ViewSetups/ViewSetup")
+    }
+    assert view_setups == {0: (0, 0), 1: (1, 0), 2: (0, 1), 3: (1, 1)}
+
+    registrations = {
+        int(registration.attrib["setup"])
+        for registration in root.findall("./ViewRegistrations/ViewRegistration")
+    }
+    assert registrations == {0, 1, 2, 3}
 
 
 @pytest.mark.parametrize("multiposition", [True, False])

--- a/test/model/metadata_sources/test_bdv_metadata.py
+++ b/test/model/metadata_sources/test_bdv_metadata.py
@@ -176,7 +176,7 @@ def test_bdv_xml_dict(dummy_model, stack_cycling_mode):
                         # assert view id
                         view_id = view_registrations[i]["setup"]
                         if ch > 1:
-                            assert view_id == ((i % ch) * pos + (i // ch))
+                            assert view_id == i % (pos * ch)
                         # assert affine position consistency between channels
                         if i % ch == 0:
                             affine = view_registrations[i]["ViewTransform"][0]["affine"]["text"]


### PR DESCRIPTION
### Motivation
- N5 writer was creating an extra, unwritten position worth of `setup` groups at the end of a complete acquisition because setup expansion was performed after advancing the frame index.
- Copilot also pointed out that simply moving expansion before the write exposed a second issue for dynamic growth: `c * positions + p` changes existing setup IDs when `positions` grows, which can overwrite an existing channel/position setup.

### Description
- Move dynamic N5/HDF5 setup expansion in `BigDataViewerDataSource.write()` to happen before the write, and only when the current frame actually targets a new position (`if pos >= self.positions: ...`).
- Use an append-friendly setup ID mapping, `position * channel_count + channel`, for HDF5/N5 dataset names and BDV XML metadata.
- Keep `metadata.positions` synchronized when dynamic growth occurs so the XML includes positions that were actually written.
- Make the BDV data source tests deterministic by using explicit z/time dimensions, deterministic image and stage data, and deterministic stop-early behavior instead of random shape choices.
- Update the BDV metadata test expectation to the append-friendly setup ordering.

### Evidence from 2026-05-21 acquisitions
- Inspected `/Users/Dean/Desktop/pr1207/20260521_lung_mv3_488nm_562nm`.
- `cell_001` (`per_stack`) has 4 N5 setups, 240 chunk files, 12 MIP files, and 12 XML view registrations.
- `cell_002` (`per_z`) has 4 N5 setups, 240 chunk files, 12 MIP files, and 12 XML view registrations.
- Logs for both acquisitions report 240 total received frames and include the final expected frame `C=1, Z=19, T=2, P=1`.

### Testing
- `uv run --python 3.9 --extra dev python -m pytest -p no:cov -o addopts= test/model/data_sources/test_bdv_data_source.py::test_bdv_getitem -vv`
  - Result: 24 passed in 36.89s.
- `uv run --python 3.9 --extra dev python -m pytest -p no:cov -o addopts= test/model/data_sources/test_bdv_data_source.py`
  - Result: 122 passed, 196 warnings in 130.29s.
- `uv run --python 3.9 --extra dev python -m pytest -p no:cov -o addopts= test/model/metadata_sources/test_bdv_metadata.py::test_bdv_xml_dict -vv`
  - Result: 2 passed in 2.56s.
- `uv run --python 3.9 --extra dev ruff check test/model/data_sources/test_bdv_data_source.py test/model/metadata_sources/test_bdv_metadata.py`
  - Result: All checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bed92c73a88325b20fa09c0f895a3a)
