### PR TITLE
Asi stage updates

### DIFF
--- a/src/navigate/model/devices/stage/asi.py
+++ b/src/navigate/model/devices/stage/asi.py
@@ -49,6 +49,9 @@ from navigate.tools.decorators import log_initialization
 p = __name__.split(".")[1]
 logger = logging.getLogger(p)
 
+THETA_RUN_SPEED_DEG_PER_SEC = 5.0
+THETA_MOVE_TIMEOUT_SECONDS = 120.0
+
 
 @log_initialization
 class ASIStage(StageBase, SerialDevice, IntegratedDevice):
@@ -153,6 +156,7 @@ class ASIStage(StageBase, SerialDevice, IntegratedDevice):
 
             # Speed optimizations - Set speed to 90% of maximum on each axis
             self.set_speed(percent=0.9)
+            self.set_theta_speed()
 
     def __del__(self) -> None:
         """Delete the ASI Stage connection."""
@@ -286,7 +290,7 @@ class ASIStage(StageBase, SerialDevice, IntegratedDevice):
             return False
 
         if wait_until_done:
-            self.asi_controller.wait_for_device()
+            return self._wait_for_move([axis])
         return True
 
     def verify_move(self, move_dictionary: dict[str, float]) -> dict[str, float]:
@@ -358,7 +362,7 @@ class ASIStage(StageBase, SerialDevice, IntegratedDevice):
             logger.exception("ASI Stage Exception", e)
             return False
         if wait_until_done:
-            self.asi_controller.wait_for_device()
+            return self._wait_for_move(list(abs_pos_dict.keys()))
 
         return True
 
@@ -402,6 +406,33 @@ class ASIStage(StageBase, SerialDevice, IntegratedDevice):
             except KeyError as e:
                 logger.exception(f"ASI Stage - KeyError in set_speed: {e}")
                 return False
+        return True
+
+    def set_theta_speed(self) -> bool:
+        """Set a conservative run speed for theta axes only."""
+        theta_axes = [
+            axis for axis, stage_axis in self.asi_axes.items() if stage_axis == "theta"
+        ]
+        if not theta_axes:
+            return True
+
+        try:
+            self.asi_controller.set_speed(
+                {axis: THETA_RUN_SPEED_DEG_PER_SEC for axis in theta_axes}
+            )
+        except ASIException as e:
+            print(f"ASI Controller failed to set theta speed: {e}")
+            logger.exception("ASI Stage Exception", e)
+            return False
+        return True
+
+    def _wait_for_move(self, axes: list[str]) -> bool:
+        """Wait for a move, using a longer axis-specific wait for theta."""
+        self.asi_controller.wait_for_device()
+        if "theta" in axes and "theta" in self.axes_mapping:
+            return self.wait_until_complete(
+                self.axes_mapping["theta"], timeout=THETA_MOVE_TIMEOUT_SECONDS
+            )
         return True
 
     def get_speed(self, axis: str) -> float:
@@ -542,9 +573,17 @@ class ASIStage(StageBase, SerialDevice, IntegratedDevice):
         except ASIException as e:
             logger.exception("ASI Stage Exception", e)
 
-    def wait_until_complete(self, axis: str) -> bool:
+    def wait_until_complete(self, axis: str, timeout: float = None) -> bool:
+        start_time = time.monotonic()
         try:
             while self.asi_controller.is_axis_busy(axis):
+                if timeout is not None and time.monotonic() - start_time >= timeout:
+                    logger.warning(
+                        "ASI Stage wait timed out for axis %s after %.1f seconds",
+                        axis,
+                        timeout,
+                    )
+                    return False
                 time.sleep(0.1)
         except ASIException as e:
             print(f"ASI Stage Exception {e}")

--- a/src/navigate/model/devices/stage/asi.py
+++ b/src/navigate/model/devices/stage/asi.py
@@ -32,7 +32,7 @@
 # Standard Imports
 import logging
 import time
-from typing import Any
+from typing import Any, Optional
 
 # Third Party Imports
 
@@ -422,7 +422,7 @@ class ASIStage(StageBase, SerialDevice, IntegratedDevice):
             )
         except ASIException as e:
             print(f"ASI Controller failed to set theta speed: {e}")
-            logger.exception("ASI Stage Exception", e)
+            logger.exception(f"ASI Stage Exception: {e}")
             return False
         return True
 
@@ -573,7 +573,7 @@ class ASIStage(StageBase, SerialDevice, IntegratedDevice):
         except ASIException as e:
             logger.exception("ASI Stage Exception", e)
 
-    def wait_until_complete(self, axis: str, timeout: float = None) -> bool:
+    def wait_until_complete(self, axis: str, timeout: Optional[float] = None) -> bool:
         start_time = time.monotonic()
         try:
             while self.asi_controller.is_axis_busy(axis):

--- a/src/navigate/model/features/common_features.py
+++ b/src/navigate/model/features/common_features.py
@@ -50,6 +50,20 @@ p = __name__.split(".")[1]
 logger = logging.getLogger(p)
 
 
+THETA_MOVE_EPSILON = 1e-9
+
+
+def stage_move_requires_pause(
+    delta_distances: list[float],
+    stage_distance_threshold: float,
+    theta_delta: float = 0.0,
+) -> bool:
+    """Return True when a stage move should pause camera frame reads."""
+    return any(distance > stage_distance_threshold for distance in delta_distances) or (
+        abs(theta_delta) > THETA_MOVE_EPSILON
+    )
+
+
 class Snap:
     """Snap class for capturing data frames using a microscope.
 
@@ -898,8 +912,13 @@ class MoveToNextPositionInMultiPositionTable:
         delta_distances = [
             abs(pos_dict[axis] - pre_stage_pos[axis]) for axis in self.stage_axes
         ]
-        should_pause_data_thread = any(
-            distance > self.stage_distance_threshold for distance in delta_distances
+        theta_delta = 0.0
+        if "theta" in pos_dict and "theta" in pre_stage_pos:
+            theta_delta = pos_dict["theta"] - pre_stage_pos["theta"]
+        should_pause_data_thread = stage_move_requires_pause(
+            delta_distances,
+            self.stage_distance_threshold,
+            theta_delta,
         )
         if should_pause_data_thread:
             self.model.pause_data_thread()
@@ -1263,6 +1282,9 @@ class ZStackAcquisition:
         pos_dict = self.model.get_stage_position()
         self.restore_z = pos_dict["z_pos"]
         self.restore_f = pos_dict["f_pos"]
+        self.pre_position = {
+            axis: float(pos_dict[f"{axis}_pos"]) for axis in self.stage_axes
+        }
 
         # position: x, y, z, theta, f
         # If multiposition, get the header to know which stage is which, and then
@@ -1346,7 +1368,8 @@ class ZStackAcquisition:
         # move stage X, Y, Theta
         if self.need_to_move_new_position:
             self.need_to_move_new_position = False
-            self.pre_position = self.current_position
+            if self.current_position_idx > 0:
+                self.pre_position = self.current_position
             self.current_position = dict(
                 zip(
                     self.stage_axes,
@@ -1409,8 +1432,15 @@ class ZStackAcquisition:
             # self.model.resume_data_thread() after the stage has completed the move
             # to the next position.
 
-            self.should_pause_data_thread = any(
-                distance > self.stage_distance_threshold for distance in delta_distances
+            theta_delta = 0.0
+            if "theta" in self.tiling_axes and self.pre_position is not None:
+                theta_delta = self.current_position["theta"] - self.pre_position.get(
+                    "theta", self.current_position["theta"]
+                )
+            self.should_pause_data_thread = stage_move_requires_pause(
+                delta_distances,
+                self.stage_distance_threshold,
+                theta_delta,
             )
             if self.should_pause_data_thread:
                 self.model.pause_data_thread()
@@ -1672,7 +1702,8 @@ class ASIZStackAcquisition(ZStackAcquisition):
         # move stage X, Y, Theta
         if self.need_to_move_new_position:
             self.need_to_move_new_position = False
-            self.pre_position = self.current_position
+            if self.current_position_idx > 0:
+                self.pre_position = self.current_position
             self.current_position = dict(
                 zip(
                     self.stage_axes,
@@ -1733,8 +1764,15 @@ class ASIZStackAcquisition(ZStackAcquisition):
         # if it is too far, then we can call self.model.pause_data_thread() and
         # self.model.resume_data_thread() after the stage has completed the move
         # to the next position.
-        self.should_pause_data_thread = any(
-            distance > self.stage_distance_threshold for distance in delta_distances
+        theta_delta = 0.0
+        if "theta" in self.tiling_axes and self.pre_position is not None:
+            theta_delta = self.current_position["theta"] - self.pre_position.get(
+                "theta", self.current_position["theta"]
+            )
+        self.should_pause_data_thread = stage_move_requires_pause(
+            delta_distances,
+            self.stage_distance_threshold,
+            theta_delta,
         )
         if self.should_pause_data_thread:
             self.model.pause_data_thread()

--- a/src/navigate/model/features/common_features.py
+++ b/src/navigate/model/features/common_features.py
@@ -59,7 +59,7 @@ def stage_move_requires_pause(
     theta_delta: float = 0.0,
 ) -> bool:
     """Return True when a stage move should pause camera frame reads."""
-    return any(distance > stage_distance_threshold for distance in delta_distances) or (
+    return any(abs(distance) > stage_distance_threshold for distance in delta_distances) or (
         abs(theta_delta) > THETA_MOVE_EPSILON
     )
 

--- a/src/navigate/model/model.py
+++ b/src/navigate/model/model.py
@@ -1020,6 +1020,7 @@ class Model:
                 self.pause_data_ready_lock.release()
                 self.pause_data_event.clear()
                 self.pause_data_event.wait()
+                wait_num = self.camera_wait_iterations
             start_time = time.perf_counter_ns()
             frame_ids = self.active_microscope.camera.get_new_frame()
 

--- a/test/model/devices/stages/test_asi.py
+++ b/test/model/devices/stages/test_asi.py
@@ -47,6 +47,7 @@ class MockASIStage:
         self.is_open = False
         self.input_buffer = []
         self.output_buffer = []
+        self.commands = []
         self.ignore_obj = ignore_obj
 
         for axis in self.axes:
@@ -63,6 +64,7 @@ class MockASIStage:
 
     def write(self, command):
         command = command.decode(encoding="ascii")[:-1]
+        self.commands.append(command)
         temps = command.split()
         command = temps[0]
         if command == "WHERE":
@@ -92,6 +94,10 @@ class MockASIStage:
             self.output_buffer.append(":A")
         elif command == "SPEED":
             self.output_buffer.append(":A")
+        elif command == "S":
+            self.output_buffer.append(":A")
+        elif command == "RS":
+            self.output_buffer.append(":A N")
         elif command == "BU":
             axes = " ".join(self.axes)
             self.output_buffer.append(
@@ -335,3 +341,35 @@ class TestStageASI:
         self.random_multiple_axes_test(stage)
         stage.stage_limits = False
         self.random_multiple_axes_test(stage)
+
+    def test_theta_speed_override_only_sets_theta_axis(self):
+        self.stage_configuration["stage"]["hardware"]["axes"] = ["theta"]
+        self.stage_configuration["stage"]["hardware"]["axes_mapping"] = ["N"]
+        asi_stage = self.build_device_connection()
+
+        ASIStage(self.microscope_name, asi_stage, self.configuration)
+
+        assert "S N=5.0" in self.asi_serial_device.commands
+        assert "S X=5.0" not in self.asi_serial_device.commands
+        assert "S Y=5.0" not in self.asi_serial_device.commands
+        assert "S Z=5.0" not in self.asi_serial_device.commands
+
+    def test_theta_move_waits_for_theta_axis(self):
+        self.stage_configuration["stage"]["hardware"]["axes"] = ["theta"]
+        self.stage_configuration["stage"]["hardware"]["axes_mapping"] = ["N"]
+        asi_stage = self.build_device_connection()
+        stage = ASIStage(self.microscope_name, asi_stage, self.configuration)
+        stage.stage_limits = False
+
+        queried_axes = []
+        busy_responses = iter([True, True, False])
+        asi_stage.wait_for_device = lambda: None
+
+        def is_axis_busy(axis):
+            queried_axes.append(axis)
+            return next(busy_responses)
+
+        asi_stage.is_axis_busy = is_axis_busy
+
+        assert stage.move_axis_absolute("theta", 10, wait_until_done=True)
+        assert queried_axes == ["N", "N", "N"]

--- a/test/model/features/test_common_features.py
+++ b/test/model/features/test_common_features.py
@@ -33,7 +33,39 @@
 
 import random
 import pytest
-from navigate.model.features.common_features import ZStackAcquisition
+from navigate.model.features.common_features import (
+    MoveToNextPositionInMultiPositionTable,
+    ZStackAcquisition,
+    stage_move_requires_pause,
+)
+
+
+def test_theta_move_requires_pause_below_linear_threshold():
+    assert stage_move_requires_pause([0, 0, 0], 1000, theta_delta=1)
+
+
+def test_no_stage_move_does_not_require_pause():
+    assert not stage_move_requires_pause([0, 0, 0], 1000, theta_delta=0)
+
+
+def test_multiposition_theta_move_pauses_data_thread(dummy_model_to_test_features):
+    model = dummy_model_to_test_features
+    model.signal_records = []
+    model.configuration["experiment"]["StageParameters"].update(
+        {"x": 0, "y": 0, "z": 0, "theta": 0, "f": 0}
+    )
+    model.configuration["multi_positions"] = [
+        ["X", "Y", "Z", "THETA", "F"],
+        [0, 0, 0, 45, 0],
+    ]
+    feature = MoveToNextPositionInMultiPositionTable(model)
+
+    feature.pre_signal_func()
+    feature.signal_func()
+
+    record_names = [record[0] for record in model.signal_records]
+    assert record_names.index("pause_data_thread") < record_names.index("move_stage")
+    assert record_names.index("move_stage") < record_names.index("resume_data_thread")
 
 
 class TestZStack:


### PR DESCRIPTION
Fix for #1199 - Upon reviewing the error status of the controller, realized that the theta stage was throwing this error:

```
ERROR_LARGE – RECOVERABLE. Motor set to FULL SPEED; hope to catch up (e.g. speed set faster than possible).
```
Reducing the speed fixes the issue. However, also needed to add some pauses for the data thread for theta-specific moves. Currently we have the 1000 micron stage movement threshold, which would not get thrown for degrees (often ~90 degrees). 

I did notice that the acquisition slowed down after the first z-stack, but I think that may be unrelated. Perhaps due to the stage not hitting its target and then searching locally before flagging that the movement was complete. We have occasionally seen that on other systems, and need to investigate it. 