### PR TITLE
Adjust tissue detection calculation for stacks

### DIFF
--- a/docs/source/01_getting_started/07_smart_routines.rst
+++ b/docs/source/01_getting_started/07_smart_routines.rst
@@ -92,8 +92,9 @@ Step 3: Add Tissue Detection
 3. Configure the ``DetectTissueInStackAndReturn`` node with the following parameters:
 
     1. :guilabel:`planes`: number of z-planes checked for tissue.
-    2. :guilabel:`percentage`: required image fraction containing tissue to return ``true``.
-    3. :guilabel:`detect_func`: tissue detection function from :doc:`remove_empty_tiles </05_reference/_autosummary/navigate.model.features.remove_empty_tiles>`. If set to ``None``, **navigate** uses ``detect_tissue()``.
+    2. :guilabel:`percentage`: required fraction of tissue-positive frames in the stack to return ``true``.
+    3. :guilabel:`detect_func`: tissue detection function from :doc:`remove_empty_tiles </05_reference/_autosummary/navigate.model.features.remove_empty_tiles>`. If set to ``None``, **navigate** uses ``detect_tissue3()``.
+    4. :guilabel:`threshold`: intensity threshold passed to the tissue detection function.
 
 .. tip::
 

--- a/src/navigate/model/features/remove_empty_tiles.py
+++ b/src/navigate/model/features/remove_empty_tiles.py
@@ -35,6 +35,7 @@ from math import ceil
 from queue import Queue
 
 # Third Party Imports
+from skimage.filters import threshold_otsu
 
 # Local Imports
 from navigate.model.analysis.boundary_detect import find_tissue_boundary_2d
@@ -131,6 +132,25 @@ def detect_tissue2(image_data, percentage=0.0):
 
     return False
 
+def detect_tissue3(image_data, threshold=150):
+    """Detect Tissue in an Image.
+    
+    This function analyzes an image to determine if it contains tissue based on a specified otsu threshold.
+    
+    Parameters:
+    -----------
+    image_data : numpy.ndarray
+        The input image data as a NumPy array.
+    threshold : int, optional
+        The intensity threshold for tissue detection. Default is 170.
+
+    Returns:
+    --------
+    bool
+        True if the image contains tissue above the threshold; False otherwise.
+    """
+    t = threshold_otsu(image_data)
+    return t >= threshold
 
 class DetectTissueInStack:
     """Detect Tissue in a Stack of Images.
@@ -140,13 +160,15 @@ class DetectTissueInStack:
     presence.
     """
 
-    def __init__(self, model, planes=1, percentage=0.75, detect_func=None):
+    def __init__(self, model, planes=1, threshold=150, percentage=0.75, detect_func=None):
         """Initialize the DetectTissueInStack class.
 
         Parameters:
         -----------
         model : object
             The model object representing the microscope.
+        threshold : float, optional
+            The intensity threshold for tissue detection. Default is 170.
         planes : int, optional
             The number of Z planes to capture in the stack. Default is 1.
         percentage : float, optional
@@ -163,14 +185,16 @@ class DetectTissueInStack:
         #: int: The number of Z planes to capture in the stack.
         self.planes = int(planes)
 
-        #: float: The minimum percentage of tissue required to consider a frame as
-        # having tissue.
+        #: float: The intensity threshold for tissue detection.
+        self.threshold = float(threshold)
+
+        #: float: The minimum percentage of images having tissue in a stack.
         self.percentage = float(percentage)
 
         # if not specify a detect function, use the default one
         if detect_func is None:
             #: function: The tissue detection function used to analyze image frames.
-            self.detect_func = detect_tissue
+            self.detect_func = detect_tissue3
         else:
             self.detect_func = detect_func
 
@@ -198,8 +222,16 @@ class DetectTissueInStack:
         """
 
         microscope_config = self.model.configuration["experiment"]["MicroscopeState"]
+
+        # primary z and f axes, secondary stack settings
+        self.primary_z_axis = microscope_config.get("primary_z_axis", "z")
+        self.primary_f_axis = microscope_config.get("primary_f_axis", "f")
+
         # get current z and f position
         pos = self.model.get_stage_position()
+
+        #: current stage position
+        self.starting_pos = pos
 
         #: float: The current Z position of the microscope stage.
         self.current_z_pos = pos["z_pos"] + float(microscope_config["start_position"])
@@ -239,11 +271,11 @@ class DetectTissueInStack:
 
         # move to Z anf F position
         self.model.logger.debug(
-            f"move to position (z, f): ({self.current_z_pos}, {self.current_f_pos}), "
+            f"move to position ({self.primary_z_axis}, {self.primary_f_axis}): ({self.current_z_pos}, {self.current_f_pos}), "
             f"{self.scan_num}, {self.model.frame_id}"
         )
         self.model.move_stage(
-            {"z_abs": self.current_z_pos, "f_abs": self.current_f_pos},
+            {f"{self.primary_z_axis}_abs": self.current_z_pos, f"{self.primary_f_axis}_abs": self.current_f_pos},
             wait_until_done=True,
         )
         self.scan_num += 1
@@ -263,6 +295,11 @@ class DetectTissueInStack:
             f"*** detect tissue signal end function: " f"{self.scan_num}"
         )
         if self.scan_num >= self.planes:
+            # move stage back to starting position
+            self.model.move_stage(
+                {f"{self.primary_z_axis}_abs": self.starting_pos["z_pos"], f"{self.primary_f_axis}_abs": self.starting_pos["f_pos"]}, 
+                wait_until_done=True
+            )
             return True
         self.current_z_pos += self.z_step
         self.current_f_pos += self.f_step
@@ -280,6 +317,9 @@ class DetectTissueInStack:
         """
         #: int: The number of received frames.
         self.received_frames = 0
+
+        #: int: The number of images having tissue detected.
+        self.tissue_frames = 0
 
         #: bool: Flag indicating whether tissue is detected.
         self.has_tissue_flag = False
@@ -305,13 +345,16 @@ class DetectTissueInStack:
         if not self.has_tissue_flag:
             for frame_id in frame_ids:
                 # check if the frame has tissue
-                r = self.detect_func(self.model.data_buffer[frame_id], self.percentage)
+                r = self.detect_func(self.model.data_buffer[frame_id], self.threshold)
                 if r:
                     self.model.logger.debug(
-                        f"*** this frame has enough percentage of tissue!{frame_id}"
+                        f"*** this frame has tissue!{frame_id}"
                     )
-                    self.has_tissue_flag = True
-                    break
+                    self.tissue_frames += 1
+                    # self.has_tissue_flag = True
+                    self.has_tissue_flag = (self.tissue_frames / self.planes) >= self.percentage
+                    if self.has_tissue_flag:
+                        break
         self.received_frames += len(frame_ids)
         return self.has_tissue_flag
 
@@ -330,7 +373,7 @@ class DetectTissueInStack:
 
 
 class DetectTissueInStackAndReturn(DetectTissueInStack):
-    def __init__(self, model, planes=1, percentage=0.75, detect_func=None):
+    def __init__(self, model, planes=1, threshold=150, percentage=0.75, detect_func=None):
         """Initialize the DetectTissueInStackAndReturn class.
 
         Parameters:
@@ -339,6 +382,8 @@ class DetectTissueInStackAndReturn(DetectTissueInStack):
             The model object representing the microscope.
         planes : int, optional
             The number of Z planes to capture in the stack. Default is 1.
+        threshold : float, optional
+            The intensity threshold for tissue detection. Default is 170.
         percentage : float, optional
             The minimum percentage of tissue required to consider a frame as having
             tissue. Default is 0.75 (75%).
@@ -346,7 +391,7 @@ class DetectTissueInStackAndReturn(DetectTissueInStack):
             The custom tissue detection function to use. If not specified, the default
             `detect_tissue` function will be used.
         """
-        super().__init__(model, planes, percentage, detect_func)
+        super().__init__(model, planes, threshold, percentage, detect_func)
 
         self.detect_tissue_queue = Queue()
         self.result_sent_flag = False
@@ -429,7 +474,7 @@ class DetectTissueInStackAndRecord(DetectTissueInStack):
     """
 
     def __init__(
-        self, model, planes=1, percentage=0.75, position_records=[], detect_func=None
+        self, model, planes=1, threshold=150, percentage=0.75, position_records=[], detect_func=None
     ):
         """Initialize the DetectTissueInStackAndRecord class.
 
@@ -439,6 +484,8 @@ class DetectTissueInStackAndRecord(DetectTissueInStack):
             The model object representing the microscope.
         planes : int, optional
             The number of Z planes to capture in the stack. Default is 1.
+        threshold : float, optional
+            The intensity threshold for tissue detection. Default is 170.
         percentage : float, optional
             The minimum percentage of tissue required to consider a frame as having
             tissue. Default is 0.75 (75%).
@@ -449,7 +496,7 @@ class DetectTissueInStackAndRecord(DetectTissueInStack):
             The custom tissue detection function to use. If not specified, the default
             `detect_tissue` function will be used.
         """
-        super().__init__(model, planes, percentage, detect_func)
+        super().__init__(model, planes, threshold, percentage, detect_func)
 
         #: list: A list to record positions where tissue was detected.
         self.position_records = position_records

--- a/src/navigate/model/features/remove_empty_tiles.py
+++ b/src/navigate/model/features/remove_empty_tiles.py
@@ -132,25 +132,30 @@ def detect_tissue2(image_data, percentage=0.0):
 
     return False
 
+
 def detect_tissue3(image_data, threshold=150):
-    """Detect Tissue in an Image.
-    
-    This function analyzes an image to determine if it contains tissue based on a specified otsu threshold.
-    
+    """Detect tissue in an image using the computed Otsu threshold.
+
+    This function computes the Otsu threshold value for an image and compares that
+    computed value against a minimum threshold.
+
     Parameters:
     -----------
     image_data : numpy.ndarray
         The input image data as a NumPy array.
     threshold : float, optional
-        The intensity threshold for tissue detection. Default is 150.
+        The minimum computed Otsu threshold required for tissue detection.
+        Default is 150.
 
     Returns:
     --------
     bool
-        True if the image contains tissue above the threshold; False otherwise.
+        True if the computed Otsu threshold is greater than or equal to
+        ``threshold``; False otherwise.
     """
     t = threshold_otsu(image_data)
     return t >= threshold
+
 
 class DetectTissueInStack:
     """Detect Tissue in a Stack of Images.
@@ -160,23 +165,26 @@ class DetectTissueInStack:
     presence.
     """
 
-    def __init__(self, model, planes=1, threshold=150, percentage=0.75, detect_func=None):
+    def __init__(
+        self, model, planes=1, percentage=0.75, detect_func=None, threshold=150
+    ):
         """Initialize the DetectTissueInStack class.
 
         Parameters:
         -----------
         model : object
             The model object representing the microscope.
-        threshold : float, optional
-            The intensity threshold for tissue detection. Default is 150.
         planes : int, optional
             The number of Z planes to capture in the stack. Default is 1.
         percentage : float, optional
-            The minimum percentage of tissue required to consider a frame as having
-            tissue. Default is 0.75 (75%).
+            The minimum fraction of tissue-positive frames required for the stack to
+            be considered as having tissue. Default is 0.75 (75%).
         detect_func : function, optional
             The custom tissue detection function to use. If not specified, the default
-            `detect_tissue` function will be used.
+            `detect_tissue3` function will be used. The function must accept
+            ``(image_data, threshold)`` and return whether the frame contains tissue.
+        threshold : float, optional
+            The intensity threshold passed to ``detect_func``. Default is 150.
         """
 
         #: navigate.model.Model: The model object representing the microscope.
@@ -234,10 +242,14 @@ class DetectTissueInStack:
         self.starting_pos = pos
 
         #: float: The current Z position of the microscope stage.
-        self.current_z_pos = pos[f"{self.primary_z_axis}_pos"] + float(microscope_config["start_position"])
+        self.current_z_pos = pos[f"{self.primary_z_axis}_pos"] + float(
+            microscope_config["start_position"]
+        )
 
         #: float: The current F position of the microscope stage.
-        self.current_f_pos = pos[f"{self.primary_f_axis}_pos"] + float(microscope_config["start_focus"])
+        self.current_f_pos = pos[f"{self.primary_f_axis}_pos"] + float(
+            microscope_config["start_focus"]
+        )
 
         # calculate Z and F stage step sizes
         z_pos_range = float(microscope_config["end_position"]) - float(
@@ -271,11 +283,15 @@ class DetectTissueInStack:
 
         # move to Z anf F position
         self.model.logger.debug(
-            f"move to position ({self.primary_z_axis}, {self.primary_f_axis}): ({self.current_z_pos}, {self.current_f_pos}), "
+            f"move to position ({self.primary_z_axis}, {self.primary_f_axis}): "
+            f"({self.current_z_pos}, {self.current_f_pos}), "
             f"{self.scan_num}, {self.model.frame_id}"
         )
         self.model.move_stage(
-            {f"{self.primary_z_axis}_abs": self.current_z_pos, f"{self.primary_f_axis}_abs": self.current_f_pos},
+            {
+                f"{self.primary_z_axis}_abs": self.current_z_pos,
+                f"{self.primary_f_axis}_abs": self.current_f_pos,
+            },
             wait_until_done=True,
         )
         self.scan_num += 1
@@ -292,7 +308,7 @@ class DetectTissueInStack:
             True if the signal phase should end, False otherwise.
         """
         self.model.logger.debug(
-            f"*** detect tissue signal end function: " f"{self.scan_num}"
+            f"*** detect tissue signal end function: {self.scan_num}"
         )
         if self.scan_num >= self.planes:
             # move stage back to starting position
@@ -300,12 +316,12 @@ class DetectTissueInStack:
                 {
                     f"{self.primary_z_axis}_abs": self.starting_pos[
                         f"{self.primary_z_axis}_pos"
-                    ], 
+                    ],
                     f"{self.primary_f_axis}_abs": self.starting_pos[
                         f"{self.primary_f_axis}_pos"
-                    ]
-                }, 
-                wait_until_done=True
+                    ],
+                },
+                wait_until_done=True,
             )
             return True
         self.current_z_pos += self.z_step
@@ -354,12 +370,12 @@ class DetectTissueInStack:
                 # check if the frame has tissue
                 r = self.detect_func(self.model.data_buffer[frame_id], self.threshold)
                 if r:
-                    self.model.logger.debug(
-                        f"*** this frame has tissue!{frame_id}"
-                    )
+                    self.model.logger.debug(f"*** this frame has tissue!{frame_id}")
                     self.tissue_frames += 1
                     # self.has_tissue_flag = True
-                    self.has_tissue_flag = (self.tissue_frames / self.planes) >= self.percentage
+                    self.has_tissue_flag = (
+                        self.tissue_frames / self.planes
+                    ) >= self.percentage
                     if self.has_tissue_flag:
                         break
         self.received_frames += len(frame_ids)
@@ -380,7 +396,9 @@ class DetectTissueInStack:
 
 
 class DetectTissueInStackAndReturn(DetectTissueInStack):
-    def __init__(self, model, planes=1, threshold=150, percentage=0.75, detect_func=None):
+    def __init__(
+        self, model, planes=1, percentage=0.75, detect_func=None, threshold=150
+    ):
         """Initialize the DetectTissueInStackAndReturn class.
 
         Parameters:
@@ -389,16 +407,17 @@ class DetectTissueInStackAndReturn(DetectTissueInStack):
             The model object representing the microscope.
         planes : int, optional
             The number of Z planes to capture in the stack. Default is 1.
-        threshold : float, optional
-            The intensity threshold for tissue detection. Default is 150.
         percentage : float, optional
-            The minimum percentage of tissue required to consider a frame as having
-            tissue. Default is 0.75 (75%).
+            The minimum fraction of tissue-positive frames required for the stack to
+            be considered as having tissue. Default is 0.75 (75%).
         detect_func : function, optional
             The custom tissue detection function to use. If not specified, the default
-            `detect_tissue` function will be used.
+            `detect_tissue3` function will be used. The function must accept
+            ``(image_data, threshold)`` and return whether the frame contains tissue.
+        threshold : float, optional
+            The intensity threshold passed to ``detect_func``. Default is 150.
         """
-        super().__init__(model, planes, threshold, percentage, detect_func)
+        super().__init__(model, planes, percentage, detect_func, threshold)
 
         self.detect_tissue_queue = Queue()
         self.result_sent_flag = False
@@ -481,7 +500,13 @@ class DetectTissueInStackAndRecord(DetectTissueInStack):
     """
 
     def __init__(
-        self, model, planes=1, threshold=150, percentage=0.75, position_records=[], detect_func=None
+        self,
+        model,
+        planes=1,
+        percentage=0.75,
+        position_records=None,
+        detect_func=None,
+        threshold=150,
     ):
         """Initialize the DetectTissueInStackAndRecord class.
 
@@ -491,21 +516,24 @@ class DetectTissueInStackAndRecord(DetectTissueInStack):
             The model object representing the microscope.
         planes : int, optional
             The number of Z planes to capture in the stack. Default is 1.
-        threshold : float, optional
-            The intensity threshold for tissue detection. Default is 150.
         percentage : float, optional
-            The minimum percentage of tissue required to consider a frame as having
-            tissue. Default is 0.75 (75%).
+            The minimum fraction of tissue-positive frames required for the stack to
+            be considered as having tissue. Default is 0.75 (75%).
         position_records : list, optional
-            A list to record positions where tissue was detected. Default is an empty
-            list.
+            A list to record positions where tissue was detected. A new list is
+            created when no list is provided.
         detect_func : function, optional
             The custom tissue detection function to use. If not specified, the default
-            `detect_tissue` function will be used.
+            `detect_tissue3` function will be used. The function must accept
+            ``(image_data, threshold)`` and return whether the frame contains tissue.
+        threshold : float, optional
+            The intensity threshold passed to ``detect_func``. Default is 150.
         """
-        super().__init__(model, planes, threshold, percentage, detect_func)
+        super().__init__(model, planes, percentage, detect_func, threshold)
 
         #: list: A list to record positions where tissue was detected.
+        if position_records is None:
+            position_records = []
         self.position_records = position_records
 
     def pre_func_data(self):

--- a/src/navigate/model/features/remove_empty_tiles.py
+++ b/src/navigate/model/features/remove_empty_tiles.py
@@ -141,8 +141,8 @@ def detect_tissue3(image_data, threshold=150):
     -----------
     image_data : numpy.ndarray
         The input image data as a NumPy array.
-    threshold : int, optional
-        The intensity threshold for tissue detection. Default is 170.
+    threshold : float, optional
+        The intensity threshold for tissue detection. Default is 150.
 
     Returns:
     --------
@@ -168,7 +168,7 @@ class DetectTissueInStack:
         model : object
             The model object representing the microscope.
         threshold : float, optional
-            The intensity threshold for tissue detection. Default is 170.
+            The intensity threshold for tissue detection. Default is 150.
         planes : int, optional
             The number of Z planes to capture in the stack. Default is 1.
         percentage : float, optional
@@ -234,10 +234,10 @@ class DetectTissueInStack:
         self.starting_pos = pos
 
         #: float: The current Z position of the microscope stage.
-        self.current_z_pos = pos["z_pos"] + float(microscope_config["start_position"])
+        self.current_z_pos = pos[f"{self.primary_z_axis}_pos"] + float(microscope_config["start_position"])
 
         #: float: The current F position of the microscope stage.
-        self.current_f_pos = pos["f_pos"] + float(microscope_config["start_focus"])
+        self.current_f_pos = pos[f"{self.primary_f_axis}_pos"] + float(microscope_config["start_focus"])
 
         # calculate Z and F stage step sizes
         z_pos_range = float(microscope_config["end_position"]) - float(
@@ -297,7 +297,14 @@ class DetectTissueInStack:
         if self.scan_num >= self.planes:
             # move stage back to starting position
             self.model.move_stage(
-                {f"{self.primary_z_axis}_abs": self.starting_pos["z_pos"], f"{self.primary_f_axis}_abs": self.starting_pos["f_pos"]}, 
+                {
+                    f"{self.primary_z_axis}_abs": self.starting_pos[
+                        f"{self.primary_z_axis}_pos"
+                    ], 
+                    f"{self.primary_f_axis}_abs": self.starting_pos[
+                        f"{self.primary_f_axis}_pos"
+                    ]
+                }, 
                 wait_until_done=True
             )
             return True
@@ -383,7 +390,7 @@ class DetectTissueInStackAndReturn(DetectTissueInStack):
         planes : int, optional
             The number of Z planes to capture in the stack. Default is 1.
         threshold : float, optional
-            The intensity threshold for tissue detection. Default is 170.
+            The intensity threshold for tissue detection. Default is 150.
         percentage : float, optional
             The minimum percentage of tissue required to consider a frame as having
             tissue. Default is 0.75 (75%).
@@ -485,7 +492,7 @@ class DetectTissueInStackAndRecord(DetectTissueInStack):
         planes : int, optional
             The number of Z planes to capture in the stack. Default is 1.
         threshold : float, optional
-            The intensity threshold for tissue detection. Default is 170.
+            The intensity threshold for tissue detection. Default is 150.
         percentage : float, optional
             The minimum percentage of tissue required to consider a frame as having
             tissue. Default is 0.75 (75%).

--- a/test/model/features/test_remove_empty_tiles.py
+++ b/test/model/features/test_remove_empty_tiles.py
@@ -1,0 +1,72 @@
+import numpy as np
+
+from navigate.model.features.feature_related_functions import SharedList
+from navigate.model.features.remove_empty_tiles import (
+    DetectTissueInStack,
+    DetectTissueInStackAndRecord,
+    DetectTissueInStackAndReturn,
+    detect_tissue3,
+)
+
+
+class _Logger:
+    def debug(self, *args, **kwargs):
+        pass
+
+
+class _Model:
+    def __init__(self):
+        self.data_buffer = {}
+        self.logger = _Logger()
+
+
+def test_return_detector_preserves_legacy_positional_arguments():
+    feature = DetectTissueInStackAndReturn(_Model(), 1, 0.5, None)
+
+    assert feature.planes == 1
+    assert feature.percentage == 0.5
+    assert feature.threshold == 150
+    assert feature.detect_func is detect_tissue3
+
+
+def test_record_detector_preserves_legacy_positional_records_argument():
+    records = SharedList([], "records")
+
+    feature = DetectTissueInStackAndRecord(_Model(), 5, 0.75, records)
+
+    assert feature.planes == 5
+    assert feature.percentage == 0.75
+    assert feature.threshold == 150
+    assert feature.position_records is records
+
+
+def test_record_detector_default_records_are_not_shared():
+    first = DetectTissueInStackAndRecord(_Model())
+    second = DetectTissueInStackAndRecord(_Model())
+
+    first.position_records.append(True)
+
+    assert second.position_records == []
+
+
+def test_stack_decision_uses_percentage_of_tissue_positive_frames():
+    model = _Model()
+    model.data_buffer = {0: False, 1: True, 2: True}
+    feature = DetectTissueInStack(
+        model,
+        planes=3,
+        percentage=2 / 3,
+        detect_func=lambda frame, threshold: frame,
+    )
+    feature.pre_func_data()
+
+    assert not feature.in_func_data([0, 1])
+    assert feature.in_func_data([2])
+
+
+def test_detect_tissue3_documents_computed_otsu_threshold_contract():
+    assert "computed Otsu threshold" in (detect_tissue3.__doc__ or "")
+
+    image_data = np.full((4, 4), 200, dtype=np.uint16)
+
+    assert detect_tissue3(image_data, threshold=150)


### PR DESCRIPTION
This PR updates the tissue detection logic used to determine whether a Z-scan should be performed on a stack.

Previously, tissue detection was based on the percentage of tissue within an individual frame. With this change, each frame is first evaluated against a threshold to determine whether it contains tissue. The percentage of tissue-positive frames across the stack is then calculated and used to decide whether the stack qualifies for Z-scanning.