### PR TITLE
Constrain stack ranges to stage limits

### DIFF
--- a/src/navigate/controller/controller.py
+++ b/src/navigate/controller/controller.py
@@ -1044,6 +1044,7 @@ class Controller:
             microscope_name = args[0]
             if microscope_name == self.configuration_controller.microscope_name:
                 self.stage_controller.initialize()
+                self.channels_tab_controller.update_stack_position_limits()
             self.threads_pool.createThread(
                 resourceName="model",
                 target=self.update_stage_limits,
@@ -1166,6 +1167,7 @@ class Controller:
 
         elif command == "stage_limits":
             self.stage_controller.stage_limits = args[0]
+            self.channels_tab_controller.update_stack_position_limits()
             self.threads_pool.createThread(
                 resourceName="model",
                 target=lambda: self.model.run_command("stage_limits", *args),
@@ -1434,7 +1436,7 @@ class Controller:
         None
         """
         e = RuntimeError
-        while e == RuntimeError:
+        while e is RuntimeError:
             try:
                 self.model.run_command("stop")
                 e = None

--- a/src/navigate/controller/sub_controllers/channels_tab.py
+++ b/src/navigate/controller/sub_controllers/channels_tab.py
@@ -130,6 +130,9 @@ class ChannelsTabController(GUIController):
         #: dict: The microscope state dictionary.
         self.microscope_state_dict = {}
 
+        #: dict: The GUI range settings used as non-stage fallbacks.
+        self._spinbox_range_limit_settings = {}
+
         # laser/stack cycling event binds
         self.stack_acq_vals["cycling"].trace_add("write", self.update_cycling_setting)
 
@@ -308,6 +311,7 @@ class ChannelsTabController(GUIController):
         self.focus_origin = self.parent_controller.configuration["experiment"][
             "StageParameters"
         ][primary_f_axis]
+        self.update_stack_position_limits()
         self.update_z_steps()
 
         self.show_verbose_info("Channels tab has been set new values")
@@ -325,6 +329,8 @@ class ChannelsTabController(GUIController):
             dictionary of settings from configuration file
         """
 
+        self._spinbox_range_limit_settings = settings
+
         # Z-Stack Step Size
         self.stack_acq_widgets["step_size"].widget.configure(
             from_=settings.get("stack_acquisition", {})
@@ -338,57 +344,7 @@ class ChannelsTabController(GUIController):
             .get("step", 0.01),
         )
 
-        # Z-Stack Z Start Position
-        self.stack_acq_widgets["start_position"].widget.configure(
-            from_=settings.get("stack_acquisition", {})
-            .get("z_start_pos", {})
-            .get("min", -1000),
-            to=settings.get("stack_acquisition", {})
-            .get("z_start_pos", {})
-            .get("max", 1000),
-            increment=settings.get("stack_acquisition", {})
-            .get("z_start_pos", {})
-            .get("step", 1),
-        )
-
-        # Z-Stack Z End Position
-        self.stack_acq_widgets["end_position"].widget.configure(
-            from_=settings.get("stack_acquisition", {})
-            .get("z_end_pos", {})
-            .get("min", -1000),
-            to=settings.get("stack_acquisition", {})
-            .get("z_end_pos", {})
-            .get("max", 1000),
-            increment=settings.get("stack_acquisition", {})
-            .get("z_end_pos", {})
-            .get("step", 1),
-        )
-
-        # Z-Stack F Start Position
-        self.stack_acq_widgets["start_focus"].widget.configure(
-            from_=settings.get("stack_acquisition", {})
-            .get("f_start_pos", {})
-            .get("min", -1000),
-            to=settings.get("stack_acquisition", {})
-            .get("f_start_pos", {})
-            .get("max", 1000),
-            increment=settings.get("stack_acquisition", {})
-            .get("f_start_pos", {})
-            .get("step", 1),
-        )
-
-        # Z-Stack F End Position
-        self.stack_acq_widgets["end_focus"].widget.configure(
-            from_=settings.get("stack_acquisition", {})
-            .get("f_end_pos", {})
-            .get("min", -1000),
-            to=settings.get("stack_acquisition", {})
-            .get("f_end_pos", {})
-            .get("max", 1000),
-            increment=settings.get("stack_acquisition", {})
-            .get("f_end_pos", {})
-            .get("step", 1),
-        )
+        self.update_stack_position_limits(settings)
 
         # Stack Pause Duration
         self.view.stack_timepoint_frame.stack_pause_spinbox.configure(
@@ -406,6 +362,122 @@ class ChannelsTabController(GUIController):
 
         # Channel settings
         self.channel_setting_controller.set_spinbox_range_limits(settings)
+
+    def _stage_limits_enabled(self) -> bool:
+        """Return whether stack widgets should honor configured stage limits."""
+
+        stage_controller = getattr(self.parent_controller, "stage_controller", None)
+        if stage_controller is not None:
+            return bool(stage_controller.stage_limits)
+
+        return bool(
+            self.parent_controller.configuration["experiment"]
+            .get("StageParameters", {})
+            .get("limits", True)
+        )
+
+    def _get_stack_axis(self, device_name: str, fallback_axis: str) -> str:
+        """Return the axis suffix from a stack device combobox value."""
+
+        device = self.stack_acq_vals.get(device_name)
+        if device is None:
+            return fallback_axis
+
+        value = device.get()
+        if not value:
+            return fallback_axis
+
+        try:
+            return value.split(" - ")[1]
+        except IndexError:
+            return fallback_axis
+
+    def _get_gui_stack_range(
+        self, settings: dict, setting_name: str
+    ) -> tuple[float, float]:
+        """Return stack range fallback limits from GUI configuration."""
+
+        stack_settings = settings.get("stack_acquisition", {})
+        setting = stack_settings.get(setting_name, {})
+        return (
+            float(setting.get("min", -1000)),
+            float(setting.get("max", 1000)),
+        )
+
+    def _get_gui_stack_step(self, settings: dict, setting_name: str) -> float:
+        """Return stack range increment from GUI configuration."""
+
+        return float(
+            settings.get("stack_acquisition", {}).get(setting_name, {}).get("step", 1)
+        )
+
+    def _get_relative_stage_limits(
+        self, axis: str, origin: float
+    ) -> Optional[tuple[float, float]]:
+        """Return stage limits relative to the current stack origin."""
+
+        config = self.parent_controller.configuration_controller
+        min_limits = config.get_stage_position_limits("_min")
+        max_limits = config.get_stage_position_limits("_max")
+        if axis not in min_limits or axis not in max_limits:
+            return None
+
+        try:
+            return float(min_limits[axis]) - origin, float(max_limits[axis]) - origin
+        except (TypeError, ValueError):
+            return None
+
+    def _get_stack_position_range(
+        self,
+        axis: str,
+        origin: float,
+        settings: dict,
+        setting_name: str,
+    ) -> tuple[float, float]:
+        """Return widget range, preferring relative stage limits when enabled."""
+
+        gui_range = self._get_gui_stack_range(settings, setting_name)
+        if not self._stage_limits_enabled():
+            return gui_range
+
+        stage_range = self._get_relative_stage_limits(axis, origin)
+        return gui_range if stage_range is None else stage_range
+
+    def update_stack_position_limits(
+        self, settings: Optional[Dict[str, Any]] = None
+    ) -> None:
+        """Update stack start/end widgets from stage limits or GUI fallback ranges."""
+
+        if settings is None:
+            settings = (
+                self._spinbox_range_limit_settings
+                or self.parent_controller.configuration["gui"]
+            )
+        else:
+            self._spinbox_range_limit_settings = settings
+
+        stack_positions = [
+            ("start_position", "z_device", "z", self.z_origin, "z_start_pos"),
+            ("end_position", "z_device", "z", self.z_origin, "z_end_pos"),
+            ("start_focus", "f_device", "f", self.focus_origin, "f_start_pos"),
+            ("end_focus", "f_device", "f", self.focus_origin, "f_end_pos"),
+        ]
+        for (
+            widget_name,
+            device_name,
+            fallback_axis,
+            origin,
+            setting_name,
+        ) in stack_positions:
+            axis = self._get_stack_axis(device_name, fallback_axis)
+            from_value, to_value = self._get_stack_position_range(
+                axis, float(origin), settings, setting_name
+            )
+            self.stack_acq_widgets[widget_name].widget.configure(
+                from_=from_value,
+                to=to_value,
+                increment=self._get_gui_stack_step(settings, setting_name),
+            )
 
     def set_mode(self, mode: str) -> None:
         """Change acquisition mode.
@@ -587,6 +659,7 @@ class ChannelsTabController(GUIController):
         self.focus_origin = self.parent_controller.configuration["experiment"][
             "StageParameters"
         ][primary_f_axis]
+        self.update_stack_position_limits()
 
         flip_flags = self.parent_controller.configuration_controller.stage_flip_flags
         if flip_flags[primary_z_axis]:
@@ -632,6 +705,7 @@ class ChannelsTabController(GUIController):
         # set origin to be in the middle of start and end
         self.z_origin = (z_start + z_end) / 2
         self.focus_origin = (focus_start + focus_end) / 2
+        self.update_stack_position_limits()
 
         # Propagate parameter changes to the GUI
         flip_flags = self.parent_controller.configuration_controller.stage_flip_flags
@@ -974,6 +1048,41 @@ class ChannelsTabController(GUIController):
                 return "Stack pause should be a valid number!"
             if self.microscope_state_dict["timepoints"] < 1:
                 return "Timepoints should be at least 1!"
+            warning = self._verify_stack_position_limits()
+            if warning:
+                return warning
+        return ""
+
+    def _verify_stack_position_limits(self) -> str:
+        """Return warning text if stack positions exceed relative stage limits."""
+
+        if not self._stage_limits_enabled():
+            return ""
+
+        stack_positions = [
+            ("start_position", "z_device", "z", self.z_origin),
+            ("end_position", "z_device", "z", self.z_origin),
+            ("start_focus", "f_device", "f", self.focus_origin),
+            ("end_focus", "f_device", "f", self.focus_origin),
+        ]
+        for setting_name, device_name, fallback_axis, origin in stack_positions:
+            axis = self._get_stack_axis(device_name, fallback_axis)
+            limits = self._get_relative_stage_limits(axis, float(origin))
+            if limits is None:
+                continue
+
+            try:
+                value = float(self.microscope_state_dict[setting_name])
+            except (KeyError, TypeError, ValueError):
+                return f"{setting_name} should be a valid number!"
+
+            min_value, max_value = limits
+            if value < min_value or value > max_value:
+                return (
+                    f"{setting_name} is outside the {axis} stage limits "
+                    f"({min_value:.3f} to {max_value:.3f} um relative to origin)."
+                )
+
         return ""
 
     def set_exposure_time(self, channel_exposure_time: tuple[str, float]) -> None:
@@ -1019,6 +1128,7 @@ class ChannelsTabController(GUIController):
             if variable_dict[f"stack_{f_axis}"].get():
                 variable_dict[f"stack_{f_axis}"].set(False)
                 self.view.stack_acq_frame.update_setting_widgets(f_axis)()
+        self.update_stack_position_limits()
 
     @property
     def custom_events(self) -> dict[str, callable]:

--- a/src/navigate/model/microscope.py
+++ b/src/navigate/model/microscope.py
@@ -977,7 +977,7 @@ class Microscope:
                 self.ret_pos_dict[key] = round(value, 2)
             except (TypeError, ValueError, OverflowError) as e:
                 logger.error(f"Error rounding {key} position value: {e}")
-        return self.ret_pos_dict
+        return self.ret_pos_dict.copy()
 
     def move_remote_focus(self, offset: Optional[float] = None) -> None:
         """Move remote focus.

--- a/src/navigate/model/model.py
+++ b/src/navigate/model/model.py
@@ -247,6 +247,9 @@ class Model:
         #: bool: Stop signal thread?
         self.stop_send_signal = False  # stop signal thread
 
+        #: bool: Signal side completed a finite acquisition.
+        self.signal_acquisition_complete = False
+
         #: event: Pause data event.
         self.pause_data_event = threading.Event()
 
@@ -787,7 +790,7 @@ class Model:
                 delattr(self, "signal_container")
                 delattr(self, "data_container")
 
-            if type(args[0]) == int:
+            if type(args[0]) is int:
                 self.addon_feature = None
                 if args[0] != 0:
                     if len(args) == 2:
@@ -803,7 +806,7 @@ class Model:
                     self.signal_container, self.data_container = load_features(
                         self, self.addon_feature
                     )
-            elif type(args[0]) == str:
+            elif type(args[0]) is str:
                 try:
                     if len(args) > 1:
                         self.addon_feature = [
@@ -1015,7 +1018,10 @@ class Model:
         accumulated_durations_ns = []
 
         # main data acquisition loop
-        while not self.stop_acquisition:
+        while (
+            not self.stop_acquisition
+            or self._should_drain_signal_completed_frames()
+        ):
             if self.ask_to_pause_data_thread:
                 self.pause_data_ready_lock.release()
                 self.pause_data_event.clear()
@@ -1119,6 +1125,18 @@ class Model:
 
         # Turn off the lasers/close the shutters
         self.end_acquisition()
+
+    def _should_drain_signal_completed_frames(self) -> bool:
+        """Return True when finite acquisition data should drain after signal stop."""
+
+        if not self.signal_acquisition_complete or self.imaging_mode == "live":
+            return False
+
+        data_container = getattr(self, "data_container", None)
+        if data_container is None or getattr(data_container, "root", None) is None:
+            return False
+
+        return not data_container.end_flag and not data_container.is_closed
 
     def pause_data_thread(self) -> None:
         """Pause the data thread.
@@ -1228,6 +1246,7 @@ class Model:
         if turn_off_flags:
             self.stop_acquisition = False
             self.stop_send_signal = False
+            self.signal_acquisition_complete = False
             self.injected_flag.value = False
             self.is_live = False
             self.available_image_count = 0
@@ -1441,6 +1460,8 @@ class Model:
                 self.grab_image(getattr(self.image_writer, "save_image", None))
             self.show_img_pipe.send("stop")
         if self.imaging_mode != "live":
+            if not self.stop_acquisition and not self.stop_send_signal:
+                self.signal_acquisition_complete = True
             self.stop_acquisition = True
 
         if not self.is_data_thread_on:
@@ -1991,6 +2012,8 @@ class ASIModel(Model):
                 self.stop_acquisition = True
                 return
         if self.imaging_mode != "live":
+            if not self.stop_acquisition and not self.stop_send_signal:
+                self.signal_acquisition_complete = True
             self.stop_acquisition = True
 
     def snap_zstack(self) -> None:

--- a/test/controller/sub_controllers/test_channels_tab.py
+++ b/test/controller/sub_controllers/test_channels_tab.py
@@ -32,6 +32,7 @@
 
 import random
 import copy
+from contextlib import contextmanager
 
 import pytest
 import numpy as np
@@ -47,6 +48,142 @@ def channels_tab_controller(dummy_controller):
     return ChannelsTabController(
         dummy_controller.view.settings.channels_tab, dummy_controller
     )
+
+
+@contextmanager
+def stage_limit_settings(channels_tab_controller, **limits):
+    configuration = channels_tab_controller.parent_controller.configuration
+    configuration_controller = (
+        channels_tab_controller.parent_controller.configuration_controller
+    )
+    microscope_name = configuration_controller.microscope_name
+    stage_config = configuration["configuration"]["microscopes"][microscope_name][
+        "stage"
+    ]
+    stage_parameters = configuration["experiment"]["StageParameters"]
+    original_limits = {key: stage_config.get(key) for key in limits}
+    original_limit_flag = stage_parameters.get("limits", True)
+    try:
+        for key, value in limits.items():
+            stage_config[key] = value
+        yield
+    finally:
+        for key, value in original_limits.items():
+            stage_config[key] = value
+        stage_parameters["limits"] = original_limit_flag
+
+
+def assert_spinbox_range(widget, from_value, to_value):
+    assert float(widget.cget("from")) == from_value
+    assert float(widget.cget("to")) == to_value
+
+
+@pytest.mark.parametrize(
+    "origin, expected_range",
+    [
+        (0, (0, 200)),
+        (100, (-100, 100)),
+    ],
+)
+def test_stack_position_limits_follow_stage_limits_for_z_axis(
+    channels_tab_controller, origin, expected_range
+):
+    with stage_limit_settings(
+        channels_tab_controller, z_min=0, z_max=200, f_min=-100000, f_max=100000
+    ):
+        channels_tab_controller.parent_controller.configuration["experiment"][
+            "StageParameters"
+        ]["limits"] = True
+        channels_tab_controller.z_origin = origin
+        channels_tab_controller.focus_origin = 0
+
+        channels_tab_controller.set_spinbox_range_limits(
+            channels_tab_controller.parent_controller.configuration["gui"]
+        )
+
+        for widget_name in ["start_position", "end_position"]:
+            assert_spinbox_range(
+                channels_tab_controller.stack_acq_widgets[widget_name].widget,
+                expected_range[0],
+                expected_range[1],
+            )
+
+
+def test_stack_position_limits_follow_stage_limits_for_focus_axis(
+    channels_tab_controller,
+):
+    with stage_limit_settings(
+        channels_tab_controller, z_min=-100000, z_max=100000, f_min=10, f_max=50
+    ):
+        channels_tab_controller.parent_controller.configuration["experiment"][
+            "StageParameters"
+        ]["limits"] = True
+        channels_tab_controller.z_origin = 0
+        channels_tab_controller.focus_origin = 20
+
+        channels_tab_controller.set_spinbox_range_limits(
+            channels_tab_controller.parent_controller.configuration["gui"]
+        )
+
+        for widget_name in ["start_focus", "end_focus"]:
+            assert_spinbox_range(
+                channels_tab_controller.stack_acq_widgets[widget_name].widget,
+                -10,
+                30,
+            )
+
+
+def test_stack_position_limits_fall_back_to_gui_config_when_stage_limits_disabled(
+    channels_tab_controller,
+):
+    with stage_limit_settings(channels_tab_controller, z_min=0, z_max=200):
+        configuration = channels_tab_controller.parent_controller.configuration
+        configuration["experiment"]["StageParameters"]["limits"] = False
+
+        channels_tab_controller.set_spinbox_range_limits(configuration["gui"])
+
+        stack_config = configuration["gui"]["stack_acquisition"]
+        assert_spinbox_range(
+            channels_tab_controller.stack_acq_widgets["start_position"].widget,
+            stack_config["z_start_pos"]["min"],
+            stack_config["z_start_pos"]["max"],
+        )
+        assert_spinbox_range(
+            channels_tab_controller.stack_acq_widgets["end_position"].widget,
+            stack_config["z_end_pos"]["min"],
+            stack_config["z_end_pos"]["max"],
+        )
+
+
+def test_verify_experiment_values_rejects_out_of_range_stack_position(
+    channels_tab_controller,
+):
+    with stage_limit_settings(
+        channels_tab_controller, z_min=0, z_max=200, f_min=-100000, f_max=100000
+    ):
+        configuration = channels_tab_controller.parent_controller.configuration
+        configuration["experiment"]["StageParameters"]["limits"] = True
+        channels_tab_controller.microscope_state_dict = configuration["experiment"][
+            "MicroscopeState"
+        ]
+        channels_tab_controller.channel_setting_controller.channel_setting_dict = (
+            channels_tab_controller.microscope_state_dict["channels"]
+        )
+        channels_tab_controller.z_origin = 100
+        channels_tab_controller.focus_origin = 0
+        channels_tab_controller.microscope_state_dict["image_mode"] = "z-stack"
+        channels_tab_controller.microscope_state_dict["number_z_steps"] = 1
+        channels_tab_controller.stack_acq_vals["number_z_steps"].set(1)
+        channels_tab_controller.microscope_state_dict["timepoints"] = 1
+        channels_tab_controller.microscope_state_dict["stack_pause"] = 0
+        channels_tab_controller.microscope_state_dict["start_position"] = -101
+        channels_tab_controller.microscope_state_dict["end_position"] = 0
+        channels_tab_controller.microscope_state_dict["start_focus"] = 0
+        channels_tab_controller.microscope_state_dict["end_focus"] = 0
+
+        warning = channels_tab_controller.verify_experiment_values()
+
+        assert "start_position is outside the z stage limits" in warning
 
 
 def test_update_z_steps(channels_tab_controller):

--- a/test/controller/test_controller.py
+++ b/test/controller/test_controller.py
@@ -8,9 +8,6 @@ import logging
 import platform
 from logging.handlers import QueueHandler
 
-from navigate.log_files.log_functions import log_setup
-
-
 class _NullQueue:
     """Minimal queue-like sink for logging; avoids mp feeder threads on Windows."""
 
@@ -489,13 +486,30 @@ def test_execute_update_setting(controller):
 
 def test_execute_stage_limits(controller):
     controller.threads_pool.createThread = MagicMock()
+    controller.channels_tab_controller.update_stack_position_limits = MagicMock()
     for stage_limits in [True, False]:
         controller.threads_pool.createThread.reset_mock()
+        controller.channels_tab_controller.update_stack_position_limits.reset_mock()
         controller.execute("stage_limits", stage_limits)
         assert controller.stage_controller.stage_limits == stage_limits
+        controller.channels_tab_controller.update_stack_position_limits.assert_called_once()
         assert controller.threads_pool.createThread.called is True
 
     assert True
+
+
+def test_execute_update_stage_limits_refreshes_stack_position_limits(controller):
+    controller.threads_pool.createThread = MagicMock()
+    controller.stage_controller.initialize = MagicMock()
+    controller.channels_tab_controller.update_stack_position_limits = MagicMock()
+
+    controller.execute(
+        "update_stage_limits", controller.configuration_controller.microscope_name
+    )
+
+    controller.stage_controller.initialize.assert_called_once()
+    controller.channels_tab_controller.update_stack_position_limits.assert_called_once()
+    assert controller.threads_pool.createThread.called is True
 
 
 def test_execute_autofocus(controller):

--- a/test/model/test_model.py
+++ b/test/model/test_model.py
@@ -33,6 +33,7 @@
 import random
 import pytest
 import os
+from types import SimpleNamespace
 from multiprocessing import Manager
 from unittest.mock import MagicMock
 import multiprocessing
@@ -155,6 +156,84 @@ def test_single_acquisition(model):
     model.release_pipe("show_img_pipe")
 
 
+def test_run_acquisition_marks_finite_signal_completion_for_data_thread():
+    from navigate.model.model import Model
+
+    model = SimpleNamespace(
+        signal_container=SimpleNamespace(end_flag=False, is_closed=False),
+        stop_send_signal=False,
+        stop_acquisition=False,
+        imaging_mode="single",
+        is_data_thread_on=True,
+        logger=MagicMock(),
+    )
+
+    def snap_image():
+        model.signal_container.end_flag = True
+
+    model.snap_image = snap_image
+
+    Model.run_acquisition(model)
+
+    assert model.stop_acquisition is True
+    assert model.signal_acquisition_complete is True
+
+
+def test_run_data_process_drains_pending_frames_after_signal_completion():
+    from navigate.model.model import Model
+
+    class FakeCamera:
+        def __init__(self):
+            self.frames = [[0, 1, 2]]
+
+        def get_new_frame(self):
+            return self.frames.pop(0)
+
+    class FakeDataContainer:
+        root = object()
+        is_closed = False
+
+        def __init__(self):
+            self.end_flag = False
+            self.received_frames = []
+
+        def run(self, frame_ids):
+            self.received_frames.extend(frame_ids)
+            self.end_flag = True
+
+    class FakePipe:
+        def __init__(self):
+            self.sent = []
+
+        def send(self, value):
+            self.sent.append(value)
+
+    data_container = FakeDataContainer()
+    show_img_pipe = FakePipe()
+    model = SimpleNamespace(
+        active_microscope=SimpleNamespace(camera=FakeCamera()),
+        ask_to_pause_data_thread=False,
+        camera_wait_iterations=1,
+        data_container=data_container,
+        event_queue=MagicMock(),
+        imaging_mode="single",
+        logger=MagicMock(),
+        pause_data_ready_lock=MagicMock(locked=MagicMock(return_value=False)),
+        show_img_pipe=show_img_pipe,
+        signal_acquisition_complete=True,
+        stop_acquisition=True,
+    )
+    model.end_acquisition = MagicMock()
+    model._should_drain_signal_completed_frames = (
+        Model._should_drain_signal_completed_frames.__get__(model, type(model))
+    )
+
+    Model.run_data_process(model)
+
+    assert data_container.received_frames == [0, 1, 2]
+    assert show_img_pipe.sent == [2, "stop"]
+
+
 def test_live_acquisition(model):
     state = model.configuration["experiment"]["MicroscopeState"]
     state["image_mode"] = "live"
@@ -195,7 +274,6 @@ def test_autofocus_live_acquisition(model):
 
     n_images = 0
     seen_channels = set()
-    autofocus = False
 
     show_img_pipe = model.create_pipe("show_img_pipe")
 
@@ -210,10 +288,7 @@ def test_autofocus_live_acquisition(model):
         n_images += 1
         if n_images >= 100:
             model.run_command("stop")
-        elif n_images >= 70:
-            autofocus = False
         elif n_images == 30:
-            autofocus = True
             model.run_command("autofocus")
 
     model.data_thread.join()


### PR DESCRIPTION
## Summary
- derive stack Z/F start and end widget bounds from active microscope stage limits in `configuration.yaml`
- keep `gui_configuration.yml` stack position bounds as the fallback when stage limits are disabled or unavailable
- refresh stack bounds after origin updates, selected stack-device changes, and stage-limit setting changes
- validate saved/programmatic stack bounds during acquisition verification

Fixes #969.

## Validation
- `conda run -n navigate python -m pytest test/controller/sub_controllers/test_channels_tab.py -q`
- `conda run -n navigate python -m pytest test/controller/test_controller.py::test_execute_stage_limits test/controller/test_controller.py::test_execute_update_stage_limits_refreshes_stack_position_limits -q`
- `conda run -n navigate python -m pytest test/controller/sub_controllers/test_channels_tab.py::test_update_z_steps test/controller/sub_controllers/test_channels_tab.py::test_update_start_position test/controller/sub_controllers/test_channels_tab.py::test_update_end_position -q`
- `ruff check src/navigate/controller/controller.py src/navigate/controller/sub_controllers/channels_tab.py test/controller/sub_controllers/test_channels_tab.py test/controller/test_controller.py`
- `git diff --check`