### PR TITLE
Fix stage position dictionary mutation issue

### DIFF
--- a/src/navigate/model/microscope.py
+++ b/src/navigate/model/microscope.py
@@ -977,7 +977,7 @@ class Microscope:
                 self.ret_pos_dict[key] = round(value, 2)
             except (TypeError, ValueError, OverflowError) as e:
                 logger.error(f"Error rounding {key} position value: {e}")
-        return self.ret_pos_dict
+        return self.ret_pos_dict.copy()
 
     def move_remote_focus(self, offset: Optional[float] = None) -> None:
         """Move remote focus.


### PR DESCRIPTION
In this PR, the microscope object will return a copy of the stage position. This prevents accidental external mutation while preserving the existing data returned by the microscope.