### PR TITLE
Document DAQ trigger reset configuration

### DIFF
--- a/docs/source/02_user_guide/01_supported_hardware/daq.rst
+++ b/docs/source/02_user_guide/01_supported_hardware/daq.rst
@@ -112,6 +112,11 @@ Manager as a **NI Data Acquisition Device**.
 - Connect the ``camera_trigger_out_line`` to the ``Ext. Trigger`` on the camera using
   the ``CTR0Out`` pin.
 
+- DAQ self-reset is disabled by default. Leave ``trigger_reset_count`` unset,
+  or set it to ``0``, unless the system has DAQ instability during long
+  acquisitions. For affected systems, set a positive trigger count and adjust
+  the value for the microscope computer.
+
 - These values must precisely match those in the configuration file. An example is provided below:
 
 
@@ -125,6 +130,7 @@ Manager as a **NI Data Acquisition Device**.
               hardware:
                 type: NI
               sample_rate: 10000
+              trigger_reset_count: 0
               master_trigger_out_line: PXI6259/port0/line1
               camera_trigger_out_line: /PXI6259/ctr0
               trigger_source: /PXI6259/PFIO

--- a/src/navigate/config/configuration_database.py
+++ b/src/navigate/config/configuration_database.py
@@ -117,6 +117,13 @@ daq_device_types = {
 daq_hardware_widgets = {
     "hardware/type": ["Device Type", "Combobox", "string", daq_device_types, None],
     "sample_rate": ["Sample Rate", "Input", "int", None, "Example: 100000"],
+    "trigger_reset_count": [
+        "Trigger Reset Count",
+        "Input",
+        "int",
+        None,
+        "Default: 0 (disabled). Use a positive value only for unstable systems.",
+    ],
     "master_trigger_out_line": [
         "Master Trigger Out",
         "Input",

--- a/src/navigate/model/devices/daq/ni.py
+++ b/src/navigate/model/devices/daq/ni.py
@@ -34,7 +34,7 @@ import logging
 from threading import Lock
 import traceback
 import time
-from typing import Any
+from typing import Any, Optional
 import gc
 
 # Third Party Imports
@@ -109,11 +109,30 @@ class NIDAQ(DAQBase):
         self.trigger_count = 0
 
         #: int: trigger reset count
-        self.trigger_reset_count = None
+        self.trigger_reset_count = self._get_trigger_reset_count(self.microscope_name)
 
     def __str__(self) -> str:
         """String representation of the class."""
         return "NIDAQ"
+
+    @staticmethod
+    def _normalize_trigger_reset_count(value: Any) -> Optional[int]:
+        """Return a positive DAQ reset count, or None when disabled."""
+        try:
+            trigger_reset_count = int(value)
+        except (TypeError, ValueError):
+            return None
+
+        if trigger_reset_count <= 0:
+            return None
+        return trigger_reset_count
+
+    def _get_trigger_reset_count(self, microscope_name: str) -> Optional[int]:
+        """Return the DAQ reset count for the microscope."""
+        value = self.configuration["configuration"]["microscopes"][microscope_name][
+            "daq"
+        ].get("trigger_reset_count", None)
+        return self._normalize_trigger_reset_count(value)
 
     def __del__(self) -> None:
         """Destructor."""
@@ -178,8 +197,7 @@ class NIDAQ(DAQBase):
                     self.analog_output_tasks[board_name].stop()
                 except Exception:
                     logger.debug(
-                        f"Error stopping analog output tasks: "
-                        f"{traceback.format_exc()}"
+                        f"Error stopping analog output tasks: {traceback.format_exc()}"
                     )
                 self.analog_output_tasks[
                     board_name
@@ -198,8 +216,7 @@ class NIDAQ(DAQBase):
                     self.master_trigger_task.close()
                 except Exception:
                     logger.debug(
-                        f"Error stopping master trigger task: "
-                        f"{traceback.format_exc()}"
+                        f"Error stopping master trigger task: {traceback.format_exc()}"
                     )
             self.master_trigger_task = None
             # camera task trigger source
@@ -549,9 +566,8 @@ class NIDAQ(DAQBase):
             self.microscope_name = microscope_name
             self.analog_outputs = {}
             self.analog_output_tasks = {}
-            self.trigger_reset_count = self.configuration["configuration"][
-                "microscopes"
-            ][microscope_name]["daq"].get("trigger_reset_count", None)
+
+        self.trigger_reset_count = self._get_trigger_reset_count(microscope_name)
 
         self.camera_delay = (
             float(self.waveform_constants["other_constants"].get("camera_delay", 5))

--- a/src/navigate/model/devices/daq/ni.py
+++ b/src/navigate/model/devices/daq/ni.py
@@ -30,6 +30,7 @@
 
 
 # Standard Imports
+import math
 import logging
 from threading import Lock
 import traceback
@@ -118,9 +119,21 @@ class NIDAQ(DAQBase):
     @staticmethod
     def _normalize_trigger_reset_count(value: Any) -> Optional[int]:
         """Return a positive DAQ reset count, or None when disabled."""
-        try:
+        if isinstance(value, bool):
+            return None
+
+        if isinstance(value, int):
+            trigger_reset_count = value
+        elif isinstance(value, float):
+            if not math.isfinite(value) or not value.is_integer():
+                return None
             trigger_reset_count = int(value)
-        except (TypeError, ValueError):
+        elif isinstance(value, str):
+            try:
+                trigger_reset_count = int(value.strip())
+            except ValueError:
+                return None
+        else:
             return None
 
         if trigger_reset_count <= 0:

--- a/test/config/test_configuration.py
+++ b/test/config/test_configuration.py
@@ -183,6 +183,7 @@ class TestConfiguration(unittest.TestCase):
             "hardware",
             "sample_rate",
             "sweep_time",
+            "trigger_reset_count",
             "master_trigger_out_line",
             "camera_trigger_out_line",
             "trigger_source",

--- a/test/config/test_configuration_database.py
+++ b/test/config/test_configuration_database.py
@@ -1,0 +1,44 @@
+# Copyright (c) 2021-2026  The University of Texas Southwestern Medical Center.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted for academic and research use only (subject to the
+# limitations in the disclaimer below) provided that the following conditions are met:
+#
+#      * Redistributions of source code must retain the above copyright notice,
+#      this list of conditions and the following disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#      * Neither the name of the copyright holders nor the names of its
+#      contributors may be used to endorse or promote products derived from this
+#      software without specific prior written permission.
+#
+# NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE GRANTED BY
+# THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+# CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+# PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+# BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+# IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+from navigate.config.configuration_database import daq_hardware_widgets
+
+
+def test_daq_hardware_widgets_include_trigger_reset_count():
+    widget = daq_hardware_widgets["trigger_reset_count"]
+
+    assert widget[0] == "Trigger Reset Count"
+    assert widget[1] == "Input"
+    assert widget[2] == "int"
+    assert widget[3] is None
+    assert "0" in widget[4]
+    assert "disabled" in widget[4]
+    assert "unstable" in widget[4]

--- a/test/model/devices/daq/test_daq_ni.py
+++ b/test/model/devices/daq/test_daq_ni.py
@@ -138,7 +138,9 @@ class _FakeTask:
         self.timing = _FakeTiming()
         self.triggers = _FakeTriggers()
         self.write_calls = []
-        self.read_sequence = list(read_sequence if read_sequence is not None else [True])
+        self.read_sequence = list(
+            read_sequence if read_sequence is not None else [True]
+        )
         self.wait_calls = []
         self.register_done_event_calls = []
         self.start_calls = 0
@@ -340,6 +342,54 @@ def test_initialize_daq_ni_defaults(ni_module):
     assert daq.trigger_count == 0
 
 
+def test_initialize_daq_ni_loads_active_scope_trigger_reset_count(ni_module):
+    module, _, _ = ni_module
+    daq = _build_ni_daq(module)
+
+    assert daq.trigger_reset_count == 2
+
+
+@pytest.mark.parametrize(
+    ("raw_value", "expected"),
+    [
+        (500, 500),
+        ("500", 500),
+        (0, None),
+        ("0", None),
+        ("", None),
+        (None, None),
+        (-1, None),
+        ("invalid", None),
+    ],
+)
+def test_enable_microscope_normalizes_trigger_reset_count(
+    ni_module, raw_value, expected
+):
+    module, _, _ = ni_module
+    configuration = _build_configuration()
+    configuration["configuration"]["microscopes"]["ScopeA"]["daq"][
+        "trigger_reset_count"
+    ] = raw_value
+    daq = module.NIDAQ(configuration)
+
+    daq.enable_microscope("ScopeA")
+
+    assert daq.trigger_reset_count == expected
+
+
+def test_enable_microscope_refreshes_active_scope_trigger_reset_count(ni_module):
+    module, _, _ = ni_module
+    configuration = _build_configuration()
+    daq = module.NIDAQ(configuration)
+    configuration["configuration"]["microscopes"]["ScopeA"]["daq"][
+        "trigger_reset_count"
+    ] = 10
+
+    daq.enable_microscope("ScopeA")
+
+    assert daq.trigger_reset_count == 10
+
+
 def test_wait_for_external_trigger_without_channel_returns_false(ni_module):
     module, _, _ = ni_module
     assert module.NIDAQ.wait_for_external_trigger("") is False
@@ -539,7 +589,9 @@ def test_prepare_acquisition_sets_up_tasks_and_releases_lock(ni_module):
     assert daq.waveform_expand_num == 1
     assert daq.trigger_mode == "self-trigger"
     assert not daq.wait_to_run_lock.locked()
-    assert daq.camera_trigger_task.triggers.start_trigger.cfg_calls[-1] == "/ScopeA/PFI0"
+    assert (
+        daq.camera_trigger_task.triggers.start_trigger.cfg_calls[-1] == "/ScopeA/PFI0"
+    )
     assert (
         daq.analog_output_tasks["Dev1"].triggers.start_trigger.cfg_calls[-1]
         == "/ScopeA/PFI0"
@@ -561,7 +613,9 @@ def test_set_external_trigger_self_trigger_handles_task_exceptions(ni_module):
 
     assert daq.trigger_mode == "self-trigger"
     assert daq.master_trigger_task is not None
-    assert daq.camera_trigger_task.triggers.start_trigger.cfg_calls[-1] == "/ScopeA/PFI0"
+    assert (
+        daq.camera_trigger_task.triggers.start_trigger.cfg_calls[-1] == "/ScopeA/PFI0"
+    )
     assert analog_task.triggers.start_trigger.cfg_calls[-1] == "/ScopeA/PFI0"
     assert analog_task.register_done_event_calls[0] is None
     daq.camera_trigger_task.stop_exception = None
@@ -584,7 +638,9 @@ def test_set_external_trigger_external_mode_reconfigures_tasks(ni_module):
     assert daq.trigger_mode == "external-trigger"
     assert daq.external_trigger == "/External/PFI7"
     assert daq.master_trigger_task is None
-    assert daq.camera_trigger_task.triggers.start_trigger.cfg_calls[-1] == "/External/PFI7"
+    assert (
+        daq.camera_trigger_task.triggers.start_trigger.cfg_calls[-1] == "/External/PFI7"
+    )
     assert daq.camera_trigger_task.triggers.start_trigger.retriggerable is False
     assert analog_task.triggers.start_trigger.cfg_calls[-1] == "/External/PFI7"
     assert analog_task.register_done_event_calls[0] is None
@@ -612,7 +668,13 @@ def test_run_acquisition_starts_tasks_and_writes_master_trigger(ni_module):
     assert fake_lock.release_calls == 1
     assert camera_task.start_calls == 1
     assert analog_task.start_calls == 1
-    assert master_task.write_calls[0]["data"].tolist() == [False, True, True, True, False]
+    assert master_task.write_calls[0]["data"].tolist() == [
+        False,
+        True,
+        True,
+        True,
+        False,
+    ]
     assert master_task.write_calls[0]["auto_start"] is True
     assert calls["wait"] == 1
     assert daq.trigger_count == 1

--- a/test/model/devices/daq/test_daq_ni.py
+++ b/test/model/devices/daq/test_daq_ni.py
@@ -359,6 +359,9 @@ def test_initialize_daq_ni_loads_active_scope_trigger_reset_count(ni_module):
         ("", None),
         (None, None),
         (-1, None),
+        (True, None),
+        (1.9, None),
+        (float("inf"), None),
         ("invalid", None),
     ],
 )


### PR DESCRIPTION
## Summary
- Expose `trigger_reset_count` in the microscope configurator as an optional NI DAQ self-reset setting.
- Normalize the setting in `NIDAQ` so missing, blank, zero, negative, or invalid values keep self-reset disabled.
- Update DAQ docs to show `trigger_reset_count: 0` as the default disabled value and describe positive values as an opt-in workaround for unstable systems.

Closes #1135.

## Test Plan
- `PYTHONPATH=/Users/Dean/.config/superpowers/worktrees/navigate/1135-daq-trigger-reset-config-docs/src /opt/anaconda3/envs/navigate/bin/python -m pytest -o addopts='' test/model/devices/daq/test_daq_ni.py test/config/test_configuration.py test/config/test_configuration_database.py -q`
- `ruff check src/navigate/model/devices/daq/ni.py src/navigate/config/configuration_database.py test/model/devices/daq/test_daq_ni.py test/config/test_configuration.py test/config/test_configuration_database.py`
- `ruff format --check src/navigate/model/devices/daq/ni.py src/navigate/config/configuration_database.py test/model/devices/daq/test_daq_ni.py test/config/test_configuration.py test/config/test_configuration_database.py`
- `git diff --check`
- `PYTHONPATH=/Users/Dean/.config/superpowers/worktrees/navigate/1135-daq-trigger-reset-config-docs/src conda run -n navigate make html -j 15`

## Notes
- The docs build exits successfully with one existing warning: `docs/source/02_user_guide/01_supported_hardware/asi_logic.rst` is not included in a toctree.