### PR TITLE
Getting Photometrics and ImagineOpticsMirror to work with multiple defined scopes in configuration.yaml

### DIFF
--- a/src/navigate/model/devices/camera/photometrics.py
+++ b/src/navigate/model/devices/camera/photometrics.py
@@ -42,6 +42,7 @@ from pyvcam.camera import Camera as PyvcamCamera
 
 # Local Imports
 from navigate.model.devices.camera.base import CameraBase
+from navigate.model.devices.device_types import IntegratedDevice
 from navigate.tools.decorators import log_initialization
 
 # Logger Setup
@@ -50,7 +51,7 @@ logger = logging.getLogger(p)
 
 
 @log_initialization
-class PhotometricsCamera(CameraBase):
+class PhotometricsCamera(CameraBase, IntegratedDevice):
     """Photometrics Base camera class.
 
     This class is the interface between the rest of the microscope code and the

--- a/src/navigate/model/devices/mirror/imop.py
+++ b/src/navigate/model/devices/mirror/imop.py
@@ -38,6 +38,7 @@ import logging
 
 # Local Imports
 from navigate.model.devices.mirror.base import MirrorBase
+from navigate.model.devices.device_types import IntegratedDevice
 from navigate.model.devices.APIs.imagineoptics.imop import IMOP_Mirror
 from navigate.tools.decorators import log_initialization
 
@@ -47,8 +48,30 @@ logger = logging.getLogger(p)
 
 
 @log_initialization
-class ImagineOpticsMirror(MirrorBase):
+class ImagineOpticsMirror(MirrorBase, IntegratedDevice):
     """ImageineOpticsMirror mirror class."""
+
+    @classmethod
+    def get_connect_params(cls) -> list[str]:
+        """No connection parameters needed - uses hardcoded file paths.
+        
+        Returns
+        -------
+        list
+            Empty list since no config parameters are needed.
+        """
+        return []
+
+    @classmethod
+    def connect(cls) -> IMOP_Mirror:
+        """Create and return IMOP_Mirror connection.
+        
+        Returns
+        -------
+        IMOP_Mirror
+            The mirror controller instance.
+        """
+        return IMOP_Mirror()
 
     def __init__(
         self, microscope_name, device_connection, configuration, *args, **kwargs
@@ -59,14 +82,15 @@ class ImagineOpticsMirror(MirrorBase):
         ----------
         microscope_name : str
             Name of the microscope.
-        device_connection : dict
-            Dictionary containing the device connection information.
+        device_connection : IMOP_Mirror
+            The cached IMOP_Mirror connection instance from the factory.
         configuration : dict
             Dictionary containing the configuration information.
         """
         super().__init__(microscope_name, device_connection, configuration)
 
-        self.mirror_controller = IMOP_Mirror()
+        # obj: mirror controller (IMOP_Mirror)
+        self.mirror_controller = device_connection
 
         flat_path = configuration["configuration"]["microscopes"][microscope_name][
             "mirror"

--- a/test/model/devices/mirror/test_mirror_imop.py
+++ b/test/model/devices/mirror/test_mirror_imop.py
@@ -117,7 +117,7 @@ def test_imop_constructor_initializes_controller_and_flattens(
 ):
     module, fake_class = imop_module
 
-    mirror = module.ImagineOpticsMirror("scope-a", None, mirror_configuration)
+    mirror = module.ImagineOpticsMirror("scope-a", fake_class(), mirror_configuration)
     controller = fake_class.instances[0]
 
     assert mirror.mirror_controller is controller
@@ -141,7 +141,7 @@ def test_imop_constructor_raises_for_unknown_microscope(
 
 def test_imop_forwarders_dispatch_to_controller(imop_module, mirror_configuration):
     module, fake_class = imop_module
-    mirror = module.ImagineOpticsMirror("scope-a", None, mirror_configuration)
+    mirror = module.ImagineOpticsMirror("scope-a", fake_class(), mirror_configuration)
     controller = fake_class.instances[0]
 
     controller.calls.clear()
@@ -164,7 +164,7 @@ def test_imop_forwarders_dispatch_to_controller(imop_module, mirror_configuratio
 
 def test_imop_wcs_load_and_save_forwarders(imop_module, mirror_configuration):
     module, fake_class = imop_module
-    mirror = module.ImagineOpticsMirror("scope-a", None, mirror_configuration)
+    mirror = module.ImagineOpticsMirror("scope-a", fake_class(), mirror_configuration)
     controller = fake_class.instances[0]
 
     controller.calls.clear()
@@ -191,8 +191,8 @@ def test_imop_wcs_load_and_save_forwarders(imop_module, mirror_configuration):
 
 
 def test_imop_destructor_is_error_tolerant_noop(imop_module, mirror_configuration):
-    module, _ = imop_module
-    mirror = module.ImagineOpticsMirror("scope-a", None, mirror_configuration)
+    module, fake_class = imop_module
+    mirror = module.ImagineOpticsMirror("scope-a", fake_class(), mirror_configuration)
 
     class ExplodingController:
         def __getattribute__(self, _name):


### PR DESCRIPTION
Previously, we could define multiple microscopes in config using an inheritance structure. At some point, the way devices are loaded was refactored to be more general, using DeviceFactories. Attempting to define multiple scopes, I ran into the Photometrics and Imagine Optics mirror device connections being initialized multiple times, running into such "device already open" errors.

I noticed that `PhotometricsCamera` and `ImagineOpticsMirror` both needed to be an `IntegratedDevice`, and the mirror in particular needed some `@classmethod`s for the connections to get cached properly. Now it seems to work with multiple scopes.


My config file which ended up working:
[configuration.yaml](https://github.com/user-attachments/files/26360247/configuration.yaml)
