### PR TITLE
Random fix: handle missing camera config values and persist channel setting update

### DIFF
--- a/src/navigate/controller/configuration_controller.py
+++ b/src/navigate/controller/configuration_controller.py
@@ -99,7 +99,10 @@ class ConfigurationController:
             microscope_name = self.configuration["experiment"]["MicroscopeState"][
                 "microscope_name"
             ]
-        if microscope_name not in self.configuration["configuration"]["microscopes"].keys():
+        if (
+            microscope_name
+            not in self.configuration["configuration"]["microscopes"].keys()
+        ):
             logger.warning(
                 f"Microscope {microscope_name} not found in configuration. Available microscopes: "
                 f" {list(self.configuration['configuration']['microscopes'].keys())}"
@@ -148,7 +151,9 @@ class ConfigurationController:
         setting = {
             "laser": self.lasers_info,
         }
-        for i, filter_wheel_config in enumerate(self.microscope_config.get("filter_wheel", [])):
+        for i, filter_wheel_config in enumerate(
+            self.microscope_config.get("filter_wheel", [])
+        ):
             filter_wheel_name = filter_wheel_config.get("name", f"FilterWheel-{i}")
             setting[filter_wheel_name] = list(
                 filter_wheel_config["available_filters"].keys()
@@ -624,6 +629,25 @@ class ConfigurationController:
         return self.configuration["waveform_constants"]["remote_focus_constants"][
             microscope_name
         ].keys()
+
+    def get_zoom_pixel_sizes(self, microscope_name: str) -> dict:
+        """Return a dictionary of pixel sizes
+
+        Returns
+        -------
+        pixel_size_dict : dict
+            A dictionary of pixel sizes: {zoom_value : pixel_size}
+        """
+        if (
+            microscope_name is None
+            or microscope_name
+            not in self.configuration["configuration"]["microscopes"].keys()
+        ):
+            microscope_name = self.microscope_name
+
+        return self.configuration["configuration"]["microscopes"][microscope_name][
+            "zoom"
+        ]["pixel_size"].copy()
 
     @property
     def gui_setting(self) -> dict:

--- a/src/navigate/controller/configuration_controller.py
+++ b/src/navigate/controller/configuration_controller.py
@@ -99,6 +99,12 @@ class ConfigurationController:
             microscope_name = self.configuration["experiment"]["MicroscopeState"][
                 "microscope_name"
             ]
+        if microscope_name not in self.configuration["configuration"]["microscopes"].keys():
+            logger.warning(
+                f"Microscope {microscope_name} not found in configuration. Available microscopes: "
+                f" {list(self.configuration['configuration']['microscopes'].keys())}"
+            )
+            return False
 
         assert (
             microscope_name in self.configuration["configuration"]["microscopes"].keys()

--- a/src/navigate/controller/controller.py
+++ b/src/navigate/controller/controller.py
@@ -679,7 +679,7 @@ class Controller:
         )
         self.set_mode_of_sub("stop")
 
-    def change_microscope(self, microscope_name: str, zoom: str | None = None) -> None:
+    def change_microscope(self, microscope_name: str, zoom: str | None = None) -> bool:
         """Change the microscope configuration.
 
         Parameters
@@ -691,28 +691,95 @@ class Controller:
 
         Returns
         -------
-        None
+        bool
+            ``True`` when the microscope or zoom is updated successfully,
+            otherwise ``False``.
         """
-        self.configuration["experiment"]["MicroscopeState"][
-            "microscope_name"
-        ] = microscope_name
-        if zoom:
+        if self.configuration_controller.change_microscope(microscope_name):
+            supported_zoom = list(
+                self.configuration_controller.get_zoom_value_list(microscope_name)
+            )
+            if not supported_zoom:
+                messagebox.showwarning(
+                    title="Navigate",
+                    message=(
+                        f"No zoom values are configured for microscope "
+                        f"'{microscope_name}'. Please update the configuration YAML."
+                    ),
+                )
+                return False
+            if zoom not in supported_zoom:
+                fallback_zoom = supported_zoom[0]
+                messagebox.showwarning(
+                    title="Navigate",
+                    message=(
+                        f"Zoom '{zoom}' is not available for microscope "
+                        f"'{microscope_name}'. Using '{fallback_zoom}' instead."
+                    ),
+                )
+                zoom = fallback_zoom
+
+            # update microscope name
+            self.configuration["experiment"]["MicroscopeState"][
+                "microscope_name"
+            ] = microscope_name
+            # set zoom value
             self.configuration["experiment"]["MicroscopeState"]["zoom"] = zoom
-        if self.configuration_controller.change_microscope():
             # update widgets
             self.stage_controller.initialize()
             self.channels_tab_controller.initialize()
             self.channels_tab_controller.populate_experiment_values()
             self.camera_setting_controller.update_camera_device_related_setting()
             self.camera_setting_controller.populate_experiment_values()
-            self.camera_setting_controller.calculate_physical_dimensions()
+            r = self.camera_setting_controller.calculate_physical_dimensions()
+            if not r:
+                messagebox.showwarning(
+                    title="Navigate",
+                    message=(
+                        f"Please make sure a valid pixel size is configured for zoom "
+                        f"'{zoom}' on microscope '{microscope_name}' in the "
+                        "configuration YAML."
+                    ),
+                )
             self.camera_view_controller.update_snr()
-
+            result = True
+        elif self.configuration_controller.microscope_name == microscope_name:
+            # update zoom only if it's valid
+            if zoom != self.configuration["experiment"]["MicroscopeState"][
+                "zoom"
+            ] and zoom in self.configuration_controller.get_zoom_value_list(
+                microscope_name
+            ):
+                self.configuration["experiment"]["MicroscopeState"]["zoom"] = zoom
+                r = self.camera_setting_controller.calculate_physical_dimensions()
+                if not r:
+                    messagebox.showwarning(
+                        title="Navigate",
+                        message=(
+                            f"Please make sure a valid pixel size is configured for "
+                            f"zoom '{zoom}' on microscope '{microscope_name}' in the "
+                            "configuration YAML."
+                        ),
+                    )
+                result = True
+            else:
+                result = False
+        else:
+            messagebox.showwarning(
+                title="Navigate",
+                message=(
+                    f"Microscope '{microscope_name}' is not configured."
+                    if not zoom
+                    else f"Microscope '{microscope_name}' with zoom '{zoom}' is not configured."
+                ),
+            )
+            return False
         if (
             hasattr(self, "waveform_popup_controller")
             and self.waveform_popup_controller
         ):
             self.waveform_popup_controller.populate_experiment_values()
+        return result
 
     def initialize_cam_view(self) -> None:
         """Populate view and maximum intensity projection tabs.
@@ -767,6 +834,7 @@ class Controller:
             "microscope_name"
         ]
         self.configuration_controller.change_microscope()
+        self.camera_setting_controller.populate_experiment_values()
         self.menu_controller.resolution_value.set(
             f"{microscope_name} "
             f"{self.configuration['experiment']['MicroscopeState']['zoom']}"
@@ -785,7 +853,6 @@ class Controller:
             self.configuration["multi_positions"]
         )
         self.channels_tab_controller.populate_experiment_values()
-        self.camera_setting_controller.populate_experiment_values()
         self.waveform_tab_controller.set_waveform_template(
             self.configuration["experiment"]["MicroscopeState"]["waveform_template"]
         )
@@ -1127,6 +1194,7 @@ class Controller:
             if resolution_value != self.menu_controller.resolution_value.get():
                 self.menu_controller.resolution_value.set(resolution_value)
                 return
+
             self.change_microscope(temp[0], temp[1])
             work_thread = self.threads_pool.createThread(
                 resourceName="model",
@@ -1255,10 +1323,6 @@ class Controller:
                 filename="multi_positions.yml",
             )
 
-            self.camera_setting_controller.solvent = self.configuration["experiment"][
-                "Saving"
-            ]["solvent"]
-            self.camera_setting_controller.calculate_physical_dimensions()
             self.execute("acquire")
 
         elif command == "acquire":

--- a/src/navigate/controller/sub_controllers/camera_settings.py
+++ b/src/navigate/controller/sub_controllers/camera_settings.py
@@ -361,9 +361,6 @@ class CameraSettingController(GUIController):
         #: str: Mode value
         self.mode = "stop"
 
-        #: str: Solvent type
-        self.solvent = "BABB"
-
         # Getting Widgets/Buttons
 
         #: dict: Mode widgets
@@ -625,6 +622,13 @@ class CameraSettingController(GUIController):
 
         self.roi_widgets["Width"].set(x_pixels)
         self.roi_widgets["Height"].set(y_pixels)
+        if self.calculate_physical_dimensions() is False:
+            return (
+                "Image physical dimensions could not be calculated from the "
+                "current microscope configuration.\n\n"
+                "Please verify that the zoom value and pixel size are "
+                "configured correctly in the configuration YAML."
+            )
         self.camera_setting_dict["fov_x"] = self.roi_widgets["FOV_X"].get()
         self.camera_setting_dict["fov_y"] = self.roi_widgets["FOV_Y"].get()
 
@@ -839,41 +843,63 @@ class CameraSettingController(GUIController):
         system, the physical size of the pixel, and the number of pixels.
         update FOV_X and FOV_Y
 
-        TODO: Should make sure that this is updated before we run the tiling wizard.
-        Also can probably be done more elegantly in a configuration file and
-        dictionary structure.
+        Returns
+        -------
+        bool
+            True if the calculation is successful.
         """
-
-        # pixel_size = self.default_pixel_size
         try:
             x_pixel = float(self.roi_widgets["Width"].get())
             y_pixel = float(self.roi_widgets["Height"].get())
         except ValueError:
-            return
+            return False
 
         microscope_state_dict = self.parent_controller.configuration["experiment"][
             "MicroscopeState"
         ]
         zoom = microscope_state_dict["zoom"]
-        # TODO: calculate fov_x and fov_y for additional microscopes
         if self.microscope_name:
-            return
-        microscope_name = microscope_state_dict["microscope_name"]
-        try:
-            pixel_size = self.parent_controller.configuration["configuration"][
-                "microscopes"
-            ][microscope_name]["zoom"]["pixel_size"][zoom]
-        except KeyError:
-            logger.warning(
-                f"Pixel size for microscope {microscope_name} and zoom {zoom} not found."
-            )
-            return
+            # Set the zoom value and save the pixel size to the camera settings when enabling the additional microscope for acquisition.
+            try:
+                pixel_size = float(self.camera_setting_dict["pixel_size"])
+            except (KeyError, ValueError):
+                logger.warning(
+                    f"Invalid pixel size configured for microscope "
+                    f"'{self.microscope_name}' at zoom '{zoom}' in the "
+                    "configuration YAML."
+                )
+                return False
+
+        else:
+            microscope_name = microscope_state_dict["microscope_name"]
+            try:
+                pixel_size = float(
+                    self.parent_controller.configuration["configuration"][
+                        "microscopes"
+                    ][microscope_name]["zoom"]["pixel_size"][zoom]
+                )
+            except KeyError:
+                logger.warning(
+                    f"No pixel size is configured for microscope "
+                    f"'{microscope_name}' at zoom '{zoom}' in the configuration YAML."
+                )
+                return False
+            except ValueError:
+                logger.warning(
+                    f"Invalid pixel size configured for microscope "
+                    f"'{microscope_name}' at zoom '{zoom}' in the "
+                    "configuration YAML."
+                )
+                return False
 
         physical_dimensions_x = x_pixel * pixel_size
         physical_dimensions_y = y_pixel * pixel_size
 
+        # Updating these widget values automatically syncs them with the Tiling Wizard.
         self.roi_widgets["FOV_X"].set(physical_dimensions_x)
         self.roi_widgets["FOV_Y"].set(physical_dimensions_y)
+
+        return True
 
     def update_readout_time(self):
         """Update camera readout time.

--- a/src/navigate/controller/sub_controllers/camera_settings.py
+++ b/src/navigate/controller/sub_controllers/camera_settings.py
@@ -859,9 +859,15 @@ class CameraSettingController(GUIController):
         if self.microscope_name:
             return
         microscope_name = microscope_state_dict["microscope_name"]
-        pixel_size = self.parent_controller.configuration["configuration"][
-            "microscopes"
-        ][microscope_name]["zoom"]["pixel_size"][zoom]
+        try:
+            pixel_size = self.parent_controller.configuration["configuration"][
+                "microscopes"
+            ][microscope_name]["zoom"]["pixel_size"][zoom]
+        except KeyError:
+            logger.warning(
+                f"Pixel size for microscope {microscope_name} and zoom {zoom} not found."
+            )
+            return
 
         physical_dimensions_x = x_pixel * pixel_size
         physical_dimensions_y = y_pixel * pixel_size

--- a/src/navigate/controller/sub_controllers/camera_view.py
+++ b/src/navigate/controller/sub_controllers/camera_view.py
@@ -1328,6 +1328,13 @@ class BaseViewController(GUIController, ABaseViewController):
             self.canvas_width = r_canvas_width
             self.canvas_height = int(r_canvas_width / img_ratio)
 
+        # minimum canvas height and width is 1
+        if self.canvas_width < 1:
+            self.canvas_width = 1
+
+        if self.canvas_height < 1:
+            self.canvas_height = 1
+
         self.canvas_width_scale = float(self.original_image_width / self.canvas_width)
         self.canvas_height_scale = float(
             self.original_image_height / self.canvas_height

--- a/src/navigate/controller/sub_controllers/channels_settings.py
+++ b/src/navigate/controller/sub_controllers/channels_settings.py
@@ -426,6 +426,8 @@ class ChannelSettingController(GUIController):
 
             r = update_setting_dict(setting_dict, widget_name)
 
+            self.channel_setting_dict[channel_key] = setting_dict
+
             if self.mode == "live":
                 # call central controller
                 if self.event_id:

--- a/src/navigate/controller/sub_controllers/microscope_popup.py
+++ b/src/navigate/controller/sub_controllers/microscope_popup.py
@@ -100,6 +100,37 @@ class MicroscopePopupController(GUIController):
                 "<<ComboboxSelected>>", self.update_microscope_mode(microscope_name)
             )
 
+            # zoom value
+            zoom_values = list(
+                self.parent_controller.configuration_controller.get_zoom_pixel_sizes(
+                    microscope_name
+                ).keys()
+            )
+            self.widgets[f"{microscope_name}_zoom_value"].widget.config(
+                values=zoom_values
+            )
+
+        # primary microscope
+        microscope_name = self.parent_controller.configuration["experiment"][
+            "MicroscopeState"
+        ]["microscope_name"]
+        self.variables[microscope_name].set("Primary Microscope")
+        self.primary_microscope = microscope_name
+
+        # additional microscopes
+        additional_microscopes = (
+            self.parent_controller.configuration["experiment"]["MicroscopeState"]
+            .get("additional_microscopes", "")
+            .split(",")
+        )
+        for microscope_name in additional_microscopes:
+            if microscope_name:
+                self.variables[microscope_name].set("Additional Microscope")
+                zoom = self.parent_controller.configuration["experiment"][
+                    "CameraParameters"
+                ][microscope_name].get("zoom", "")
+                if zoom:
+                    self.variables[f"{microscope_name}_zoom_value"].set(zoom)
         # button events
         self.buttons["confirm"].configure(command=self.confirm_microscope_setting)
         self.buttons["cancel"].configure(command=self.exit_func)
@@ -205,6 +236,7 @@ class MicroscopePopupController(GUIController):
             )
 
         has_multi_cameras = False
+        additional_microscopes = []
         for microscope_name in self.microscope_info.keys():
             if self.variables[microscope_name].get() == "Additional Microscope":
                 config = {}
@@ -214,12 +246,37 @@ class MicroscopePopupController(GUIController):
                     microscope_name
                 ] = config
                 has_multi_cameras = True
+                # update the zoom value setting
+                pixel_sizes = self.parent_controller.configuration_controller.get_zoom_pixel_sizes(
+                    microscope_name
+                )
+                zoom = self.variables[f"{microscope_name}_zoom_value"].get()
+                if not zoom or zoom.strip() == "":
+                    tkinter.messagebox.showerror(
+                        title="Warning",
+                        message=f"Please set the zoom value for the microscope {microscope_name}.",
+                    )
+                    self.showup()
+                    return False
+                self.parent_controller.configuration["experiment"]["CameraParameters"][
+                    microscope_name
+                ]["pixel_size"] = pixel_sizes[zoom]
+                self.parent_controller.configuration["experiment"]["CameraParameters"][
+                    microscope_name
+                ]["zoom"] = zoom
+                additional_microscopes.append(microscope_name)
+
             elif (
                 microscope_name in self.parent_controller.additional_microscopes_configs
             ):
                 del self.parent_controller.additional_microscopes_configs[
                     microscope_name
                 ]
+
+        # save additional microscope info
+        self.parent_controller.configuration["experiment"]["MicroscopeState"][
+            "additional_microscopes"
+        ] = ",".join(additional_microscopes)
 
         # enable/disable change 'resolution'(microscope) menu if there are multiple
         # cameras running

--- a/src/navigate/tools/common_functions.py
+++ b/src/navigate/tools/common_functions.py
@@ -96,22 +96,12 @@ def copy_proxy_object(content: Any) -> Any:
     result
         The serialized object.
     """
-    from multiprocessing import managers
-
-    def func(content: Any) -> Any:
-        if type(content) is managers.DictProxy:
-            result = {}
-            for k in content.keys():
-                result[k] = func(content[k])
-        elif type(content) is managers.ListProxy:
-            result = []
-            for v in content:
-                result.append(func(v))
-        else:
-            result = content
-        return result
-
-    return func(content)
+    if hasattr(content, "items"):
+        return {k: copy_proxy_object(v) for k, v in content.items()}
+    elif hasattr(content, "append") or isinstance(content, list):
+        return [copy_proxy_object(v) for v in content]
+    else:
+        return content
 
 
 def load_module_from_file(module_name: str, file_path: str) -> Optional[Any]:

--- a/src/navigate/view/popups/microscope_setting_popup_window.py
+++ b/src/navigate/view/popups/microscope_setting_popup_window.py
@@ -114,6 +114,8 @@ class MicroscopeSettingPopupWindow:
                 device = " ".join(map(lambda v: v.capitalize(), k.split("_")))
                 if device not in self.labels:
                     self.labels.append(device)
+
+        self.labels.append("Zoom Value")
         self.labels.append("Setting")
 
         for i, name in enumerate(self.labels):
@@ -180,7 +182,7 @@ class MicroscopeSettingPopupWindow:
                 padx=get_theme_padding_px((0, 5)),
                 pady=get_theme_padding_px((5, 16)),
             )
-            for i in range(1, len(self.labels) - 1):
+            for i in range(1, len(self.labels) - 2):
                 device_ref_name = build_ref_name(
                     "_", *self.labels[i].lower().split(" ")
                 )
@@ -200,6 +202,23 @@ class MicroscopeSettingPopupWindow:
                     pady=get_theme_padding_px((2, 0)),
                 )
                 self.inputs[f"{microscope_name} {device_ref_name}"] = entry
+
+            # add zoom value
+            combo = LabelInput(
+                parent=frame,
+                input_class=ttk.Combobox,
+                input_var=tk.StringVar(),
+                label_args={"padding": (0, 0, 5, 20)},
+            )
+            combo.grid(
+                row=len(self.labels) - 1,
+                column=0,
+                sticky=tk.SE,
+                padx=get_theme_padding_px((2, 5)),
+                pady=get_theme_padding_px((2, 0)),
+            )
+            combo.widget.config(state="readonly")
+            self.inputs[f"{microscope_name}_zoom_value"] = combo
             # usage
             combo = LabelInput(
                 parent=frame,

--- a/test/controller/sub_controllers/test_camera_settings.py
+++ b/test/controller/sub_controllers/test_camera_settings.py
@@ -158,7 +158,6 @@ class TestCameraSettingController:
             "in_initialization",
             "resolution_value",
             "mode",
-            "solvent",
             "mode_widgets",
             "framerate_widgets",
             "roi_widgets",
@@ -485,39 +484,40 @@ class TestCameraSettingController:
         for btn_name in self.camera_settings.roi_btns:
             assert str(self.camera_settings.roi_btns[btn_name]["state"]) == state
 
-    @pytest.mark.parametrize("zoom", ["0.63x", "1x", "2x", "3x", "4x", "5x", "6x"])
-    def test_calculate_physical_dimensions(self, zoom):
-        self.camera_settings.parent_controller.configuration["experiment"][
-            "MicroscopeState"
-        ]["zoom"] = zoom
-
-        self.camera_settings.populate_experiment_values()
-
-        # Calling
-        self.camera_settings.calculate_physical_dimensions()
-
-        pixel_size = self.camera_settings.default_pixel_size
-        x_pixel = float(self.camera_settings.roi_widgets["Width"].get())
-        y_pixel = float(self.camera_settings.roi_widgets["Height"].get())
-
+    def test_calculate_physical_dimensions(self):
         microscope_state_dict = self.camera_settings.parent_controller.configuration[
             "experiment"
         ]["MicroscopeState"]
-        zoom = microscope_state_dict["zoom"]
         microscope_name = microscope_state_dict["microscope_name"]
-        pixel_size = self.camera_settings.parent_controller.configuration[
-            "configuration"
-        ]["microscopes"][microscope_name]["zoom"]["pixel_size"][zoom]
-
-        dim_x = x_pixel * pixel_size
-        dim_y = y_pixel * pixel_size
-
-        assert float(self.camera_settings.roi_widgets["FOV_X"].get()) == float(
-            int(dim_x)
+        zoom_values = list(
+            self.camera_settings.parent_controller.configuration["configuration"][
+                "microscopes"
+            ][microscope_name]["zoom"]["pixel_size"].keys()
         )
-        assert float(self.camera_settings.roi_widgets["FOV_Y"].get()) == float(
-            int(dim_y)
-        )
+
+        for zoom in zoom_values:
+            microscope_state_dict["zoom"] = zoom
+            self.camera_settings.populate_experiment_values()
+
+            assert self.camera_settings.calculate_physical_dimensions() is True
+
+            x_pixel = float(self.camera_settings.roi_widgets["Width"].get())
+            y_pixel = float(self.camera_settings.roi_widgets["Height"].get())
+            pixel_size = float(
+                self.camera_settings.parent_controller.configuration["configuration"][
+                    "microscopes"
+                ][microscope_name]["zoom"]["pixel_size"][zoom]
+            )
+
+            dim_x = x_pixel * pixel_size
+            dim_y = y_pixel * pixel_size
+
+            assert float(self.camera_settings.roi_widgets["FOV_X"].get()) == float(
+                int(dim_x)
+            )
+            assert float(self.camera_settings.roi_widgets["FOV_Y"].get()) == float(
+                int(dim_y)
+            )
 
     def test_calculate_physical_dimensions_missing_pixel_size(self, caplog):
         self.camera_settings.populate_experiment_values()
@@ -536,15 +536,16 @@ class TestCameraSettingController:
 
         try:
             with caplog.at_level("WARNING", logger="navigate"):
-                self.camera_settings.calculate_physical_dimensions()
+                result = self.camera_settings.calculate_physical_dimensions()
         finally:
             pixel_size_config[zoom] = original_pixel_size
 
+        assert result is False
         assert self.camera_settings.roi_widgets["FOV_X"].get() == original_fov_x
         assert self.camera_settings.roi_widgets["FOV_Y"].get() == original_fov_y
         assert (
-            f"Pixel size for microscope {microscope_name} and zoom {zoom} not found."
-            in caplog.text
+            f"No pixel size is configured for microscope '{microscope_name}' "
+            f"at zoom '{zoom}' in the configuration YAML." in caplog.text
         )
 
         # Reset to zoom of 1
@@ -556,6 +557,22 @@ class TestCameraSettingController:
                 "MicroscopeState"
             ]["zoom"]
             == "1x"
+        )
+
+    def test_update_experiment_values_returns_warning_when_physical_dimensions_fail(
+        self,
+    ):
+        self.camera_settings.populate_experiment_values()
+        self.camera_settings.calculate_physical_dimensions = lambda: False
+
+        warning = self.camera_settings.update_experiment_values()
+
+        assert (
+            warning
+            == "Image physical dimensions could not be calculated from the current "
+            "microscope configuration.\n\n"
+            "Please verify that the zoom value and pixel size are configured "
+            "correctly in the configuration YAML."
         )
 
     def test_calculate_readout_time(self):

--- a/test/controller/sub_controllers/test_camera_settings.py
+++ b/test/controller/sub_controllers/test_camera_settings.py
@@ -519,6 +519,34 @@ class TestCameraSettingController:
             int(dim_y)
         )
 
+    def test_calculate_physical_dimensions_missing_pixel_size(self, caplog):
+        self.camera_settings.populate_experiment_values()
+
+        microscope_state = self.camera_settings.parent_controller.configuration[
+            "experiment"
+        ]["MicroscopeState"]
+        microscope_name = microscope_state["microscope_name"]
+        zoom = microscope_state["zoom"]
+        pixel_size_config = self.camera_settings.parent_controller.configuration[
+            "configuration"
+        ]["microscopes"][microscope_name]["zoom"]["pixel_size"]
+        original_fov_x = self.camera_settings.roi_widgets["FOV_X"].get()
+        original_fov_y = self.camera_settings.roi_widgets["FOV_Y"].get()
+        original_pixel_size = pixel_size_config.pop(zoom)
+
+        try:
+            with caplog.at_level("WARNING", logger="navigate"):
+                self.camera_settings.calculate_physical_dimensions()
+        finally:
+            pixel_size_config[zoom] = original_pixel_size
+
+        assert self.camera_settings.roi_widgets["FOV_X"].get() == original_fov_x
+        assert self.camera_settings.roi_widgets["FOV_Y"].get() == original_fov_y
+        assert (
+            f"Pixel size for microscope {microscope_name} and zoom {zoom} not found."
+            in caplog.text
+        )
+
         # Reset to zoom of 1
         self.camera_settings.parent_controller.configuration["experiment"][
             "MicroscopeState"

--- a/test/controller/sub_controllers/test_channels_settings.py
+++ b/test/controller/sub_controllers/test_channels_settings.py
@@ -29,6 +29,8 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 #
+from multiprocessing import Manager
+
 import pytest
 
 
@@ -191,3 +193,30 @@ class TestChannelSettingController:
     def test_get_index(self):
         # Not needed to test IMO
         pass
+
+    def test_channel_callback_persists_updates_in_proxy_dict(self):
+        with Manager() as manager:
+            self.channel_setting.channel_setting_dict = manager.dict(
+                {
+                    "channel_1": {
+                        "is_selected": False,
+                        "laser": self.channel_setting.view.laser_variables[0].get(),
+                        "laser_index": 0,
+                        "camera_exposure_time": 50.0,
+                        "laser_power": 10.0,
+                        "interval_time": 1.0,
+                        "defocus": 0.0,
+                    }
+                }
+            )
+            self.channel_setting.in_initialization = False
+
+            self.channel_setting.view.exptime_variables[0].set(125.0)
+            self.channel_setting.channel_callback(0, "camera_exposure_time")()
+
+            assert (
+                self.channel_setting.channel_setting_dict["channel_1"][
+                    "camera_exposure_time"
+                ]
+                == 125.0
+            )

--- a/test/controller/test_configuration_controller.py
+++ b/test/controller/test_configuration_controller.py
@@ -116,3 +116,16 @@ def test_filter_wheel_visibility_listproxy(configuration):
         controller = ConfigurationController(configuration)
 
         assert controller.filter_wheel_visibility == [True, False]
+
+
+def test_change_microscope_logs_warning_for_missing_name(configuration, caplog):
+    controller = ConfigurationController(configuration)
+
+    with caplog.at_level("WARNING", logger="navigate"):
+        result = controller.change_microscope("missing_scope")
+
+    assert result is False
+    assert controller.microscope_name == "scope_a"
+    assert "Microscope missing_scope not found in configuration." in caplog.text
+    assert "scope_a" in caplog.text
+    assert "scope_b" in caplog.text

--- a/test/controller/test_controller.py
+++ b/test/controller/test_controller.py
@@ -1,12 +1,13 @@
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import MagicMock, ANY
+from unittest.mock import MagicMock, ANY, patch
 import pytest
 import numpy
 import multiprocessing as mp
 import logging
 import platform
 from logging.handlers import QueueHandler
+
 
 class _NullQueue:
     """Minimal queue-like sink for logging; avoids mp feeder threads on Windows."""
@@ -24,6 +25,17 @@ class _NullQueue:
 class DummySplashScreen:
     def destroy(self):
         pass
+
+
+@pytest.fixture(autouse=True)
+def suppress_controller_messageboxes():
+    with (
+        patch(
+            "navigate.controller.controller.messagebox.showwarning", return_value=None
+        ),
+        patch("navigate.controller.controller.messagebox.showerror", return_value=None),
+    ):
+        yield
 
 
 def _normalize_log_setup(start_listener):
@@ -329,6 +341,119 @@ def test_change_microscope(controller):
         )
 
         assert True
+
+
+def test_change_microscope_invalid_zoom_falls_back(controller):
+    microscope_name = controller.configuration_controller.microscope_list[0]
+    supported_zoom = list(
+        controller.configuration_controller.get_zoom_value_list(microscope_name)
+    )
+    fallback_zoom = supported_zoom[0]
+
+    with (
+        patch.object(
+            controller.configuration_controller, "change_microscope", return_value=True
+        ),
+        patch.object(controller.stage_controller, "initialize"),
+        patch.object(controller.channels_tab_controller, "initialize"),
+        patch.object(controller.channels_tab_controller, "populate_experiment_values"),
+        patch.object(
+            controller.camera_setting_controller, "update_camera_device_related_setting"
+        ),
+        patch.object(
+            controller.camera_setting_controller, "populate_experiment_values"
+        ),
+        patch.object(
+            controller.camera_setting_controller,
+            "calculate_physical_dimensions",
+            return_value=True,
+        ) as mock_physical_dimensions,
+        patch.object(controller.camera_view_controller, "update_snr"),
+        patch("navigate.controller.controller.messagebox.showwarning") as mock_warning,
+    ):
+        result = controller.change_microscope(microscope_name, "invalid_zoom")
+
+    assert result is True
+    assert (
+        controller.configuration["experiment"]["MicroscopeState"]["microscope_name"]
+        == microscope_name
+    )
+    assert (
+        controller.configuration["experiment"]["MicroscopeState"]["zoom"]
+        == fallback_zoom
+    )
+    mock_physical_dimensions.assert_called_once()
+    mock_warning.assert_called_once()
+    assert "Using" in mock_warning.call_args.kwargs["message"]
+
+
+def test_change_microscope_updates_zoom_on_same_microscope(controller):
+    microscope_name = controller.configuration_controller.microscope_list[0]
+    supported_zoom = list(
+        controller.configuration_controller.get_zoom_value_list(microscope_name)
+    )
+    if len(supported_zoom) < 2:
+        pytest.skip("Active test microscope does not have multiple zoom values.")
+
+    original_zoom = supported_zoom[0]
+    new_zoom = supported_zoom[-1]
+    controller.configuration["experiment"]["MicroscopeState"][
+        "microscope_name"
+    ] = microscope_name
+    controller.configuration["experiment"]["MicroscopeState"]["zoom"] = original_zoom
+
+    with (
+        patch.object(
+            controller.configuration_controller, "change_microscope", return_value=False
+        ),
+        patch.object(
+            controller.configuration_controller, "microscope_name", microscope_name
+        ),
+        patch.object(
+            controller.camera_setting_controller,
+            "calculate_physical_dimensions",
+            return_value=True,
+        ) as mock_physical_dimensions,
+    ):
+        result = controller.change_microscope(microscope_name, new_zoom)
+
+    assert result is True
+    assert controller.configuration["experiment"]["MicroscopeState"]["zoom"] == new_zoom
+    mock_physical_dimensions.assert_called_once()
+
+
+def test_change_microscope_invalid_microscope_returns_false(controller):
+    previous_microscope_name = controller.configuration["experiment"][
+        "MicroscopeState"
+    ]["microscope_name"]
+    previous_zoom = controller.configuration["experiment"]["MicroscopeState"]["zoom"]
+
+    with (
+        patch.object(
+            controller.configuration_controller, "change_microscope", return_value=False
+        ),
+        patch.object(
+            controller.configuration_controller, "microscope_name", "different_scope"
+        ),
+        patch.object(
+            controller.camera_setting_controller, "calculate_physical_dimensions"
+        ) as mock_physical_dimensions,
+        patch("navigate.controller.controller.messagebox.showwarning") as mock_warning,
+    ):
+        result = controller.change_microscope("missing_scope", previous_zoom)
+
+    assert result is False
+    assert (
+        controller.configuration["experiment"]["MicroscopeState"]["microscope_name"]
+        == previous_microscope_name
+    )
+    assert (
+        controller.configuration["experiment"]["MicroscopeState"]["zoom"]
+        == previous_zoom
+    )
+    mock_physical_dimensions.assert_not_called()
+    mock_warning.assert_called_once()
+    assert "not configured" in mock_warning.call_args.kwargs["message"]
 
 
 def test_initialize_cam_view(controller):

--- a/test/tools/test_common_functions.py
+++ b/test/tools/test_common_functions.py
@@ -121,10 +121,11 @@ class CopyProxyObjectTestCase(unittest.TestCase):
         assert copied_list[1] == {"key": "value"}
 
     def test_copy_proxy_object_with_non_proxy_object(self):
-        non_proxy_object = {"key": "value"}
+        non_proxy_object = {"key": ["value"]}
         copied_object = common_functions.copy_proxy_object(non_proxy_object)
-        self.assertIs(non_proxy_object, copied_object)
-        assert copied_object["key"] == "value"
+        self.assertIsNot(non_proxy_object, copied_object)
+        self.assertIsNot(non_proxy_object["key"], copied_object["key"])
+        assert copied_object["key"] == ["value"]
         assert isinstance(copied_object, dict)
 
 


### PR DESCRIPTION
This PR adds a few small stability fixes across configuration, camera, channel, and common utility code.

        camera_settings.py: avoid crashing when pixel size is missing for the selected microscope/zoom and log a warning instead
        channels_settings.py: write updated channel settings back to channel_setting_dict after widget changes
        common_functions.py: make copy_proxy_object() recursively copy dict- and list-like objects more generally
        configuration_controller.py: clean up the missing-microscope warning message formatting