### PR TITLE
Make OME-Zarr default save format

### DIFF
--- a/docs/source/01_getting_started/06_acquiring_data.rst
+++ b/docs/source/01_getting_started/06_acquiring_data.rst
@@ -152,7 +152,7 @@ Acquiring a Single Image
        :align: center
        :alt: Selecting the single acquisition mode in **navigate**.
 
-* Press :guilabel:`Acquire` to open the :guilabel:`File Saving Dialog` interface. Enter the sample parameters, notes, location to save file, and filetype in the :guilabel:`File Saving Dialog` that pops up.
+* Press :guilabel:`Acquire` to open the :guilabel:`File Saving Dialog` interface. Enter the sample parameters, notes, location to save file, and save format in the :guilabel:`File Saving Dialog` that pops up. OME-Zarr is the default and recommended choice for new acquisitions.
 
     .. image:: ../images/save-dialog-box.png
        :align: center
@@ -224,5 +224,5 @@ Acquiring a Z-Stack
     .. image:: ../images/z-stack-acquisition.png
        :align: center
 
-* Enter the sample parameters, notes, location to save file, and filetype in the :guilabel:`File Saving Dialog` that pops up.  
+* Enter the sample parameters, notes, location to save file, and save format in the :guilabel:`File Saving Dialog` that pops up. OME-Zarr is the default and recommended choice for new acquisitions.  
 * Press :guilabel:`Acquire Data` to initiate acquisition. Acquisition will automatically stop once the image series is acquired.

--- a/docs/source/02_user_guide/02_file_formats/file_formats.rst
+++ b/docs/source/02_user_guide/02_file_formats/file_formats.rst
@@ -4,49 +4,76 @@
 Supported File Formats
 ======================
 
-The choice of file format for saving imaging data in microscopy is crucial because it affects write speed, data integrity, accessibility, and analysis efficiency. Formats like TIFF and its derivative OME-TIFF are widely used due to their ability to store metadata and support multiple imaging channels. However, modern formats such as Zarr, N5, and HDF5, including OME-Zarr, cater to the needs of large-scale, multi-dimensional datasets by enabling efficient data storage, access, and processing at cloud-compute scales.
+The choice of file format for saving imaging data in microscopy is crucial because it
+affects write speed, data integrity, accessibility, and analysis efficiency. In
+**navigate**, OME-Zarr is now the primary save format because it combines standardized
+microscopy metadata with chunked, multiscale storage for large multidimensional
+datasets. It also matches the storage contract used by the lab's downstream analysis
+software, reducing format translation steps and keeping acquisition and analysis
+tightly coupled.
 
-To enable ambitious imaging projects, **navigate** comes pre-packaged with TIFF,
-OME-TIFF, OME-Zarr, and HDF5/N5 (`BigDataViewer <https://imagej.net/plugins/bdv/>`_)
-file saving formats. OME, or Open Microscopy Environment, is a standardized metadata
-model that ensures that imaging data can be accurately understood, shared, and analyzed
-across different software platforms and research groups.
+To support both modern analysis workflows and compatibility with existing tools,
+**navigate** writes OME-Zarr and OME-TIFF. OME, or Open Microscopy Environment, is a
+standardized metadata model that helps ensure imaging data can be accurately
+understood, shared, and analyzed across different software platforms and research
+groups.
 
 .. note::
 
     The performance of saving to these data sources is limited by write speed to disk. To achieve maximal saving speed, we recommend saving all data to a local solid state drive. See :ref:`Hardware Considerations <computer_considerations>` for more information.
 
-File Types:
------------
-
-TIFF/OME-TIFF
-~~~~~~~~~~~~~
-
-**navigate** uses the `tifffile <https://pypi.org/project/tifffile/>`_ package to write TIFF, BigTIFF, and OME-TIFF data to file. The **navigate** package creates a custom :doc:`OME-TIFF XML <../../05_reference/_autosummary/navigate.model.metadata_sources.ome_tiff_metadata.OMETIFFMetadata>` to store metadata.
-
-BigDataViewer H5/N5
-~~~~~~~~~~~~~~~~~~~
-
-**navigate** uses `h5py <https://docs.h5py.org/en/stable/index.html>`_ (H5) and
-`zarr <https://zarr.readthedocs.io/en/stable/>`_ (N5) to store data in a BigDataViewer
-file format. This is a pyramidal format, necessitating the saving of both the original
-data and downsampled versions of this data. The additional data slows down write speed.
-The N5 format can be faster than H5 because it allows for multithreaded writes.
+File Types
+----------
 
 OME-Zarr
 ~~~~~~~~
 
-OME-Zarr is a Zarr file format that adheres to strict metadata specifications
-(`OME-NGFF 0.4 <https://ngff.openmicroscopy.org/0.4/index.html>`_). It allows for
-pyramidal data writing, storage of segmentation labels with the dataset, and updating
-the pyramidal structure on the fly.
+**navigate** uses `zarr <https://zarr.readthedocs.io/en/stable/>`_ and
+`ome-zarr-models <https://ome-zarr-models-py.readthedocs.io/en/stable/>`_ to write
+acquisitions in the `OME-NGFF 0.5 <https://ngff.openmicroscopy.org/0.5/index.html>`_
+format. Each acquisition is materialized as ``data_store.ome.zarr`` inside the save
+directory. The store root is written as a single-well HCS plate with synthetic well
+``A/1``, and each Navigate position is saved as one field image beneath that well.
+Field images are stored as multiscale ``TCZYX`` arrays named ``0``, ``1``, ``2``, and
+so on.
+
+OME-Zarr is the recommended default for new acquisitions because it scales well to
+large multidimensional and multi-position datasets, keeps rich acquisition metadata
+close to the image data, and leaves room for future derived data such as labels or
+tables in the same datastore. During acquisition, **navigate** writes the
+full-resolution level first and finalizes the multiscale pyramid when the acquisition
+closes.
+
+OME-TIFF
+~~~~~~~~
+
+**navigate** uses the `tifffile <https://pypi.org/project/tifffile/>`_ package to
+write OME-TIFF data to file. The **navigate** package creates a custom
+:doc:`OME-TIFF XML <../../05_reference/_autosummary/navigate.model.metadata_sources.ome_tiff_metadata.OMETIFFMetadata>`
+to store metadata. OME-TIFF remains available as a compatibility format for workflows
+that expect TIFF-based interchange or software that does not yet read the current
+OME-Zarr layout.
 
 -------------------
 
-Image Writing Benchmarks
-------------------------
+Historical Image Writing Benchmarks
+-----------------------------------
 
-To evaluate the performance of saving imaging data in different formats, we conducted benchmarks on a Windows 10 system. We assessed the median disk write time for TIFF, OME-TIFF, H5, N5, and OME-Zarr formats across image resolutions of 512x512, 1024x1024, and 2048x2048 under two conditions: (A) capturing 1000 single-plane images and (B) acquiring a single z-stack composed of 1000 planes. All times are measured in milliseconds. Results are presented below. For z-stack imaging, TIFF and OME-TIFF formats achieved write speeds of up to approximately 300 Hz for a 2048x2048 camera resolution, surpassing the operational speeds of most contemporary sCMOS cameras. The Big-TIFF variant was used for both TIFF and OME-TIFF formats to accommodate the large file sizes.
+The benchmark tables below were collected on the previous file-writing stack and are
+retained as historical context. They are useful for showing the general disk-speed
+limits involved in microscopy acquisition, but they should not be interpreted as a
+benchmark of the current OME-Zarr v0.5 / Zarr v3 writer.
+
+To evaluate the historical save-path performance, we conducted benchmarks on a
+Windows 10 system. We assessed the median disk write time for TIFF, OME-TIFF, H5, N5,
+and OME-Zarr formats across image resolutions of 512x512, 1024x1024, and 2048x2048
+under two conditions: (A) capturing 1000 single-plane images and (B) acquiring a
+single z-stack composed of 1000 planes. All times are measured in milliseconds.
+Results are presented below. For z-stack imaging, TIFF and OME-TIFF formats achieved
+write speeds of up to approximately 300 Hz for a 2048x2048 camera resolution,
+surpassing the operational speeds of most contemporary sCMOS cameras. The Big-TIFF
+variant was used for both TIFF and OME-TIFF formats to accommodate the large file
+sizes.
 
 Timelapse Imaging
 ~~~~~~~~~~~~~~~~~
@@ -89,7 +116,10 @@ Z-Stack Imaging
 Additional Sources of Overhead
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The initial setup for writing H5/N5 files introduces significant overhead, and to a lesser extent for TIFF and OME-TIFF files, which elevates the average write time. However, the median write time remains consistently low and stable across most of the acquisition.
+In the historical H5/N5 measurements, initial setup introduced significant overhead,
+and to a lesser extent TIFF and OME-TIFF did as well, which elevated the average
+write time. However, the median write time remained consistently low and stable
+across most of the acquisition.
 
 Computer Specifications for Benchmarks
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/02_user_guide/03_user_interface_walkthrough/06_popups_and_tools.rst
+++ b/docs/source/02_user_guide/03_user_interface_walkthrough/06_popups_and_tools.rst
@@ -16,15 +16,20 @@ File Saving Dialog (Misc. Notes Tab)
 This dialog appears when acquisition starts in a save-enabled mode (non-continuous) with :ref:`Save Data <ui_timepoint_settings>` enabled. You can provide text in the :guilabel:`Misc. Notes` field to be saved alongside acquisition metadata.
 
 .. _ui_file_save_dialog_bdv:
+.. _ui_file_save_dialog_omezarr:
 
-File Saving Dialog (BDV Settings Tab)
-=====================================
+File Saving Dialog (OME-Zarr Settings Tab)
+==========================================
 
 .. image:: ../../images/popup_save_dialog_bdv_settings.png
    :align: center
-   :alt: File Saving Dialog popup showing the BDV Settings tab.
+   :alt: File Saving Dialog popup showing the OME-Zarr Settings tab.
 
-Use this tab to configure BDV-related shear, rotation, and downsampling metadata. This information will be saved in the BDV XML file alongside acquired data when :ref:`Save Data <ui_timepoint_settings>` is enabled, enabling the correct spatial interpretation of your data in BDV and compatible tools. More about BDV can be found on the ImageJ website: https://imagej.net/plugins/bdv/.
+Use this tab to configure OME-Zarr shear, rotation, and downsampling metadata. When
+:ref:`Save Data <ui_timepoint_settings>` is enabled and OME-Zarr is selected, this
+information is saved in ``data_store.ome.zarr`` alongside the acquisition metadata so
+downstream tools can interpret the stored volume correctly. More about the save format
+is available in :ref:`file_formats`.
 
 .. _ui_autofocus:
 

--- a/docs/source/02_user_guide/05_acquiring_data/01_acquiring_guide/01_acquiring_guide.rst
+++ b/docs/source/02_user_guide/05_acquiring_data/01_acquiring_guide/01_acquiring_guide.rst
@@ -9,7 +9,11 @@ This provides detailed descriptions of **navigate**'s acquisition modes and savi
 Standard Acquisition Modes
 ==========================
 
-**navigate** features standard acquisition modes including Continuous/Live, Single Frame, and Z-Stack, which can be saved to TIFF, OME-TIFF, HDF5, N5, and OME-Zarr data formats. Saving is toggled under the GUI's :ref:`timepoint settings <ui_timepoint_settings>`.
+**navigate** features standard acquisition modes including Continuous/Live, Single
+Frame, and Z-Stack, which can be saved to OME-Zarr and OME-TIFF data formats. OME-Zarr
+is the default and recommended format for new multidimensional acquisitions, while
+OME-TIFF remains available for compatibility workflows. Saving is toggled under the
+GUI's :ref:`timepoint settings <ui_timepoint_settings>`.
 
 These modes (and other custom modes) can be selected in the program's :ref:`acquisition bar <ui_acquisition_bar>` dropdown list. Each acquisition mode is implemented as a :ref:`feature list <user_guide_features>` and can be used in sequence with other features that can, for example, :ref:`make smart decisions <intermediate>`.
 

--- a/docs/source/03_contributing/03_software_architecture/software_architecture_developer_concepts.rst
+++ b/docs/source/03_contributing/03_software_architecture/software_architecture_developer_concepts.rst
@@ -180,7 +180,14 @@ ImageWriter Save Pipeline and Disk-Safety Guards
 
 Data Source and Metadata Abstraction Layer
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-File formats are implemented behind :class:`DataSource` abstractions (TIFF/OME-TIFF, OME-Zarr, BDV-related paths), while metadata conversion is handled by metadata-source classes. This separation allows format-specific storage logic and shared acquisition metadata logic to evolve independently. New formats should follow this pattern rather than embedding file-format logic directly into acquisition threads.
+File formats are implemented behind :class:`DataSource` abstractions, while metadata
+conversion is handled by metadata-source classes. For acquisition, the primary save
+paths are OME-TIFF and OME-Zarr, and the OME-Zarr path now also uses a storage-adapter
+layer that maps logical artifacts onto the canonical HCS layout inside
+``data_store.ome.zarr``. This separation allows format-specific storage logic and
+shared acquisition metadata logic to evolve independently. New formats should follow
+this pattern rather than embedding file-format logic directly into acquisition
+threads.
 
 Controller/Sub-Controller Boundaries and Event Bus
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/05_reference/implementations/configurations/configuration_mesospimbt.yaml
+++ b/docs/source/05_reference/implementations/configurations/configuration_mesospimbt.yaml
@@ -168,15 +168,20 @@ gui:
     count: 5
 
 
-# BDVParameters:
-# # The following parameters are used to configure the BigDataViewer
-#   # visualization. See the BigDataViewer documentation for more details.
-#   # https://imagej.net/BigDataViewer
-#   shear:
-#     shear_data: True
-#     shear_dimension: YZ # XZ, YZ, or XY
-#     shear_angle: 45
-#   rotate:
-#     rotate_data: False
-#     rotate_dimension: X # X, Y, Z
-#     rotate_angle: 0
+OMEZarrParameters:
+  # The following parameters are used to configure OME-Zarr output.
+  shear:
+    shear_data: True
+    shear_dimension: YZ # XZ, YZ, or XY
+    shear_angle: 45
+  rotate:
+    rotate_data: False
+    X: 0
+    Y: 0
+    Z: 0
+  down_sample:
+    enabled: False
+    scale_factors: [2, 4, 8, 16]
+  chunk_shape: [1, 1, 8, 256, 256]
+  shard_shape: [1, 1, 32, 256, 256]
+  compression: zstd-bitshuffle-fast

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,15 +14,17 @@ classifiers = [
     "Operating System :: POSIX :: Linux",
     "Operating System :: MacOS :: MacOS X",
     "Operating System :: Microsoft :: Windows",
-    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
 
-requires-python = ">=3.9.7"
+requires-python = ">=3.11,<3.14"
 dependencies = [
     'matplotlib-inline==0.1.3',
-    'PyYAML==6.0',
+    'PyYAML>=6.0.2,<7',
     'pyserial==3.5',
     'PIPython==2.6.0.1',
     'nidaqmx==0.5.7',
@@ -35,12 +37,13 @@ dependencies = [
     'numpy; sys_platform != "darwin"',
     'numpy; sys_platform == "darwin"',
     'scikit-image',
-    'zarr',
+    'zarr>=3.1.1,<4',
     'fsspec; sys_platform != "darwin"',
     'fsspec; sys_platform == "darwin"',
     'h5py',
     'requests',
     'psutil==6.0.0',
+    'ome-zarr-models>=1.6',
     ]
 
 [project.scripts]
@@ -59,7 +62,8 @@ dev = [
     "pytest-rerunfailures",
     "ipykernel",
     "jupyterlab",
-    "pydantic-ome-ngff==0.5.3"
+    "ome-zarr",
+    "bioio-ome-zarr"
     ]
 
 docs = [

--- a/src/navigate/config/config.py
+++ b/src/navigate/config/config.py
@@ -350,7 +350,7 @@ def verify_experiment_config(manager, configuration):
         "tissue": "Lung",
         "celltype": "MV3",
         "label": "GFP",
-        "file_type": "TIFF",
+        "file_type": "OME-Zarr",
         "prefix": "Cell_",
         "date": time.strftime("%Y-%m-%d"),
         "solvent": "BABB",
@@ -372,6 +372,64 @@ def verify_experiment_config(manager, configuration):
         saving_setting_dict["root_directory"] = saving_dict_sample["root_directory"]
     if not os.path.exists(saving_setting_dict["save_directory"]):
         saving_setting_dict["save_directory"] = saving_dict_sample["save_directory"]
+
+    ome_zarr_defaults = {
+        "shear": {
+            "shear_data": False,
+            "shear_dimension": "YZ",
+            "shear_angle": 0,
+        },
+        "rotate": {
+            "rotate_data": False,
+            "X": 0,
+            "Y": 0,
+            "Z": 0,
+        },
+        "down_sample": {
+            "enabled": False,
+            "scale_factors": [2, 4, 8, 16],
+        },
+        "chunk_shape": [1, 1, 8, 256, 256],
+        "shard_shape": [1, 1, 32, 256, 256],
+        "compression": "zstd-bitshuffle-fast",
+    }
+    legacy_bdv_parameters = configuration["experiment"].get("BDVParameters", None)
+    if (
+        "OMEZarrParameters" not in configuration["experiment"]
+        or type(configuration["experiment"]["OMEZarrParameters"]) is not DictProxy
+    ):
+        if type(legacy_bdv_parameters) is DictProxy:
+            down_sample = legacy_bdv_parameters.get("down_sample", {})
+            if down_sample.get("down_sample", False):
+                max_factor = max(
+                    int(down_sample.get("lateral_down_sample", 1)),
+                    int(down_sample.get("axial_down_sample", 1)),
+                    1,
+                )
+                ome_zarr_defaults["down_sample"]["enabled"] = max_factor > 1
+                ome_zarr_defaults["down_sample"]["scale_factors"] = [
+                    factor for factor in [2, 4, 8, 16] if factor <= max_factor
+                ]
+            for key in ("shear", "rotate"):
+                if key in legacy_bdv_parameters:
+                    ome_zarr_defaults[key] = dict(legacy_bdv_parameters[key])
+        update_config_dict(
+            manager,
+            configuration["experiment"],
+            "OMEZarrParameters",
+            ome_zarr_defaults,
+        )
+    else:
+        ome_zarr_parameters = configuration["experiment"]["OMEZarrParameters"]
+        for key, value in ome_zarr_defaults.items():
+            if key not in ome_zarr_parameters.keys():
+                ome_zarr_parameters[key] = value
+        if "down_sample" not in ome_zarr_parameters:
+            ome_zarr_parameters["down_sample"] = ome_zarr_defaults["down_sample"]
+        else:
+            for key, value in ome_zarr_defaults["down_sample"].items():
+                if key not in ome_zarr_parameters["down_sample"].keys():
+                    ome_zarr_parameters["down_sample"][key] = value
 
     # camera parameters
     camera_parameters_dict_sample = {

--- a/src/navigate/config/configuration.yaml
+++ b/src/navigate/config/configuration.yaml
@@ -394,10 +394,8 @@ gui:
   channels:
     count: 5
 
-BDVParameters:
-# The following parameters are used to configure the BigDataViewer
-  # visualization. See the BigDataViewer documentation for more details.
-  # https://imagej.net/BigDataViewer
+OMEZarrParameters:
+# The following parameters are used to configure OME-Zarr output.
   shear:
     shear_data: True
     shear_dimension: YZ # XZ, YZ, or XY
@@ -407,3 +405,9 @@ BDVParameters:
     X: 0
     Y: 0
     Z: 0
+  down_sample:
+    enabled: False
+    scale_factors: [2, 4, 8, 16]
+  chunk_shape: [1, 1, 8, 256, 256]
+  shard_shape: [1, 1, 32, 256, 256]
+  compression: zstd-bitshuffle-fast

--- a/src/navigate/config/experiment.yml
+++ b/src/navigate/config/experiment.yml
@@ -7,7 +7,7 @@ Saving:
   tissue: Lung
   celltype: MV3
   label: GFP
-  file_type: TIFF
+  file_type: OME-Zarr
   date: 2022-06-07
   solvent: BABB
 CameraParameters:

--- a/src/navigate/config/synthetic_configuration.yaml
+++ b/src/navigate/config/synthetic_configuration.yaml
@@ -295,10 +295,8 @@ gui:
       max: 1000
       step: 1
 
-BDVParameters:
-# The following parameters are used to configure the BigDataViewer
-  # visualization. See the BigDataViewer documentation for more details.
-  # https://imagej.net/BigDataViewer
+OMEZarrParameters:
+# The following parameters are used to configure OME-Zarr output.
   shear:
     shear_data: False
     shear_dimension: YZ # XZ, YZ, or XY
@@ -308,3 +306,9 @@ BDVParameters:
     X: 0
     Y: 0
     Z: 0
+  down_sample:
+    enabled: False
+    scale_factors: [2, 4, 8, 16]
+  chunk_shape: [1, 1, 8, 256, 256]
+  shard_shape: [1, 1, 32, 256, 256]
+  compression: zstd-bitshuffle-fast

--- a/src/navigate/controller/sub_controllers/acquire_bar.py
+++ b/src/navigate/controller/sub_controllers/acquire_bar.py
@@ -101,13 +101,16 @@ class AcquireBarController(GUIController):
         # framerate information.
         self.framerate = 0
 
-        #: dict: The ProxyDict for the BDV configuration.
-        self.bdv_configuration = self.parent_controller.configuration["experiment"].get(
-            "BDVParameters", None
+        #: dict: The ProxyDict for the OME-Zarr configuration.
+        self.ome_zarr_configuration = self.parent_controller.configuration[
+            "experiment"
+        ].get(
+            "OMEZarrParameters",
+            self.parent_controller.configuration["experiment"].get("BDVParameters"),
         )
 
-        #: dict: BDV Widgets. Keys are primary widgets, values are lists.
-        self.bdv_widgets = {
+        #: dict: OME-Zarr widgets. Keys are primary widgets, values are lists.
+        self.ome_zarr_widgets = {
             "shear_data": ["shear_dimension", "shear_angle"],
             "rotate_data": ["rotate_angle_x", "rotate_angle_y", "rotate_angle_z"],
             "down_sample_data": ["lateral_down_sample", "axial_down_sample"],
@@ -358,15 +361,15 @@ class AcquireBarController(GUIController):
             file_type = widgets["file_type"].get_variable()
             file_type.trace_add("write", lambda *args: self.update_file_type(file_type))
 
-            self.set_bdv_settings()
+            self.set_ome_zarr_settings()
 
-            for widget in self.bdv_widgets.keys():
+            for widget in self.ome_zarr_widgets.keys():
                 # Traces for the main widgets
                 self.acquire_pop.tab_frame.inputs[widget].get_variable().trace_add(
                     "write",
-                    lambda *args, main_widget=widget, dep_widget=self.bdv_widgets[
+                    lambda *args, main_widget=widget, dep_widget=self.ome_zarr_widgets[
                         widget
-                    ]: self.toggle_bdv_widgets(main_widget, dep_widget),
+                    ]: self.toggle_ome_zarr_widgets(main_widget, dep_widget),
                 )
 
             for k, v in self.saving_settings.items():
@@ -382,97 +385,112 @@ class AcquireBarController(GUIController):
             self.view.pull_down.state(["disabled", "readonly"])
             self.parent_controller.execute("acquire")
 
-    def set_bdv_settings(self) -> None:
-        """Set the BDV Settings from the configuration file.
+    def set_ome_zarr_settings(self) -> None:
+        """Set the OME-Zarr settings from the configuration file.
 
         If the settings are not in the configuration file, they will be added.
         """
         update_config = False
 
-        if self.bdv_configuration is None:
+        if self.ome_zarr_configuration is None:
             update_config = True
-            self.bdv_configuration = {}
+            self.ome_zarr_configuration = {}
 
         # Shear Parameters
-        if self.bdv_configuration.get("shear", None) is None:
+        if self.ome_zarr_configuration.get("shear", None) is None:
             update_config = True
-            self.bdv_configuration["shear"] = {
+            self.ome_zarr_configuration["shear"] = {
                 "shear_data": False,
                 "shear_dimension": "YZ",
                 "shear_angle": 0,
             }
         self.acquire_pop.tab_frame.inputs["shear_data"].set(
-            self.bdv_configuration["shear"].get("shear_data", False)
+            self.ome_zarr_configuration["shear"].get("shear_data", False)
         )
         self.acquire_pop.tab_frame.inputs["shear_dimension"].set(
-            self.bdv_configuration["shear"].get("shear_dimension", "YZ")
+            self.ome_zarr_configuration["shear"].get("shear_dimension", "YZ")
         )
         self.acquire_pop.tab_frame.inputs["shear_angle"].set(
-            self.bdv_configuration["shear"].get("shear_angle", 0)
+            self.ome_zarr_configuration["shear"].get("shear_angle", 0)
         )
 
         # Rotation Parameters
-        if self.bdv_configuration.get("rotate", None) is None:
+        if self.ome_zarr_configuration.get("rotate", None) is None:
             update_config = True
-            self.bdv_configuration["rotate"] = {
+            self.ome_zarr_configuration["rotate"] = {
                 "rotate_data": False,
                 "X": 0,
                 "Y": 0,
                 "Z": 0,
             }
         self.acquire_pop.tab_frame.inputs["rotate_data"].set(
-            self.bdv_configuration["rotate"].get("rotate_data", False)
+            self.ome_zarr_configuration["rotate"].get("rotate_data", False)
         )
         self.acquire_pop.tab_frame.inputs["rotate_angle_x"].set(
-            self.bdv_configuration["rotate"].get("X", 0)
+            self.ome_zarr_configuration["rotate"].get("X", 0)
         )
         self.acquire_pop.tab_frame.inputs["rotate_angle_y"].set(
-            self.bdv_configuration["rotate"].get("Y", 0)
+            self.ome_zarr_configuration["rotate"].get("Y", 0)
         )
         self.acquire_pop.tab_frame.inputs["rotate_angle_z"].set(
-            self.bdv_configuration["rotate"].get("Z", 0)
+            self.ome_zarr_configuration["rotate"].get("Z", 0)
         )
 
         # Down Sample Parameters
-        if self.bdv_configuration.get("down_sample", None) is None:
+        if self.ome_zarr_configuration.get("down_sample", None) is None:
             update_config = True
-            self.bdv_configuration["down_sample"] = {
-                "down_sample": False,
-                "lateral_down_sample": 1,
-                "axial_down_sample": 1,
+            self.ome_zarr_configuration["down_sample"] = {
+                "enabled": False,
+                "scale_factors": [2, 4, 8, 16],
             }
+        if self.ome_zarr_configuration.get("chunk_shape", None) is None:
+            update_config = True
+            self.ome_zarr_configuration["chunk_shape"] = [1, 1, 8, 256, 256]
+        if self.ome_zarr_configuration.get("shard_shape", None) is None:
+            update_config = True
+            self.ome_zarr_configuration["shard_shape"] = [1, 1, 32, 256, 256]
+        if self.ome_zarr_configuration.get("compression", None) is None:
+            update_config = True
+            self.ome_zarr_configuration["compression"] = "zstd-bitshuffle-fast"
+
+        scale_factors = [
+            max(int(scale_factor), 1)
+            for scale_factor in self.ome_zarr_configuration["down_sample"].get(
+                "scale_factors", [2, 4, 8, 16]
+            )
+        ]
+        max_scale = max(scale_factors, default=1)
         self.acquire_pop.tab_frame.inputs["down_sample_data"].set(
-            self.bdv_configuration["down_sample"].get("down_sample", False)
+            self.ome_zarr_configuration["down_sample"].get("enabled", False)
         )
         self.acquire_pop.tab_frame.inputs["lateral_down_sample"].set(
-            str(self.bdv_configuration["down_sample"].get("lateral_down_sample", 1))
-            + "x"
+            str(max_scale) + "x"
         )
         self.acquire_pop.tab_frame.inputs["axial_down_sample"].set(
-            str(self.bdv_configuration["down_sample"].get("axial_down_sample", 1)) + "x"
+            str(max_scale) + "x"
         )
 
         if update_config:
             update_config_dict(
                 self.parent_controller.manager,
                 self.parent_controller.configuration["experiment"],
-                "BDVParameters",
-                self.bdv_configuration,
+                "OMEZarrParameters",
+                self.ome_zarr_configuration,
             )
-            self.bdv_configuration = self.parent_controller.configuration["experiment"][
-                "BDVParameters"
-            ]
+            self.ome_zarr_configuration = self.parent_controller.configuration[
+                "experiment"
+            ]["OMEZarrParameters"]
 
         # Set the state of the dependent widgets
-        for widget in self.bdv_widgets.keys():
-            self.toggle_bdv_widgets(widget, self.bdv_widgets[widget])
+        for widget in self.ome_zarr_widgets.keys():
+            self.toggle_ome_zarr_widgets(widget, self.ome_zarr_widgets[widget])
 
-    def update_bdv_settings(self) -> None:
-        """Update the BDV settings."""
-        if self.bdv_configuration is not None:
-            # Set the widget variables according to the BDV configuration
+    def update_ome_zarr_settings(self) -> None:
+        """Update the OME-Zarr settings."""
+        if self.ome_zarr_configuration is not None:
+            # Set the widget variables according to the OME-Zarr configuration
             # Shear Parameters
-            self.bdv_configuration["shear"]["shear_data"] = bool(
+            self.ome_zarr_configuration["shear"]["shear_data"] = bool(
                 (
                     update := self.acquire_pop.tab_frame.inputs[
                         "shear_data"
@@ -481,15 +499,15 @@ class AcquireBarController(GUIController):
             )
 
             if update:
-                self.bdv_configuration["shear"]["shear_dimension"] = str(
+                self.ome_zarr_configuration["shear"]["shear_dimension"] = str(
                     self.acquire_pop.tab_frame.inputs["shear_dimension"].variable.get()
                 )
-                self.bdv_configuration["shear"]["shear_angle"] = float(
+                self.ome_zarr_configuration["shear"]["shear_angle"] = float(
                     self.acquire_pop.tab_frame.inputs["shear_angle"].variable.get()
                 )
 
             # Rotation Parameters
-            self.bdv_configuration["rotate"]["rotate_data"] = bool(
+            self.ome_zarr_configuration["rotate"]["rotate_data"] = bool(
                 (
                     update := self.acquire_pop.tab_frame.inputs[
                         "rotate_data"
@@ -498,18 +516,18 @@ class AcquireBarController(GUIController):
             )
 
             if update:
-                self.bdv_configuration["rotate"]["X"] = float(
+                self.ome_zarr_configuration["rotate"]["X"] = float(
                     self.acquire_pop.tab_frame.inputs["rotate_angle_x"].variable.get()
                 )
-                self.bdv_configuration["rotate"]["Y"] = float(
+                self.ome_zarr_configuration["rotate"]["Y"] = float(
                     self.acquire_pop.tab_frame.inputs["rotate_angle_y"].variable.get()
                 )
-                self.bdv_configuration["rotate"]["Z"] = float(
+                self.ome_zarr_configuration["rotate"]["Z"] = float(
                     self.acquire_pop.tab_frame.inputs["rotate_angle_z"].variable.get()
                 )
 
             # Down Sample Parameters
-            self.bdv_configuration["down_sample"]["down_sample"] = bool(
+            self.ome_zarr_configuration["down_sample"]["enabled"] = bool(
                 (
                     update := self.acquire_pop.tab_frame.inputs[
                         "down_sample_data"
@@ -518,19 +536,35 @@ class AcquireBarController(GUIController):
             )
 
             if update:
-                self.bdv_configuration["down_sample"]["lateral_down_sample"] = int(
+                lateral_down_sample = int(
                     self.acquire_pop.tab_frame.inputs[
                         "lateral_down_sample"
                     ].variable.get()[:-1]
                 )
-
-                self.bdv_configuration["down_sample"]["axial_down_sample"] = int(
+                axial_down_sample = int(
                     self.acquire_pop.tab_frame.inputs[
                         "axial_down_sample"
                     ].variable.get()[:-1]
                 )
+                max_scale = max(lateral_down_sample, axial_down_sample, 1)
+                self.ome_zarr_configuration["down_sample"]["scale_factors"] = [
+                    scale_factor
+                    for scale_factor in [2, 4, 8, 16]
+                    if scale_factor <= max_scale
+                ]
+            else:
+                self.ome_zarr_configuration["down_sample"]["scale_factors"] = [
+                    2,
+                    4,
+                    8,
+                    16,
+                ]
 
-    def toggle_bdv_widgets(self, main_widget: str, dependent_widgets: list) -> None:
+            self.ome_zarr_configuration["chunk_shape"] = [1, 1, 8, 256, 256]
+            self.ome_zarr_configuration["shard_shape"] = [1, 1, 32, 256, 256]
+            self.ome_zarr_configuration["compression"] = "zstd-bitshuffle-fast"
+
+    def toggle_ome_zarr_widgets(self, main_widget: str, dependent_widgets: list) -> None:
         """Toggles the state of the dependent widgets.
 
         Parameters
@@ -597,7 +631,7 @@ class AcquireBarController(GUIController):
 
         # update saving settings according to user's input
         self.update_experiment_values(popup_window)
-        self.update_bdv_settings()
+        self.update_ome_zarr_settings()
 
         # Collect all entry names to validate
         entry_names = [

--- a/src/navigate/controller/sub_controllers/camera_map.py
+++ b/src/navigate/controller/sub_controllers/camera_map.py
@@ -127,8 +127,8 @@ class CameraMapSettingPopupController(GUIController):
         save_path_offset = Path(save_dir).joinpath(save_name_offset)
         save_path_variance = Path(save_dir).joinpath(save_name_variance)
 
-        tifffile.imsave(save_path_offset, self.off)
-        tifffile.imsave(save_path_variance, self.var)
+        tifffile.imwrite(save_path_offset, self.off)
+        tifffile.imwrite(save_path_variance, self.var)
 
     def display_plot(self):
         """Display the offset and variance maps."""

--- a/src/navigate/model/data_sources/__init__.py
+++ b/src/navigate/model/data_sources/__init__.py
@@ -43,7 +43,7 @@ logger = logging.getLogger(p)
 
 """ File type specific data sources. """
 
-FILE_TYPES = ["TIFF", "OME-TIFF", "H5", "N5", "OME-Zarr"]
+FILE_TYPES = ["OME-Zarr", "OME-TIFF"]
 
 
 def get_data_source(file_type: str):

--- a/src/navigate/model/data_sources/ome_zarr_writer.py
+++ b/src/navigate/model/data_sources/ome_zarr_writer.py
@@ -1,0 +1,284 @@
+# Copyright (c) 2021-2026  The University of Texas Southwestern Medical Center.
+# All rights reserved.
+
+from __future__ import annotations
+
+import json
+from typing import Dict, Iterable, Optional
+
+import numpy as np
+import numpy.typing as npt
+import zarr
+from zarr.codecs import BloscCodec
+
+from navigate.tools.common_functions import copy_proxy_object
+
+from .storage_adapter import OMEZarrStorageAdapter
+
+
+class OMEZarrV3StoreWriter:
+    """Write Navigate acquisitions into the canonical v0.5 OME-Zarr layout."""
+
+    def __init__(
+        self,
+        file_name: str,
+        metadata,
+        dtype: str,
+        chunk_shape: tuple[int, int, int, int, int],
+        shard_shape: tuple[int, int, int, int, int],
+        scale_factors: tuple[int, ...],
+    ) -> None:
+        self.file_name = file_name
+        self.metadata = metadata
+        self.dtype = np.dtype(dtype)
+        self.chunk_shape = tuple(int(v) for v in chunk_shape)
+        self.shard_shape = tuple(int(v) for v in shard_shape)
+        self.scale_factors = tuple(int(v) for v in scale_factors)
+        self.adapter = OMEZarrStorageAdapter(file_name)
+        self.compressor = BloscCodec(cname="zstd", clevel=1, shuffle="bitshuffle")
+
+        self.root = None
+        self._well_group = None
+        self._field_groups: dict[int, zarr.Group] = {}
+        self._field_views: dict[int, Dict] = {}
+        self._slabs: dict[tuple[int, int, int], dict] = {}
+        self._written_positions: set[int] = set()
+
+    @property
+    def image(self):
+        return self.root
+
+    def setup(self) -> None:
+        self.root = zarr.open_group(self.file_name, mode="w", zarr_format=3)
+        row_group = self.root.create_group(self.adapter.row_name)
+        self._well_group = row_group.create_group(self.adapter.column_name)
+        self._update_hcs_metadata(positions=self.metadata.positions)
+        self._update_well_metadata([])
+
+    def _update_hcs_metadata(self, positions: int) -> None:
+        self.root.attrs.update(self.metadata.hcs_attributes(positions))
+        self.root.attrs["bioformats2raw.layout"] = 3
+
+    def _update_well_metadata(self, field_names: Iterable[str]) -> None:
+        self._well_group.attrs.update(self.metadata.well_attributes(field_names))
+
+    def _field_group(self, position_index: int) -> zarr.Group:
+        if position_index in self._field_groups:
+            return self._field_groups[position_index]
+
+        field_group = self._well_group.create_group(str(position_index))
+        level0_shape = (
+            int(self.metadata.shape_t),
+            int(self.metadata.shape_c),
+            int(self.metadata.shape_z),
+            int(self.metadata.shape_y),
+            int(self.metadata.shape_x),
+        )
+        chunks = self._clamp_chunks(level0_shape)
+        shards = self._clamp_shards(level0_shape, chunks)
+        field_group.create_array(
+            "0",
+            shape=level0_shape,
+            dtype=self.dtype,
+            chunks=chunks,
+            shards=shards,
+            compressors=self.compressor,
+            dimension_names=self.metadata.axes_names,
+            overwrite=True,
+        )
+        self._field_groups[position_index] = field_group
+        return field_group
+
+    def write_plane(
+        self,
+        position_index: int,
+        time_index: int,
+        channel_index: int,
+        z_index: int,
+        data: npt.ArrayLike,
+        view: Optional[Dict] = None,
+    ) -> None:
+        self._field_group(position_index)
+        self._written_positions.add(position_index)
+        if view is not None and position_index not in self._field_views:
+            self._field_views[position_index] = dict(view)
+
+        chunk_depth = max(int(self.chunk_shape[2]), 1)
+        slab_key = (position_index, time_index, channel_index)
+        slab_start = (z_index // chunk_depth) * chunk_depth
+        slab = self._slabs.get(slab_key)
+        if slab is None or slab["start_z"] != slab_start:
+            self._flush_slab(slab_key)
+            slab_length = min(chunk_depth, self.metadata.shape_z - slab_start)
+            slab = {
+                "start_z": slab_start,
+                "data": np.zeros(
+                    (slab_length, self.metadata.shape_y, self.metadata.shape_x),
+                    dtype=self.dtype,
+                ),
+                "count": 0,
+            }
+            self._slabs[slab_key] = slab
+
+        plane_offset = z_index - slab_start
+        slab["data"][plane_offset] = np.asarray(data, dtype=self.dtype)
+        slab["count"] = max(slab["count"], plane_offset + 1)
+
+        if slab["count"] == slab["data"].shape[0]:
+            self._flush_slab(slab_key)
+
+    def _flush_slab(self, slab_key: tuple[int, int, int]) -> None:
+        slab = self._slabs.pop(slab_key, None)
+        if slab is None or slab["count"] == 0:
+            return
+
+        position_index, time_index, channel_index = slab_key
+        field_group = self._field_groups[position_index]
+        level0 = field_group["0"]
+        start = slab["start_z"]
+        stop = start + slab["count"]
+        level0[
+            time_index,
+            channel_index,
+            start:stop,
+            : self.metadata.shape_y,
+            : self.metadata.shape_x,
+        ] = slab["data"][: slab["count"]]
+
+    def finalize(self, shape_t: int, shape_c: int, shape_z: int, positions: int) -> None:
+        for slab_key in list(self._slabs):
+            self._flush_slab(slab_key)
+
+        valid_positions = sorted(position for position in self._written_positions if position < positions)
+        for position_index in valid_positions:
+            field_group = self._field_groups[position_index]
+            level0 = field_group["0"]
+            target_shape = (
+                int(shape_t),
+                int(shape_c),
+                int(shape_z),
+                int(self.metadata.shape_y),
+                int(self.metadata.shape_x),
+            )
+            if tuple(level0.shape) != target_shape:
+                level0.resize(target_shape)
+
+            level_paths = ["0"]
+            for level_index, scale_factor in enumerate(self.scale_factors[1:], start=1):
+                level_name = str(level_index)
+                if level_name in field_group:
+                    del field_group[level_name]
+
+                level_shape = self._scaled_shape(target_shape, scale_factor)
+                chunks = self._clamp_chunks(level_shape)
+                shards = self._clamp_shards(level_shape, chunks)
+                level_array = field_group.create_array(
+                    level_name,
+                    shape=level_shape,
+                    dtype=self.dtype,
+                    chunks=chunks,
+                    shards=shards,
+                    compressors=self.compressor,
+                    dimension_names=self.metadata.axes_names,
+                    overwrite=True,
+                )
+                for t_idx in range(level_shape[0]):
+                    for c_idx in range(level_shape[1]):
+                        downsampled = level0[
+                            t_idx,
+                            c_idx,
+                            : target_shape[2],
+                            : target_shape[3],
+                            : target_shape[4],
+                        ][::scale_factor, ::scale_factor, ::scale_factor]
+                        level_array[t_idx, c_idx, ...] = np.asarray(
+                            downsampled, dtype=self.dtype
+                        )
+                level_paths.append(level_name)
+
+            field_group.attrs.update(
+                self.metadata.image_attributes(
+                    name=f"Field {position_index}",
+                    paths=level_paths,
+                    scale_factors=self.scale_factors[: len(level_paths)],
+                    view=self._field_views.get(position_index),
+                )
+            )
+            self.metadata.validate_image_group(field_group)
+
+        field_names = [str(position_index) for position_index in valid_positions]
+        self._update_hcs_metadata(positions=max(len(field_names), 1))
+        self._update_well_metadata(field_names)
+        self.metadata.validate_hcs_group(self.root)
+        self.metadata.validate_well_group(self._well_group)
+        self._write_metadata_sidecars(field_names)
+
+    def _write_metadata_sidecars(self, field_names: list[str]) -> None:
+        metadata_dir = self.adapter.absolute_path(self.adapter.metadata_root)
+        metadata_dir.mkdir(parents=True, exist_ok=True)
+
+        acquisition = copy_proxy_object(self.metadata.configuration.get("experiment", {}))
+        configuration = copy_proxy_object(
+            self.metadata.configuration.get("configuration", {})
+        )
+        artifacts = self.adapter.artifact_manifest(
+            int(name) for name in field_names if name.isdigit()
+        )
+
+        acquisition["field_names"] = field_names
+        acquisition["store"] = self.file_name
+
+        for name, payload in (
+            ("artifacts", artifacts),
+            ("acquisition", acquisition),
+            ("configuration", configuration),
+        ):
+            target_path = self.adapter.absolute_path(self.adapter.metadata_blob_path(name))
+            target_path.parent.mkdir(parents=True, exist_ok=True)
+            with open(target_path, "w", encoding="utf-8") as handle:
+                json.dump(payload, handle, indent=2, default=self._json_default)
+
+        ome_dir = self.adapter.absolute_path("OME")
+        ome_dir.mkdir(parents=True, exist_ok=True)
+        with open(ome_dir / "METADATA.ome.xml", "w", encoding="utf-8") as handle:
+            handle.write(self.metadata.metadata_only_xml(field_names))
+
+    @staticmethod
+    def _json_default(value):
+        if isinstance(value, np.generic):
+            return value.item()
+        if hasattr(value, "isoformat"):
+            return value.isoformat()
+        return str(value)
+
+    def close(self) -> None:
+        self.root = None
+        self._well_group = None
+        self._field_groups.clear()
+        self._field_views.clear()
+        self._slabs.clear()
+        self._written_positions.clear()
+
+    def _scaled_shape(
+        self, shape: tuple[int, int, int, int, int], scale_factor: int
+    ) -> tuple[int, int, int, int, int]:
+        return (
+            shape[0],
+            shape[1],
+            max((shape[2] + scale_factor - 1) // scale_factor, 1),
+            max((shape[3] + scale_factor - 1) // scale_factor, 1),
+            max((shape[4] + scale_factor - 1) // scale_factor, 1),
+        )
+
+    def _clamp_chunks(self, shape: tuple[int, ...]) -> tuple[int, ...]:
+        return tuple(max(1, min(target, axis_len)) for target, axis_len in zip(self.chunk_shape, shape))
+
+    def _clamp_shards(
+        self, shape: tuple[int, ...], chunks: tuple[int, ...]
+    ) -> tuple[int, ...]:
+        shards = []
+        for axis_len, chunk, target in zip(shape, chunks, self.shard_shape):
+            axis_target = min(target, axis_len)
+            multiple = max((axis_target // chunk), 1)
+            shards.append(max(chunk, multiple * chunk))
+        return tuple(shards)

--- a/src/navigate/model/data_sources/pyramidal_data_source.py
+++ b/src/navigate/model/data_sources/pyramidal_data_source.py
@@ -166,33 +166,34 @@ class PyramidalDataSource(DataSource):
         """
         self._subdivisions = None
         self._shapes = None
+        self._resolutions = np.array([[1, 1, 1]], dtype=int)
 
-        if (
-            "BDVParameters" in configuration["experiment"].keys()
-            and "down_sample" in configuration["experiment"]["BDVParameters"].keys()
+        experiment = configuration.get("experiment", {})
+        ome_zarr_parameters = experiment.get("OMEZarrParameters", {})
+        down_sample = ome_zarr_parameters.get("down_sample", {})
+        if down_sample.get("enabled", False):
+            scale_factors = [1]
+            for factor in down_sample.get("scale_factors", [2, 4, 8, 16]):
+                factor = max(int(factor), 1)
+                if factor not in scale_factors:
+                    scale_factors.append(factor)
+            self._resolutions = np.array(
+                [[factor, factor, factor] for factor in scale_factors], dtype=int
+            )
+        elif (
+            "BDVParameters" in experiment.keys()
+            and "down_sample" in experiment["BDVParameters"].keys()
         ):
-            down_sample = configuration["experiment"]["BDVParameters"][
-                "down_sample"
-            ].get("down_sample", False)
-
-            if down_sample:
-                max_xy = configuration["experiment"]["BDVParameters"][
-                    "down_sample"
-                ].get("lateral_down_sample", 1)
-                max_z = configuration["experiment"]["BDVParameters"]["down_sample"].get(
-                    "axial_down_sample", 1
-                )
-
-                xy_values = [2**i for i in range(int(np.log2(max_xy)) + 1)]
-                z_values = [2**i for i in range(int(np.log2(max_z)) + 1)]
-
-                max_len = max(len(xy_values), len(z_values))
-                xy_values.extend([xy_values[-1]] * (max_len - len(xy_values)))
-                z_values.extend([z_values[-1]] * (max_len - len(z_values)))
-
-                #: npt.NDArray: The resolution of each down-sampled pyramid level.
+            legacy_down_sample = experiment["BDVParameters"]["down_sample"]
+            if legacy_down_sample.get("down_sample", False):
+                max_xy = int(legacy_down_sample.get("lateral_down_sample", 1))
+                max_z = int(legacy_down_sample.get("axial_down_sample", 1))
+                max_factor = max(max_xy, max_z, 1)
+                scale_factors = [1] + [
+                    factor for factor in [2, 4, 8, 16] if factor <= max_factor
+                ]
                 self._resolutions = np.array(
-                    [[xy, xy, z] for xy, z in zip(xy_values, z_values)], dtype=int
+                    [[factor, factor, factor] for factor in scale_factors], dtype=int
                 )
 
         return super().set_metadata_from_configuration_experiment(

--- a/src/navigate/model/data_sources/storage_adapter.py
+++ b/src/navigate/model/data_sources/storage_adapter.py
@@ -1,0 +1,99 @@
+# Copyright (c) 2021-2026  The University of Texas Southwestern Medical Center.
+# All rights reserved.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+ARTIFACT_KINDS = (
+    "image_collection",
+    "label_collection",
+    "table",
+    "metadata_blob",
+)
+
+
+@dataclass(frozen=True)
+class ArtifactRef:
+    """Logical reference to data materialized inside an OME-Zarr store."""
+
+    kind: str
+    artifact_id: str
+
+    def __post_init__(self) -> None:
+        if self.kind not in ARTIFACT_KINDS:
+            raise ValueError(f"Unsupported artifact kind {self.kind!r}.")
+
+
+class OMEZarrStorageAdapter:
+    """Maps logical artifact references to canonical OME-Zarr paths."""
+
+    row_name = "A"
+    column_name = "1"
+    well_path = f"{row_name}/{column_name}"
+    metadata_root = "navigate/metadata"
+    metadata_blob_names = {
+        "artifacts": f"{metadata_root}/artifacts.json",
+        "acquisition": f"{metadata_root}/acquisition.json",
+        "configuration": f"{metadata_root}/configuration.json",
+    }
+
+    def __init__(self, root_path: str) -> None:
+        self.root_path = Path(root_path)
+
+    def field_group_path(self, position_index: int) -> str:
+        return f"{self.well_path}/{position_index}"
+
+    def image_array_path(self, position_index: int, level: int) -> str:
+        return f"{self.field_group_path(position_index)}/{level}"
+
+    def metadata_blob_path(self, artifact_id: str) -> str:
+        try:
+            return self.metadata_blob_names[artifact_id]
+        except KeyError as exc:
+            raise ValueError(f"Unknown metadata blob {artifact_id!r}.") from exc
+
+    def resolve(self, ref: ArtifactRef) -> str:
+        if ref.kind == "image_collection":
+            if not ref.artifact_id.startswith("field:"):
+                raise ValueError(f"Unsupported image collection ref {ref.artifact_id!r}.")
+            return self.field_group_path(int(ref.artifact_id.split(":", maxsplit=1)[1]))
+        if ref.kind == "metadata_blob":
+            return self.metadata_blob_path(ref.artifact_id)
+        if ref.kind in {"label_collection", "table"}:
+            raise NotImplementedError(
+                f"Artifact kind {ref.kind!r} is reserved but not materialized by "
+                "Navigate acquisition."
+            )
+        raise ValueError(f"Unknown artifact kind {ref.kind!r}.")
+
+    def absolute_path(self, relative_path: str) -> Path:
+        return self.root_path / relative_path
+
+    @classmethod
+    def metadata_blob_refs(cls) -> tuple[ArtifactRef, ...]:
+        return tuple(
+            ArtifactRef(kind="metadata_blob", artifact_id=artifact_id)
+            for artifact_id in cls.metadata_blob_names
+        )
+
+    def image_collection_refs(self, positions: Iterable[int]) -> list[ArtifactRef]:
+        return [
+            ArtifactRef(kind="image_collection", artifact_id=f"field:{position}")
+            for position in sorted(set(positions))
+        ]
+
+    def artifact_manifest(self, positions: Iterable[int]) -> dict:
+        refs = self.image_collection_refs(positions) + list(self.metadata_blob_refs())
+        return {
+            "artifacts": [
+                {
+                    "kind": ref.kind,
+                    "artifact_id": ref.artifact_id,
+                    "path": self.resolve(ref),
+                }
+                for ref in refs
+            ]
+        }

--- a/src/navigate/model/data_sources/zarr_data_source.py
+++ b/src/navigate/model/data_sources/zarr_data_source.py
@@ -1,197 +1,222 @@
 # Copyright (c) 2021-2026  The University of Texas Southwestern Medical Center.
 # All rights reserved.
-from typing import Optional, Dict, Any
 
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted for academic and research use only
-# (subject to the limitations in the disclaimer below)
-# provided that the following conditions are met:
+from __future__ import annotations
 
-#      * Redistributions of source code must retain the above copyright notice,
-#      this list of conditions and the following disclaimer.
+from typing import Any, Dict, Optional
 
-#      * Redistributions in binary form must reproduce the above copyright
-#      notice, this list of conditions and the following disclaimer in the
-#      documentation and/or other materials provided with the distribution.
-
-#      * Neither the name of the copyright holders nor the names of its
-#      contributors may be used to endorse or promote products derived from this
-#      software without specific prior written permission.
-
-# NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE GRANTED BY
-# THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
-# CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-# PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
-# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
-# BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
-# IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-# POSSIBILITY OF SUCH DAMAGE.
-
-# Standard library imports
-
-# Third-party imports
-import zarr
+import numpy as np
 import numpy.typing as npt
-import zarr.storage
+import zarr
 
-# Local application imports
+from .ome_zarr_writer import OMEZarrV3StoreWriter
 from .pyramidal_data_source import PyramidalDataSource
+from .storage_adapter import OMEZarrStorageAdapter
 from ..metadata_sources.zarr_metadata import OMEZarrMetadata
-
-GROUP_PREFIX = "p"
 
 
 class OMEZarrDataSource(PyramidalDataSource):
-    """OME-Zarr data source.
+    """OME-Zarr data source backed by a Zarr v3 single-well HCS layout."""
 
-    This class implements an OME-Zarr image data source using the Zarr v2 format.
-    """
+    default_chunk_shape = (1, 1, 8, 256, 256)
+    default_shard_shape = (1, 1, 32, 256, 256)
+    default_scale_factors = (1, 2, 4, 8, 16)
 
     def __init__(self, file_name: str = None, mode: str = "w") -> None:
-        """Initialize the OME-Zarr data source.
-
-        Parameters
-        ----------
-        file_name : str
-            Name of the file to open.
-        mode : str
-            Mode to open the file in.
-        """
-
-        #: OMEZarrMetadata: Metadata object for the OME-Zarr data source.
         self.metadata = OMEZarrMetadata()
-        self.__store = None
-        self._current_position = -1
+        self.image = None
+        self._writer: Optional[OMEZarrV3StoreWriter] = None
+        self._adapter = OMEZarrStorageAdapter(file_name or "")
+        self.chunk_shape = self.default_chunk_shape
+        self.shard_shape = self.default_shard_shape
+        self.scale_factors = self.default_scale_factors
 
         super().__init__(file_name=file_name, mode=mode)
 
-    def get_slice(self, x, y, c, z=0, t=0, p=0, subdiv=0) -> npt.ArrayLike:
-        """Get a 3D slice of the dataset for a single c, t, p, subdiv.
+    @property
+    def artifact_refs(self):
+        return self._adapter.artifact_manifest(range(self.positions))
 
-        Parameters
-        ----------
-        x : int or slice
-            x indices to grab
-        y : int or slice
-            y indices to grab
-        c : int
-            Single channel
-        z : int or slice
-            z indices to grab
-        t : int
-            Single timepoint
-        p : int
-            Single position
-        subdiv : int
-            Subdivision of the dataset to index along
-
-        Returns
-        -------
-        npt.ArrayLike
-            3D (z, y, x) slice of data set
-        """
-        dataset_name = f"{GROUP_PREFIX}{p}_{subdiv}"
-        return self.image[dataset_name][t, c, z, y, x]
-
-    def setup(self):
-        """Set up the Zarr writer."""
-        # Use FSStore as a universal backend
-        self.__store = zarr.storage.FSStore(self.file_name, mode=self.mode)
-
-        #: zarr.group: Zarr group object for the image data source.
-        self.image = zarr.group(store=self.__store, overwrite=True)
-        self._current_position = -1
-
-    def new_position(self, pos, view):
-        """Create new arrays on the fly for each position in self.positions.
-
-        Parameters
-        ----------
-        pos : int
-            Position index
-        view : str
-            View name
-        """
-        name = f"{GROUP_PREFIX}{pos}"
-        paths = []
-        # Create the subdivisions...
-        for si, zyx_shape in enumerate(self.shapes):
-            shape = tuple([self.shape_t, self.shape_c] + list(zyx_shape))
-            setup = f"{name}_{si}"
-            arr = self.image.create(
-                name=setup,
-                shape=shape,
-                chunks=(1,) * len(shape[:-2]) + shape[-2:],
-                dtype=self.dtype,
-            )
-            # xarray multidim
-            paths.append(arr.path)
-            arr.attrs["_ARRAY_DIMENSIONS"] = shape
-
-        # Append setup to multiscales
-        scales = self.image.attrs.get("multiscales", [])
-        scales.append(
-            self.metadata.multiscales_dict(name, paths, self.resolutions, view)
+    def setup(self) -> None:
+        self._adapter = OMEZarrStorageAdapter(self.file_name)
+        self._writer = OMEZarrV3StoreWriter(
+            file_name=self.file_name,
+            metadata=self.metadata,
+            dtype=self.dtype,
+            chunk_shape=self.chunk_shape,
+            shard_shape=self.shard_shape,
+            scale_factors=self.scale_factors,
         )
-        self.image.attrs["multiscales"] = scales
+        self._writer.setup()
+        self.image = self._writer.image
+
+    def set_metadata_from_configuration_experiment(
+        self, configuration: Dict[str, Any], microscope_name: str = None
+    ) -> None:
+        super().set_metadata_from_configuration_experiment(configuration, microscope_name)
+        self._apply_storage_parameters(configuration)
+
+    def set_metadata(self, metadata_config: dict) -> None:
+        super().set_metadata(metadata_config)
+        self._apply_storage_parameters(self.metadata.configuration)
+
+    def _apply_storage_parameters(self, configuration: Optional[Dict[str, Any]]) -> None:
+        experiment = configuration.get("experiment", {}) if configuration else {}
+        params = experiment.get("OMEZarrParameters", {})
+        if params is None:
+            params = {}
+
+        self.chunk_shape = self._normalize_axis_shape(
+            params.get("chunk_shape", self.default_chunk_shape),
+            self.default_chunk_shape,
+        )
+        self.shard_shape = self._normalize_axis_shape(
+            params.get("shard_shape", self.default_shard_shape),
+            self.default_shard_shape,
+        )
+
+        down_sample = params.get("down_sample", {})
+        if down_sample and down_sample.get("enabled", False):
+            configured_scale_factors = tuple(
+                sorted(
+                    {
+                        max(int(factor), 1)
+                        for factor in down_sample.get(
+                            "scale_factors", self.default_scale_factors[1:]
+                        )
+                    }
+                )
+            )
+            self.scale_factors = (1,) + tuple(
+                factor for factor in configured_scale_factors if factor > 1
+            )
+        else:
+            self.scale_factors = (1,)
+
+        if self._writer is not None:
+            self._writer.chunk_shape = self.chunk_shape
+            self._writer.shard_shape = self.shard_shape
+            self._writer.scale_factors = self.scale_factors
+
+    @staticmethod
+    def _normalize_axis_shape(
+        value: Any, fallback: tuple[int, int, int, int, int]
+    ) -> tuple[int, int, int, int, int]:
+        try:
+            normalized = tuple(max(int(axis), 1) for axis in list(value))
+        except (TypeError, ValueError):
+            return fallback
+        if len(normalized) != len(fallback):
+            return fallback
+        return normalized
+
+    def get_slice(self, x, y, c, z=0, t=0, p=0, subdiv=0) -> npt.ArrayLike:
+        field_group = self.image[self._adapter.field_group_path(int(p))]
+        level_name = str(int(subdiv))
+        return field_group[level_name][t, c, z, y, x]
 
     def write(self, data: npt.ArrayLike, **kw) -> None:
-        """Writes 2D image to the data source.
-
-        Parameters
-        ----------
-        data : npt.ArrayLike
-            2D image data
-        kw : dict
-            Keyword arguments
-        """
-        #: str: Mode of the data source.
         self.mode = "w"
 
-        if self.__store is None:
+        if self._writer is None:
             self.setup()
 
-        c, z, t, p = self._cztp_indices(
+        c_index, z_index, t_index, p_index = self._cztp_indices(
             self._current_frame, self.metadata.per_stack
-        )  # find current channel
-
-        if self._current_position != p:
-            self._current_position = p
-            if len(kw) > 0:
-                self.new_position(p, kw)
-            else:
-                self.new_position(p)
-
-        # TODO: Make sure this also functions.
-        for ri, res in enumerate(self.resolutions):
-            dx, dy, dz = res
-            dataset_name = f"{GROUP_PREFIX}{p}_{ri}"
-            zs = min(z // dz, self.shapes[ri, 0] - 1)
-            self.image[dataset_name][t, c, zs, ...] = data[::dy, ::dx].astype(
-                self.dtype
-            )
-
+        )
+        view = kw if kw else None
+        self._writer.write_plane(
+            position_index=p_index,
+            time_index=t_index,
+            channel_index=c_index,
+            z_index=z_index,
+            data=data,
+            view=view,
+        )
+        self.image = self._writer.image
         self._current_frame += 1
 
     def read(self) -> None:
-        """Reads data from the image file."""
         self.mode = "r"
-        self.__store = zarr.storage.FSStore(self.file_name, mode=self.mode)
-        self.image = zarr.group(store=self.__store)
-        # TODO: parse the image metadata
-        self.get_shape_from_metadata()
+        self._adapter = OMEZarrStorageAdapter(self.file_name)
+        self.image = zarr.open_group(self.file_name, mode="r")
+        well_group = self.image[self._adapter.well_path]
+        field_names = sorted(name for name in list(well_group.keys()) if name.isdigit())
+        if not field_names:
+            return
+
+        first_field = well_group[field_names[0]]
+        level0 = first_field["0"]
+        self.shape_t, self.shape_c, self.shape_z, self.shape_y, self.shape_x = (
+            int(axis) for axis in level0.shape
+        )
+        self.positions = len(field_names)
+
+        multiscales = first_field.attrs.get("ome", {}).get("multiscales", [])
+        if multiscales:
+            datasets = multiscales[0].get("datasets", [])
+            resolutions = [[1, 1, 1]]
+            for dataset in datasets[1:]:
+                transforms = dataset.get("coordinateTransformations", [])
+                scale = next(
+                    (
+                        transform.get("scale")
+                        for transform in transforms
+                        if transform.get("type") == "scale"
+                    ),
+                    None,
+                )
+                if scale is None:
+                    continue
+                resolutions.append(
+                    [
+                        max(int(round(scale[4] / self.dx)), 1),
+                        max(int(round(scale[3] / self.dy)), 1),
+                        max(int(round(scale[2] / self.dz)), 1),
+                    ]
+                )
+            self._resolutions = np.array(resolutions, dtype=int)
+
+    def get_data(
+        self,
+        timepoint: int = 0,
+        position: int = 0,
+        channel: int = 0,
+        z: int = -1,
+        resolution: int = 1,
+    ) -> npt.ArrayLike:
+        level_index = 0
+        if resolution > 1:
+            if resolution in self.scale_factors:
+                level_index = self.scale_factors.index(resolution)
+            else:
+                level_index = min(len(self.scale_factors) - 1, int(resolution))
+
+        field_group = self.image[self._adapter.field_group_path(position)]
+        level = field_group[str(level_index)]
+        if z < 0:
+            return level[timepoint, channel]
+        return level[timepoint, channel, z]
 
     def close(self) -> None:
-        """Close the image file."""
         if self._closed:
-            if self.__store is not None:
-                self.__store = None
+            self._writer = None
+            self.image = None
             return
-        self._check_shape(self._current_frame - 1, self.metadata.per_stack)
-        self.__store.close()
-        self._closed = True
-        self.__store = None
+
+        try:
+            if self.mode == "w" and self._writer is not None:
+                self._check_shape(self._current_frame - 1, self.metadata.per_stack)
+                self._writer.finalize(
+                    shape_t=self.shape_t,
+                    shape_c=self.shape_c,
+                    shape_z=self.shape_z,
+                    positions=self.positions,
+                )
+                self.image = self._writer.image
+        finally:
+            if self._writer is not None:
+                self._writer.close()
+            self._writer = None
+            self.image = None
+            self._closed = True

--- a/src/navigate/model/features/image_writer.py
+++ b/src/navigate/model/features/image_writer.py
@@ -41,7 +41,7 @@ from datetime import datetime
 
 # Third Party Imports
 import numpy as np
-from tifffile import imsave
+from tifffile import imwrite
 
 # Local imports
 import navigate
@@ -293,7 +293,7 @@ class ImageWriter:
             else:
                 mip_8bit = np.zeros_like(mip, dtype=np.uint8)
 
-            imsave(
+            imwrite(
                 os.path.join(self.mip_directory, mip_name),
                 mip_8bit,
             )
@@ -394,11 +394,14 @@ class ImageWriter:
         self.file_type = self.model.configuration["experiment"]["Saving"]["file_type"]
         logger.info(f"Saving Data as File Type: {self.file_type}")
 
-        current_channel = self.model.active_microscope.current_channel
-        ext = "." + self.file_type.lower().replace(" ", ".").replace("-", ".")
-        if image_name is None:
-            image_name = self.generate_image_name(current_channel, ext=ext)
-        file_name = os.path.join(self.save_directory, image_name)
+        if self.file_type == "OME-Zarr":
+            file_name = os.path.join(self.save_directory, "data_store.ome.zarr")
+        else:
+            current_channel = self.model.active_microscope.current_channel
+            ext = "." + self.file_type.lower().replace(" ", ".").replace("-", ".")
+            if image_name is None:
+                image_name = self.generate_image_name(current_channel, ext=ext)
+            file_name = os.path.join(self.save_directory, image_name)
 
         return file_name
 

--- a/src/navigate/model/features/volume_search.py
+++ b/src/navigate/model/features/volume_search.py
@@ -459,7 +459,7 @@ class VolumeSearch:
             if self.debug:
                 import tifffile
 
-                tifffile.imsave(
+                tifffile.imwrite(
                     "volume_search_2d_debug_result.tif", self.volumes_selected
                 )
         return self.end_flag
@@ -628,9 +628,6 @@ class VolumeSearch3D:
                             f"configuration.yaml file!"
                         )
 
-        current_pixel_size = self.model.configuration["configuration"]["microscopes"][
-            current_microscope_name
-        ]["zoom"]["pixel_size"][current_zoom_value]
         current_image_width = self.model.configuration["experiment"][
             "CameraParameters"
         ][current_microscope_name]["img_x_pixels"]

--- a/src/navigate/model/metadata_sources/zarr_metadata.py
+++ b/src/navigate/model/metadata_sources/zarr_metadata.py
@@ -1,230 +1,249 @@
 # Copyright (c) 2021-2026  The University of Texas Southwestern Medical Center.
 # All rights reserved.
 
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted for academic and research use only
-# (subject to the limitations in the disclaimer below)
-# provided that the following conditions are met:
+from __future__ import annotations
 
-#      * Redistributions of source code must retain the above copyright notice,
-#      this list of conditions and the following disclaimer.
-
-#      * Redistributions in binary form must reproduce the above copyright
-#      notice, this list of conditions and the following disclaimer in the
-#      documentation and/or other materials provided with the distribution.
-
-#      * Neither the name of the copyright holders nor the names of its
-#      contributors may be used to endorse or promote products derived from this
-#      software without specific prior written permission.
-
-# NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE GRANTED BY
-# THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
-# CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-# PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
-# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
-# BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
-# IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-# POSSIBILITY OF SUCH DAMAGE.
-
-# Standard library imports
-from typing import Optional, Union, List, Dict
 import logging
+from typing import Dict, Iterable, List, Optional, Union
 
-# Third-party imports
 import numpy.typing as npt
+from ome_zarr_models.v05.coordinate_transformations import (
+    VectorScale,
+    VectorTranslation,
+)
+from ome_zarr_models.v05.hcs import HCS, HCSAttrs, Well
+from ome_zarr_models.v05.image import Axis, Dataset, Image, ImageAttrs, Multiscale
+from ome_zarr_models.v05.image_label import ImageLabelAttrs
+from ome_zarr_models.v05.image_label_types import Label
+from ome_zarr_models.v05.labels import LabelsAttrs
+from ome_zarr_models.v05.plate import Column, Plate, Row, WellInPlate
+from ome_zarr_models.v05.well import WellAttrs
+from ome_zarr_models.v05.well_types import WellImage, WellMeta
 
-# Local application imports
+from navigate import __commit__, __version__
+from navigate.tools import xml_tools
+
 from .metadata import Metadata
 
-NGFF_VERSION = "0.4"
+NGFF_VERSION = "0.5"
 
 p = __name__.split(".")[1]
 logger = logging.getLogger(p)
 
 
 class OMEZarrMetadata(Metadata):
-    """Class to generate OME-Zarr metadata."""
+    """Canonical OME-Zarr v0.5 metadata builder for Navigate."""
 
     @property
-    def _axes(self) -> Dict:
-        """Return tczyx axes in navigate units.
-
-        https://ngff.openmicroscopy.org/0.4/#axes-md
-
-        Returns
-        -------
-        List
-            A list of dictionaries containing the axis name, type, and unit.
-        """
-        axes = [
-            {"name": "t", "type": "time", "unit": "second"},
-            {"name": "c", "type": "channel"},
-            {"name": "z", "type": "space", "unit": "micrometer"},
-            {"name": "y", "type": "space", "unit": "micrometer"},
-            {"name": "x", "type": "space", "unit": "micrometer"},
+    def axes(self) -> List[Axis]:
+        return [
+            Axis(name="t", type="time", unit="second"),
+            Axis(name="c", type="channel"),
+            Axis(name="z", type="space", unit="micrometer"),
+            Axis(name="y", type="space", unit="micrometer"),
+            Axis(name="x", type="space", unit="micrometer"),
         ]
 
-        return axes
+    @property
+    def axes_names(self) -> tuple[str, ...]:
+        return tuple(axis.name for axis in self.axes)
 
     def _stage_positions_to_translation_transform(
         self, x: float, y: float, z: float, theta: float, f: Optional[float] = None
     ) -> List[float]:
-        """Grab the translation from the stage.
-
-        Ignore theta, focus for now.
-
-        Parameters
-        ----------
-        x : float
-            The x position of the stage (um).
-        y : float
-            The y position of the stage (um).
-        z : float
-            The z position of the stage (um).
-        theta : float
-            The theta position of the stage (deg).
-        f : float
-            The focus position of the stage (um).
-
-        Returns
-        -------
-        List
-            A translation for each axis.
-        """
-
-        # Set the transform positions
         xp, yp, zp = x, y, z
-
-        # Allow additional axes (e.g. f) to couple onto existing axes (e.g. z)
-        # if they are both moving along the same physical dimension
         if self._coupled_axes is not None:
             for leader, follower in self._coupled_axes.items():
                 if leader.lower() not in "xyz":
-                    print(
-                        f"Unrecognized coupled axis {leader}. "
-                        "Not gonna do anything with this."
-                    )
+                    logger.warning("Ignoring unsupported coupled axis %s.", leader)
                     continue
-                elif leader.lower() == "x":
-                    xp += float(locals()[f"{follower.lower()}"])
+                follower_value = float(locals().get(follower.lower(), 0.0) or 0.0)
+                if leader.lower() == "x":
+                    xp += follower_value
                 elif leader.lower() == "y":
-                    yp += float(locals()[f"{follower.lower()}"])
+                    yp += follower_value
                 elif leader.lower() == "z":
-                    zp += float(locals()[f"{follower.lower()}"])
-
-        # t, c, z, y, x
+                    zp += follower_value
         return [0.0, 0.0, zp, yp, xp]
 
-    def _scale_transform(
-        self, subdiv: Union[npt.ArrayLike, List] = [1, 1, 1]
-    ) -> List[float]:
-        """Calculate the image scale after subdivision.
-
-        Parameters
-        ----------
-        subdiv : List
-            The subdivision of the dataset.
-
-        Returns
-        -------
-        List
-            The scale of the dataset.
-        """
-        return [
-            1,  # t
-            1,  # c
-            self.dz * subdiv[2],
-            self.dy * subdiv[1],
-            self.dx * subdiv[0],
-        ]
+    def _scale_transform(self, scale_factor: Union[int, npt.ArrayLike, List]) -> List[float]:
+        if isinstance(scale_factor, int):
+            zx = float(scale_factor)
+            zy = float(scale_factor)
+            zz = float(scale_factor)
+        else:
+            values = list(scale_factor)
+            if len(values) != 3:
+                raise ValueError("Scale factor must contain exactly 3 spatial values.")
+            zx, zy, zz = map(float, values)
+        return [1.0, 1.0, self.dz * zz, self.dy * zy, self.dx * zx]
 
     def _coordinate_transformations(
-        self, scale: Optional[List] = None, translation: Optional[List] = None
-    ) -> Dict:
-        """Package scale and translation in a dict.
+        self, scale: List[float], translation: Optional[List[float]] = None
+    ) -> list:
+        transformations = [VectorScale(type="scale", scale=scale)]
+        if translation is not None:
+            transformations.append(
+                VectorTranslation(type="translation", translation=translation)
+            )
+        return transformations
 
-        Parameters
-        ----------
-        scale : List
-            The scale of the dataset.
-        translation : List
-            The translation of the dataset.
+    def hcs_attributes(self, positions: int) -> dict:
+        plate = Plate(
+            rows=[Row(name="A")],
+            columns=[Column(name="1")],
+            wells=[WellInPlate(path="A/1", rowIndex=0, columnIndex=0)],
+            field_count=max(int(positions), 1),
+            version=NGFF_VERSION,
+        )
+        return {
+            "ome": HCSAttrs(version=NGFF_VERSION, plate=plate).model_dump(
+                mode="json", exclude_none=True
+            )
+        }
 
-        Returns
-        -------
-        Dict
-            A dictionary containing the transformation.
-        """
-        transformation = []
-        if (
-            scale is None
-            or not isinstance(scale, list)
-            or len(scale) != len(self._axes)
-        ):
-            if translation is not None:
-                logger.error("Translation cannot be provided without scale.")
-                raise UserWarning("Translation cannot be provided without scale.")
-            return transformation
-        else:
-            transformation.append({"type": "scale", "scale": scale})
+    def well_attributes(self, field_names: Iterable[str]) -> dict:
+        images = [WellImage(path=str(name)) for name in field_names]
+        return {
+            "ome": WellAttrs(
+                version=NGFF_VERSION,
+                well=WellMeta(images=images, version=NGFF_VERSION),
+            ).model_dump(mode="json", exclude_none=True)
+        }
 
-        if (
-            translation is not None
-            and isinstance(translation, list)
-            and len(translation) == len(self._axes)
-        ):
-            transformation.append({"type": "translation", "translation": translation})
-
-        return transformation
-
-    def multiscales_dict(
+    def image_attributes(
         self,
         name: str,
-        paths: list,
-        resolutions: Union[npt.ArrayLike, List],
+        paths: list[str],
+        scale_factors: Union[npt.ArrayLike, List[int]],
         view: Optional[Dict] = None,
-    ) -> Dict:
-        """Create a multiscale dictionary for the OME-Zarr metadata.
-
-        https://ngff.openmicroscopy.org/0.4/index.html#multiscale-md
-
-        Parameters
-        ----------
-        name : str
-            The name of the dataset.
-        paths : list
-            The paths of the dataset.
-        resolutions : List
-            The resolutions of the dataset.
-        view : Dict
-            The view of the dataset.
-
-        Returns
-        -------
-        Dict
-            A dictionary containing the multiscale metadata.
-        """
-        d = {"version": NGFF_VERSION, "name": name, "axes": self._axes}
-
+    ) -> dict:
         datasets = []
-        for path, res in zip(paths, resolutions):
-            scale = self._scale_transform(res)
-            dd = {
-                "path": path,
-                "coordinateTransformations": self._coordinate_transformations(scale),
-            }
-            datasets.append(dd)
-        d["datasets"] = datasets
+        for path, factor in zip(paths, scale_factors):
+            scale = self._scale_transform(factor)
+            datasets.append(
+                Dataset(
+                    path=path,
+                    coordinateTransformations=self._coordinate_transformations(scale),
+                )
+            )
+        multiscale = Multiscale(
+            axes=self.axes,
+            datasets=tuple(datasets),
+            name=name,
+            coordinateTransformations=(
+                None
+                if view is None
+                else tuple(
+                    self._coordinate_transformations(
+                        [1.0] * len(self.axes),
+                        self._stage_positions_to_translation_transform(**view),
+                    )
+                )
+            ),
+            metadata={"method": "subsample"},
+            type="subsample",
+        )
+        return {
+            "ome": ImageAttrs(version=NGFF_VERSION, multiscales=[multiscale]).model_dump(
+                mode="json", exclude_none=True
+            )
+        }
 
-        if view is not None:
-            scale = [1.0] * len(self._axes)
-            translation = self._stage_positions_to_translation_transform(**view)
-            d["coordinateTransformations"] = self._coordinate_transformations(
-                scale, translation
+    def labels_attributes(self, label_paths: list[str]) -> dict:
+        return {
+            "ome": LabelsAttrs(version=NGFF_VERSION, labels=label_paths).model_dump(
+                mode="json", exclude_none=True
+            )
+        }
+
+    def image_label_attributes(
+        self, label_name: str, multiscale_paths: list[str], scale_factors: list[int]
+    ) -> dict:
+        datasets = []
+        for path, factor in zip(multiscale_paths, scale_factors):
+            datasets.append(
+                Dataset(
+                    path=path,
+                    coordinateTransformations=self._coordinate_transformations(
+                        self._scale_transform(factor)
+                    ),
+                )
+            )
+        multiscale = Multiscale(
+            axes=self.axes,
+            datasets=tuple(datasets),
+            name=label_name,
+            metadata={"method": "subsample"},
+            type="subsample",
+        )
+        return {
+            "ome": ImageLabelAttrs(
+                version=NGFF_VERSION,
+                image_label=Label(
+                    source={"image": "../../../0"},
+                    properties={"name": label_name},
+                ),
+                multiscales=[multiscale],
+            ).model_dump(mode="json", exclude_none=True)
+        }
+
+    def validate_hcs_group(self, group) -> HCS:
+        return HCS.from_zarr(group)
+
+    def validate_well_group(self, group) -> Well:
+        return Well.from_zarr(group)
+
+    def validate_image_group(self, group) -> Image:
+        return Image.from_zarr(group)
+
+    def metadata_only_xml(self, field_names: list[str]) -> str:
+        channels = [
+            {"ID": f"Channel:0:{idx}", "SamplesPerPixel": "1", "LightPath": {}}
+            for idx in range(self.shape_c)
+        ]
+        images = []
+        for idx, field_name in enumerate(field_names):
+            images.append(
+                {
+                    "ID": f"Image:{idx}",
+                    "Name": field_name,
+                    "Pixels": {
+                        "ID": f"Pixels:{idx}",
+                        "BigEndian": "false",
+                        "Interleaved": "false",
+                        "Type": str(self.dtype if hasattr(self, "dtype") else "uint16"),
+                        "SizeX": self.shape_x,
+                        "SizeY": self.shape_y,
+                        "SizeZ": self.shape_z,
+                        "SizeC": self.shape_c,
+                        "SizeT": self.shape_t,
+                        "DimensionOrder": "XYZCT",
+                        "PhysicalSizeX": self.dx,
+                        "PhysicalSizeY": self.dy,
+                        "PhysicalSizeZ": self.dz,
+                        "TimeIncrement": self.dt,
+                        "Channel": channels,
+                        "MetadataOnly": {},
+                    },
+                }
             )
 
-        return d
+        ome_dict = {
+            "Creator": f"Navigate,v{__version__}, Commit {__commit__}, Dean Lab at UTSW",
+            "xmlns": "http://www.openmicroscopy.org/Schemas/OME/2016-06",
+            "xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
+            "xsi:schemaLocation": "http://www.openmicroscopy.org/Schemas/OME/2016-06 "
+            "https://www.openmicroscopy.org/Schemas/OME/2016-06/ome.xsd",
+            "Image": images,
+            "StructuredAnnotations": {
+                "ListAnnotation": {
+                    "ID": "Annotation:misc",
+                    "Description": {"text": self.misc},
+                }
+            },
+        }
+        xml = '<?xml version="1.0" encoding="UTF-8"?>\n'
+        xml += f"<!-- Created by Navigate, v{__version__}, Commit {__commit__} -->\n"
+        xml += xml_tools.dict_to_xml(ome_dict, "OME")
+        return xml

--- a/src/navigate/view/popups/acquire_popup.py
+++ b/src/navigate/view/popups/acquire_popup.py
@@ -318,7 +318,7 @@ class EntryFrame:
                 )
                 parent.inputs[entry_names[i]].widget.state(["!disabled", "readonly"])
                 parent.inputs[entry_names[i]].set_values(tuple(FILE_TYPES))
-                parent.inputs[entry_names[i]].set("TIFF")
+                parent.inputs[entry_names[i]].set("OME-Zarr")
 
             elif entry_names[i] == "solvent":
                 parent.inputs[entry_names[i]] = LabelInput(
@@ -382,7 +382,7 @@ class TabFrame:
         tab2.columnconfigure(index=2, weight=1)
 
         notebook.add(tab1, text="Misc. Notes")
-        notebook.add(tab2, text="BDV Settings")
+        notebook.add(tab2, text="OME-Zarr Settings")
 
         row_index = 0
 
@@ -440,9 +440,8 @@ class TabFrame:
 
         row_index = 0
         text = (
-            "HDF5, N5, and Zarr files are saved with BDV metadata, "
-            "enabling immediate visualization with BigDataViewer. "
-            "All angles are in degrees."
+            "OME-Zarr data are saved as a single-well HCS plate with synthetic "
+            "well A/1 and one field per Navigate position. All angles are in degrees."
         )
 
         bdv_label = ttk.Label(

--- a/test/config/test_config.py
+++ b/test/config/test_config.py
@@ -424,7 +424,7 @@ class TestVerifyExperimentConfig(unittest.TestCase):
             "tissue": "Lung",
             "celltype": "MV3",
             "label": "GFP",
-            "file_type": "TIFF",
+            "file_type": "OME-Zarr",
             "date": time.strftime("%Y-%m-%d"),
             "solvent": "BABB",
         }

--- a/test/controller/sub_controllers/test_acquire_bar.py
+++ b/test/controller/sub_controllers/test_acquire_bar.py
@@ -468,10 +468,10 @@ class TestAcquireBarController:
                             == file
                         )
                     # Resetting file type back to orginal
-                    widgets["file_type"].set("TIFF")
+                    widgets["file_type"].set("OME-Zarr")
                     assert (
                         self.acquire_bar_controller.saving_settings["file_type"]
-                        == "TIFF"
+                        == "OME-Zarr"
                     )
 
                 # Check that loop thru saving settings is correct

--- a/test/model/data_sources/test_storage_adapter.py
+++ b/test/model/data_sources/test_storage_adapter.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+
+import pytest
+
+from navigate.model.data_sources.storage_adapter import (
+    ArtifactRef,
+    OMEZarrStorageAdapter,
+)
+
+
+def test_storage_adapter_resolves_artifacts():
+    adapter = OMEZarrStorageAdapter("data_store.ome.zarr")
+
+    assert adapter.resolve(ArtifactRef("image_collection", "field:2")) == "A/1/2"
+    assert adapter.resolve(ArtifactRef("metadata_blob", "artifacts")) == (
+        "navigate/metadata/artifacts.json"
+    )
+    assert adapter.absolute_path("A/1/0") == Path("data_store.ome.zarr") / "A/1/0"
+
+
+def test_storage_adapter_reserved_artifacts_raise():
+    adapter = OMEZarrStorageAdapter("data_store.ome.zarr")
+
+    with pytest.raises(NotImplementedError):
+        adapter.resolve(ArtifactRef("label_collection", "segmentation"))
+
+    with pytest.raises(NotImplementedError):
+        adapter.resolve(ArtifactRef("table", "measurements"))
+
+
+def test_storage_adapter_manifest():
+    adapter = OMEZarrStorageAdapter("data_store.ome.zarr")
+
+    manifest = adapter.artifact_manifest([0, 1])
+    manifest_paths = {
+        (artifact["kind"], artifact["artifact_id"]): artifact["path"]
+        for artifact in manifest["artifacts"]
+    }
+
+    assert manifest_paths[("image_collection", "field:0")] == "A/1/0"
+    assert manifest_paths[("image_collection", "field:1")] == "A/1/1"
+    assert manifest_paths[("metadata_blob", "artifacts")] == (
+        "navigate/metadata/artifacts.json"
+    )

--- a/test/model/data_sources/test_zarr_data_source.py
+++ b/test/model/data_sources/test_zarr_data_source.py
@@ -1,15 +1,13 @@
+import json
 import os
+from pathlib import Path
 
-import pytest
 import numpy as np
-
-try:
-    from pydantic import ValidationError
-    from pydantic_ome_ngff.v04.multiscale import Group
-
-    pydantic = True
-except (ImportError, TypeError):
-    pydantic = False
+import pytest
+import zarr
+from ome_zarr_models.v05.hcs import HCS
+from ome_zarr_models.v05.image import Image
+from ome_zarr_models.v05.well import Well
 
 from navigate.tools.file_functions import delete_folder
 
@@ -50,7 +48,7 @@ def zarr_ds(fn, multiposition, per_stack, z_stack, stop_early, size):
     ] = multiposition
     model.configuration["experiment"]["MicroscopeState"]["timepoints"] = timepoints
 
-    model.configuration["experiment"]["BDVParameters"] = {
+    model.configuration["experiment"]["OMEZarrParameters"] = {
         "shear": {
             "shear_data": True,
             "shear_dimension": "YZ",
@@ -63,10 +61,12 @@ def zarr_ds(fn, multiposition, per_stack, z_stack, stop_early, size):
             "Z": 0,
         },
         "down_sample": {
-            "down_sample": False,
-            "axial_down_sample": 1,
-            "lateral_down_sample": 1,
+            "enabled": True,
+            "scale_factors": [2, 4],
         },
+        "chunk_shape": [1, 1, 8, 256, 256],
+        "shard_shape": [1, 1, 32, 256, 256],
+        "compression": "zstd-bitshuffle-fast",
     }
 
     if per_stack:
@@ -103,7 +103,7 @@ def zarr_ds(fn, multiposition, per_stack, z_stack, stop_early, size):
             theta=data_positions[i, 3],
             f=data_positions[i, 4],
         )
-        if stop_early and np.random.rand() > 0.5:
+        if stop_early and i >= max(1, n_images // 3):
             break
 
     return ds
@@ -127,6 +127,63 @@ def close_zarr_ds(ds, file_name=None):
         pass
 
 
+def assert_hcs_store(ds):
+    store_path = Path(ds.file_name)
+    root = zarr.open_group(store_path, mode="r")
+    HCS.from_zarr(root)
+
+    well_group = root["A/1"]
+    Well.from_zarr(well_group)
+
+    field_names = sorted(name for name in list(well_group.keys()) if name.isdigit())
+    assert field_names == [str(position) for position in range(ds.positions)]
+
+    for field_name in field_names:
+        field_group = well_group[field_name]
+        Image.from_zarr(field_group)
+        level0 = field_group["0"]
+        assert level0.shape == (
+            ds.shape_t,
+            ds.shape_c,
+            ds.shape_z,
+            ds.shape_y,
+            ds.shape_x,
+        )
+        if len(ds.scale_factors) > 1:
+            for level_index in range(1, len(ds.scale_factors)):
+                assert str(level_index) in field_group
+
+    artifacts_path = store_path / "navigate" / "metadata" / "artifacts.json"
+    acquisition_path = store_path / "navigate" / "metadata" / "acquisition.json"
+    configuration_path = store_path / "navigate" / "metadata" / "configuration.json"
+    metadata_xml_path = store_path / "OME" / "METADATA.ome.xml"
+
+    assert artifacts_path.exists()
+    assert acquisition_path.exists()
+    assert configuration_path.exists()
+    assert metadata_xml_path.exists()
+
+    with open(artifacts_path, encoding="utf-8") as handle:
+        artifact_manifest = json.load(handle)
+    with open(acquisition_path, encoding="utf-8") as handle:
+        acquisition = json.load(handle)
+    with open(configuration_path, encoding="utf-8") as handle:
+        configuration = json.load(handle)
+
+    manifest_paths = {
+        (artifact["kind"], artifact["artifact_id"]): artifact["path"]
+        for artifact in artifact_manifest["artifacts"]
+    }
+    assert manifest_paths[("metadata_blob", "artifacts")] == (
+        "navigate/metadata/artifacts.json"
+    )
+    for position in range(ds.positions):
+        assert manifest_paths[("image_collection", f"field:{position}")] == f"A/1/{position}"
+
+    assert acquisition["field_names"] == field_names
+    assert "microscopes" in configuration
+
+
 @pytest.mark.parametrize("multiposition", [True, False])
 @pytest.mark.parametrize("per_stack", [True, False])
 @pytest.mark.parametrize("z_stack", [True, False])
@@ -137,15 +194,9 @@ def test_zarr_write(multiposition, per_stack, z_stack, stop_early, size):
     fn = "test.zarr"
 
     ds = zarr_ds(fn, multiposition, per_stack, z_stack, stop_early, size)
-
-    if pydantic:
-        try:
-            Group.from_zarr(ds.image)
-        except ValidationError as e:
-            print(e)
-            assert False
-
     file_name = ds.file_name
+    ds.close()
+    assert_hcs_store(ds)
 
     close_zarr_ds(ds, file_name=file_name)
 

--- a/test/model/metadata_sources/test_zarr_metadata.py
+++ b/test/model/metadata_sources/test_zarr_metadata.py
@@ -1,189 +1,96 @@
 import pytest
 
-SPACE_UNITS = [
-    "angstrom",
-    "attometer",
-    "centimeter",
-    "decimeter",
-    "exameter",
-    "femtometer",
-    "foot",
-    "gigameter",
-    "hectometer",
-    "inch",
-    "kilometer",
-    "megameter",
-    "meter",
-    "micrometer",
-    "mile",
-    "millimeter",
-    "nanometer",
-    "parsec",
-    "petameter",
-    "picometer",
-    "terameter",
-    "yard",
-    "yoctometer",
-    "yottameter",
-    "zeptometer",
-    "zettameter",
-]
-
-TIME_UNITS = [
-    "attosecond",
-    "centisecond",
-    "day",
-    "decisecond",
-    "exasecond",
-    "femtosecond",
-    "gigasecond",
-    "hectosecond",
-    "hour",
-    "kilosecond",
-    "megasecond",
-    "microsecond",
-    "millisecond",
-    "minute",
-    "nanosecond",
-    "petasecond",
-    "picosecond",
-    "second",
-    "terasecond",
-    "yoctosecond",
-    "yottasecond",
-    "zeptosecond",
-    "zettasecond",
-]
-
 
 @pytest.fixture
 def dummy_metadata(dummy_model):
     from navigate.model.metadata_sources.zarr_metadata import OMEZarrMetadata
 
-    # Create metadata
-    md = OMEZarrMetadata()
-
-    md.configuration = dummy_model.configuration
-
-    return md
+    metadata = OMEZarrMetadata()
+    metadata.configuration = dummy_model.configuration
+    return metadata
 
 
 def test_axes(dummy_metadata):
+    axes = dummy_metadata.axes
 
-    axes = dummy_metadata._axes
-
-    # Check length
-    assert (len(axes) > 1) and (len(axes) < 6)
-
-    # Check list types and count
-    time_count = 0
-    space_count = 0
-    channel_count = 0
-    custom_count = 0
-    for d in axes:
-        if d["type"] == "time":
-            assert d["unit"] in TIME_UNITS
-            time_count += 1
-        elif d["type"] == "space":
-            assert d["unit"] in SPACE_UNITS
-            space_count += 1
-        elif d["type"] == "channel":
-            channel_count += 1
-        else:
-            custom_count += 1
-
-    assert (space_count > 1) and (space_count < 4)
-    assert time_count < 2
-    assert ((channel_count < 2) and (custom_count == 0)) or (
-        (channel_count == 0) and (custom_count < 2)
-    )
-
-    # Check order
-    order_type = [x["type"] for x in axes]
-    if "time" in order_type:
-        # Time must be first, if present
-        assert order_type.index("time") == 0
-    if "channel" in order_type:
-        # Channel must be before all the space axes, if present
-        ci = order_type.index("channel")
-        for i, el in enumerate(order_type):
-            if el == "space":
-                assert i > ci
-
-    # Skip zyx order spec as the naming of axes is not enforcable.
+    assert [axis.name for axis in axes] == ["t", "c", "z", "y", "x"]
+    assert axes[0].type == "time"
+    assert axes[0].unit == "second"
+    assert axes[1].type == "channel"
+    assert [axis.type for axis in axes[2:]] == ["space", "space", "space"]
+    assert all(axis.unit == "micrometer" for axis in axes[2:])
 
 
 def test_stage_positions_to_translation_transform(dummy_metadata):
-    import random
+    translation = dummy_metadata._stage_positions_to_translation_transform(
+        10.0, 20.0, 30.0, 40.0, 50.0
+    )
 
-    pos = [random.random() for _ in range(5)]
-
-    translation = dummy_metadata._stage_positions_to_translation_transform(*pos)
-
-    axes = dummy_metadata._axes
-
-    assert len(translation) == len(axes)
+    assert len(translation) == len(dummy_metadata.axes)
+    assert translation[:2] == [0.0, 0.0]
+    assert translation[2:] == [30.0, 20.0, 10.0]
 
 
 def test_scale_transform(dummy_metadata):
-    scale = dummy_metadata._scale_transform()
-
-    axes = dummy_metadata._axes
-
-    assert len(scale) == len(axes)
+    assert dummy_metadata._scale_transform(1) == [
+        1.0,
+        1.0,
+        dummy_metadata.dz,
+        dummy_metadata.dy,
+        dummy_metadata.dx,
+    ]
+    assert dummy_metadata._scale_transform(4) == [
+        1.0,
+        1.0,
+        dummy_metadata.dz * 4,
+        dummy_metadata.dy * 4,
+        dummy_metadata.dx * 4,
+    ]
 
 
 def test_coordinate_transformations(dummy_metadata):
-    import random
+    scale = dummy_metadata._scale_transform(2)
+    translation = dummy_metadata._stage_positions_to_translation_transform(
+        1.0, 2.0, 3.0, 4.0, 5.0
+    )
 
-    pos = [random.random() for _ in range(5)]
+    transforms = dummy_metadata._coordinate_transformations(scale)
+    assert len(transforms) == 1
+    assert transforms[0].type == "scale"
 
-    translation = dummy_metadata._stage_positions_to_translation_transform(*pos)
-    scale = dummy_metadata._scale_transform()
-
-    assert len(dummy_metadata._coordinate_transformations(scale)) == 1
-
-    combo = dummy_metadata._coordinate_transformations(scale, translation)
-    assert len(combo) == 2
-    assert combo[0]["type"] == "scale" and combo[1]["type"] == "translation"
-
-    with pytest.raises(UserWarning):
-        dummy_metadata._coordinate_transformations(translation=translation)
+    transforms = dummy_metadata._coordinate_transformations(scale, translation)
+    assert len(transforms) == 2
+    assert transforms[0].type == "scale"
+    assert transforms[1].type == "translation"
 
 
-def test_multiscale_metadata(dummy_metadata):
-    """https://ngff.openmicroscopy.org/0.4/#multiscale-md"""
-    import numpy as np
-    import random
+def test_ngff_attribute_builders(dummy_metadata):
+    hcs_attrs = dummy_metadata.hcs_attributes(positions=3)
+    assert hcs_attrs["ome"]["version"] == "0.5"
+    assert hcs_attrs["ome"]["plate"]["field_count"] == 3
+    assert hcs_attrs["ome"]["plate"]["wells"][0]["path"] == "A/1"
 
-    resolutions = np.array([[1, 1, 1], [2, 2, 1], [4, 4, 1], [8, 8, 1]], dtype=int)
-    paths = [f"path{i}" for i in range(resolutions.shape[0])]
-    view = {k: random.random() for k in ["x", "y", "z", "theta", "f"]}
+    well_attrs = dummy_metadata.well_attributes(["0", "1", "2"])
+    assert well_attrs["ome"]["well"]["images"] == [
+        {"path": "0"},
+        {"path": "1"},
+        {"path": "2"},
+    ]
 
-    msd = dummy_metadata.multiscales_dict("test", paths, resolutions, view)
+    image_attrs = dummy_metadata.image_attributes(
+        name="Field 0",
+        paths=["0", "1", "2"],
+        scale_factors=[1, 2, 4],
+        view={"x": 1.0, "y": 2.0, "z": 3.0, "theta": 4.0, "f": 5.0},
+    )
+    multiscale = image_attrs["ome"]["multiscales"][0]
+    assert multiscale["name"] == "Field 0"
+    assert [dataset["path"] for dataset in multiscale["datasets"]] == ["0", "1", "2"]
+    assert multiscale["axes"][0]["name"] == "t"
 
-    # Each "multiscales" dictionary MUST contain the field "axes"
-    assert "axes" in msd.keys()
+    labels_attrs = dummy_metadata.labels_attributes(["cells", "nuclei"])
+    assert labels_attrs["ome"]["labels"] == ["cells", "nuclei"]
 
-    # Each "multiscales" dictionary MUST contain the field "datasets"
-    assert "datasets" in msd.keys()
-    # Each dictionary in "datasets" MUST contain the field "path",
-    # whose value contains the path to the array for this resolution
-    # relative to the current zarr group. The "path"s MUST be ordered
-    # from largest (i.e. highest resolution) to smallest.
-    # Each "datasets" dictionary MUST have the same number of dimensions
-    # and MUST NOT have more than 5 dimensions.
-
-    # Each "multiscales" dictionary SHOULD contain the field "name"
-    assert "name" in msd.keys()
-
-    # Each "multiscales" dictionary MAY contain the field "coordinateTransformations"
-    assert "coordinateTransformations" in msd.keys()
-
-    # It SHOULD contain the field "version"
-    assert "version" in msd.keys()
-
-    # Each "multiscales" dictionary SHOULD contain the field "type", which gives
-    # the type of downscaling method used to generate the multiscale image pyramid.
-    # It SHOULD contain the field "metadata", which contains a dictionary with
-    # additional information about the downscaling method.
+    xml = dummy_metadata.metadata_only_xml(["0", "1"])
+    assert "Field 0" not in xml
+    assert "Image:0" in xml


### PR DESCRIPTION
Switch the primary save format to OME‑Zarr and add support for writing acquisitions in the canonical OME‑NGFF layout. Added an OMEZarrV3 writer and storage adapter (src/navigate/model/data_sources/ome_zarr_writer.py, storage_adapter.py), updated zarr data-source and pyramidal handling to honor OMEZarrParameters and legacy BDVParameters, and wired UI/config layers to expose OME‑Zarr settings (acquire_bar, config, example YAMLs). Documentation updated to recommend OME‑Zarr and describe the new layout, and pyproject dependencies/pyversions were bumped to require newer zarr and ome-zarr-models. Tests adjusted/added for the storage adapter and zarr metadata. Backwards compatibility: legacy BDVParameters are migrated to the new OMEZarrParameters where possible.