### PR TITLE
Fix advanced settings overwriting legacy config when custom configuration is loaded

### DIFF
--- a/src/navigate/controller/sub_controllers/camera_settings.py
+++ b/src/navigate/controller/sub_controllers/camera_settings.py
@@ -39,7 +39,7 @@ from typing import Optional
 
 # Local Imports
 from navigate.controller.sub_controllers.gui import GUIController
-from navigate.config.config import update_config_dict, get_navigate_path
+from navigate.config.config import update_config_dict
 from navigate.tools.file_functions import write_to_yaml
 from navigate.controller.configuration_controller import ConfigurationController
 
@@ -134,7 +134,7 @@ class AdvancedCameraSettingController:
         # Save the updated configuration to a YAML file.
         write_to_yaml(
             content_dict=self.parent_controller.configuration["configuration"],
-            filename=os.path.join(get_navigate_path(), "config", "configuration.yaml"),
+            filename=self.parent_controller.configuration_path,
         )
 
         # Update the configuration controller with the new configuration.

--- a/src/navigate/controller/sub_controllers/camera_settings.py
+++ b/src/navigate/controller/sub_controllers/camera_settings.py
@@ -32,7 +32,6 @@
 
 # Standard Library Imports
 import logging
-import os
 from typing import Optional
 
 # Third Party Imports
@@ -670,9 +669,9 @@ class CameraSettingController(GUIController):
                 self.camera_setting_dict["readout_direction"]
                 not in self.camera_readout_directions
             ):
-                self.camera_setting_dict["readout_direction"] = (
-                    self.camera_readout_directions[0]
-                )
+                self.camera_setting_dict[
+                    "readout_direction"
+                ] = self.camera_readout_directions[0]
             self.mode_widgets["Readout"].widget.set(
                 self.camera_setting_dict["readout_direction"]
             )

--- a/src/navigate/controller/sub_controllers/stages_advanced.py
+++ b/src/navigate/controller/sub_controllers/stages_advanced.py
@@ -30,7 +30,6 @@
 
 # Standard Library Imports
 import logging
-import os
 from typing import Optional
 
 # Third Party Imports

--- a/src/navigate/controller/sub_controllers/stages_advanced.py
+++ b/src/navigate/controller/sub_controllers/stages_advanced.py
@@ -36,7 +36,7 @@ from typing import Optional
 # Third Party Imports
 
 # Local Imports
-from navigate.config.config import update_config_dict, get_navigate_path
+from navigate.config.config import update_config_dict
 from navigate.tools.file_functions import write_to_yaml
 from navigate.view.popups.stages_advanced_popup import AdvancedStageParametersPopup
 from navigate.controller.configuration_controller import ConfigurationController
@@ -132,7 +132,7 @@ class AdvancedStageParametersController:
         # Save the updated configuration to a YAML file.
         write_to_yaml(
             content_dict=self.parent_controller.configuration["configuration"],
-            filename=os.path.join(get_navigate_path(), "config", "configuration.yaml"),
+            filename=self.parent_controller.configuration_path,
         )
 
         # Update the configuration controller with the new configuration.

--- a/test/controller/sub_controllers/test_advanced_camera_settings.py
+++ b/test/controller/sub_controllers/test_advanced_camera_settings.py
@@ -1,0 +1,58 @@
+import os
+from unittest.mock import MagicMock, patch
+
+from navigate.config.config import get_navigate_path
+from navigate.controller.sub_controllers.camera_settings import (
+    AdvancedCameraSettingController,
+)
+
+
+def test_save_camera_settings_writes_to_parent_configuration_path(dummy_controller):
+    controller = AdvancedCameraSettingController.__new__(
+        AdvancedCameraSettingController
+    )
+    microscope_name = dummy_controller.configuration["experiment"]["MicroscopeState"][
+        "microscope_name"
+    ]
+    legacy_configuration_path = os.path.join(
+        get_navigate_path(), "config", "configuration.yaml"
+    )
+    dummy_controller.configuration_path = "/tmp/custom-configuration.yml"
+    assert dummy_controller.configuration_path != legacy_configuration_path
+    dummy_controller.configuration_controller.update_configuration = MagicMock()
+
+    controller.parent_controller = dummy_controller
+    controller.current_microscope = microscope_name
+    controller.camera_dict = (
+        dummy_controller.configuration["configuration"]["microscopes"][microscope_name][
+            "camera"
+        ].copy()
+    )
+    controller.view = MagicMock()
+    controller.view.inputs = {
+        "trigger_source": MagicMock(get=MagicMock(return_value="External")),
+        "cooling": MagicMock(get=MagicMock(return_value="Off")),
+    }
+
+    with patch(
+        "navigate.controller.sub_controllers.camera_settings.update_config_dict"
+    ) as mock_update_config_dict, patch(
+        "navigate.controller.sub_controllers.camera_settings.write_to_yaml"
+    ) as mock_write_to_yaml:
+        controller.save_camera_settings()
+
+    mock_update_config_dict.assert_called_once()
+    mock_write_to_yaml.assert_called_once()
+    assert (
+        mock_write_to_yaml.call_args.kwargs["filename"]
+        == dummy_controller.configuration_path
+    )
+    assert (
+        mock_write_to_yaml.call_args.kwargs["filename"] != legacy_configuration_path
+    )
+    dummy_controller.configuration_controller.update_configuration.assert_called_once()
+    camera_parameters = dummy_controller.configuration["experiment"]["CameraParameters"][
+        microscope_name
+    ]
+    assert camera_parameters["trigger_source"] == "External"
+    assert camera_parameters["cooling"] == "Off"

--- a/test/controller/sub_controllers/test_advanced_camera_settings.py
+++ b/test/controller/sub_controllers/test_advanced_camera_settings.py
@@ -23,11 +23,9 @@ def test_save_camera_settings_writes_to_parent_configuration_path(dummy_controll
 
     controller.parent_controller = dummy_controller
     controller.current_microscope = microscope_name
-    controller.camera_dict = (
-        dummy_controller.configuration["configuration"]["microscopes"][microscope_name][
-            "camera"
-        ].copy()
-    )
+    controller.camera_dict = dummy_controller.configuration["configuration"][
+        "microscopes"
+    ][microscope_name]["camera"].copy()
     controller.view = MagicMock()
     controller.view.inputs = {
         "trigger_source": MagicMock(get=MagicMock(return_value="External")),
@@ -47,12 +45,10 @@ def test_save_camera_settings_writes_to_parent_configuration_path(dummy_controll
         mock_write_to_yaml.call_args.kwargs["filename"]
         == dummy_controller.configuration_path
     )
-    assert (
-        mock_write_to_yaml.call_args.kwargs["filename"] != legacy_configuration_path
-    )
+    assert mock_write_to_yaml.call_args.kwargs["filename"] != legacy_configuration_path
     dummy_controller.configuration_controller.update_configuration.assert_called_once()
-    camera_parameters = dummy_controller.configuration["experiment"]["CameraParameters"][
-        microscope_name
-    ]
+    camera_parameters = dummy_controller.configuration["experiment"][
+        "CameraParameters"
+    ][microscope_name]
     assert camera_parameters["trigger_source"] == "External"
     assert camera_parameters["cooling"] == "Off"

--- a/test/controller/sub_controllers/test_advanced_camera_settings.py
+++ b/test/controller/sub_controllers/test_advanced_camera_settings.py
@@ -7,7 +7,9 @@ from navigate.controller.sub_controllers.camera_settings import (
 )
 
 
-def test_save_camera_settings_writes_to_parent_configuration_path(dummy_controller):
+def test_save_camera_settings_writes_to_parent_configuration_path(
+    dummy_controller, monkeypatch
+):
     controller = AdvancedCameraSettingController.__new__(
         AdvancedCameraSettingController
     )
@@ -17,9 +19,17 @@ def test_save_camera_settings_writes_to_parent_configuration_path(dummy_controll
     legacy_configuration_path = os.path.join(
         get_navigate_path(), "config", "configuration.yaml"
     )
-    dummy_controller.configuration_path = "/tmp/custom-configuration.yml"
+    configuration_path = "/tmp/custom-configuration.yml"
+    update_configuration = MagicMock()
+    monkeypatch.setattr(
+        dummy_controller, "configuration_path", configuration_path, raising=False
+    )
+    monkeypatch.setattr(
+        dummy_controller.configuration_controller,
+        "update_configuration",
+        update_configuration,
+    )
     assert dummy_controller.configuration_path != legacy_configuration_path
-    dummy_controller.configuration_controller.update_configuration = MagicMock()
 
     controller.parent_controller = dummy_controller
     controller.current_microscope = microscope_name
@@ -31,6 +41,13 @@ def test_save_camera_settings_writes_to_parent_configuration_path(dummy_controll
         "trigger_source": MagicMock(get=MagicMock(return_value="External")),
         "cooling": MagicMock(get=MagicMock(return_value="Off")),
     }
+    camera_parameters = dummy_controller.configuration["experiment"][
+        "CameraParameters"
+    ][microscope_name]
+    monkeypatch.setitem(
+        camera_parameters, "trigger_source", camera_parameters.get("trigger_source")
+    )
+    monkeypatch.setitem(camera_parameters, "cooling", camera_parameters.get("cooling"))
 
     with patch(
         "navigate.controller.sub_controllers.camera_settings.update_config_dict"
@@ -46,9 +63,6 @@ def test_save_camera_settings_writes_to_parent_configuration_path(dummy_controll
         == dummy_controller.configuration_path
     )
     assert mock_write_to_yaml.call_args.kwargs["filename"] != legacy_configuration_path
-    dummy_controller.configuration_controller.update_configuration.assert_called_once()
-    camera_parameters = dummy_controller.configuration["experiment"][
-        "CameraParameters"
-    ][microscope_name]
+    update_configuration.assert_called_once()
     assert camera_parameters["trigger_source"] == "External"
     assert camera_parameters["cooling"] == "Off"

--- a/test/controller/sub_controllers/test_advanced_camera_settings.py
+++ b/test/controller/sub_controllers/test_advanced_camera_settings.py
@@ -1,14 +1,30 @@
 import os
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from navigate.config.config import get_navigate_path
 from navigate.controller.sub_controllers.camera_settings import (
     AdvancedCameraSettingController,
 )
 
 
+@pytest.fixture
+def camera_parameters(dummy_controller):
+    microscope_name = dummy_controller.configuration["experiment"]["MicroscopeState"][
+        "microscope_name"
+    ]
+    parameters = dummy_controller.configuration["experiment"]["CameraParameters"][
+        microscope_name
+    ]
+    original_parameters = dict(parameters)
+    yield parameters
+    parameters.clear()
+    parameters.update(original_parameters)
+
+
 def test_save_camera_settings_writes_to_parent_configuration_path(
-    dummy_controller, monkeypatch
+    dummy_controller, monkeypatch, camera_parameters
 ):
     controller = AdvancedCameraSettingController.__new__(
         AdvancedCameraSettingController
@@ -41,13 +57,6 @@ def test_save_camera_settings_writes_to_parent_configuration_path(
         "trigger_source": MagicMock(get=MagicMock(return_value="External")),
         "cooling": MagicMock(get=MagicMock(return_value="Off")),
     }
-    camera_parameters = dummy_controller.configuration["experiment"][
-        "CameraParameters"
-    ][microscope_name]
-    monkeypatch.setitem(
-        camera_parameters, "trigger_source", camera_parameters.get("trigger_source")
-    )
-    monkeypatch.setitem(camera_parameters, "cooling", camera_parameters.get("cooling"))
 
     with patch(
         "navigate.controller.sub_controllers.camera_settings.update_config_dict"

--- a/test/controller/sub_controllers/test_advanced_stage_settings.py
+++ b/test/controller/sub_controllers/test_advanced_stage_settings.py
@@ -7,7 +7,9 @@ from navigate.controller.sub_controllers.stages_advanced import (
 )
 
 
-def test_save_stage_parameters_writes_to_parent_configuration_path(dummy_controller):
+def test_save_stage_parameters_writes_to_parent_configuration_path(
+    dummy_controller, monkeypatch
+):
     controller = AdvancedStageParametersController.__new__(
         AdvancedStageParametersController
     )
@@ -17,10 +19,19 @@ def test_save_stage_parameters_writes_to_parent_configuration_path(dummy_control
     legacy_configuration_path = os.path.join(
         get_navigate_path(), "config", "configuration.yaml"
     )
-    dummy_controller.configuration_path = "/tmp/custom-configuration.yml"
+    configuration_path = "/tmp/custom-configuration.yml"
+    update_configuration = MagicMock()
+    execute = MagicMock()
+    monkeypatch.setattr(
+        dummy_controller, "configuration_path", configuration_path, raising=False
+    )
+    monkeypatch.setattr(
+        dummy_controller.configuration_controller,
+        "update_configuration",
+        update_configuration,
+    )
+    monkeypatch.setattr(dummy_controller, "execute", execute)
     assert dummy_controller.configuration_path != legacy_configuration_path
-    dummy_controller.configuration_controller.update_configuration = MagicMock()
-    dummy_controller.execute = MagicMock()
 
     controller.parent_controller = dummy_controller
     controller.current_microscope = microscope_name
@@ -42,7 +53,5 @@ def test_save_stage_parameters_writes_to_parent_configuration_path(dummy_control
         == dummy_controller.configuration_path
     )
     assert mock_write_to_yaml.call_args.kwargs["filename"] != legacy_configuration_path
-    dummy_controller.configuration_controller.update_configuration.assert_called_once()
-    dummy_controller.execute.assert_called_once_with(
-        "update_stage_limits", microscope_name
-    )
+    update_configuration.assert_called_once()
+    execute.assert_called_once_with("update_stage_limits", microscope_name)

--- a/test/controller/sub_controllers/test_advanced_stage_settings.py
+++ b/test/controller/sub_controllers/test_advanced_stage_settings.py
@@ -1,0 +1,52 @@
+import os
+from unittest.mock import MagicMock, patch
+
+from navigate.config.config import get_navigate_path
+from navigate.controller.sub_controllers.stages_advanced import (
+    AdvancedStageParametersController,
+)
+
+
+def test_save_stage_parameters_writes_to_parent_configuration_path(dummy_controller):
+    controller = AdvancedStageParametersController.__new__(
+        AdvancedStageParametersController
+    )
+    microscope_name = dummy_controller.configuration["experiment"]["MicroscopeState"][
+        "microscope_name"
+    ]
+    legacy_configuration_path = os.path.join(
+        get_navigate_path(), "config", "configuration.yaml"
+    )
+    dummy_controller.configuration_path = "/tmp/custom-configuration.yml"
+    assert dummy_controller.configuration_path != legacy_configuration_path
+    dummy_controller.configuration_controller.update_configuration = MagicMock()
+    dummy_controller.execute = MagicMock()
+
+    controller.parent_controller = dummy_controller
+    controller.current_microscope = microscope_name
+    controller.stage_dict = (
+        dummy_controller.configuration["configuration"]["microscopes"][microscope_name][
+            "stage"
+        ].copy()
+    )
+
+    with patch(
+        "navigate.controller.sub_controllers.stages_advanced.update_config_dict"
+    ) as mock_update_config_dict, patch(
+        "navigate.controller.sub_controllers.stages_advanced.write_to_yaml"
+    ) as mock_write_to_yaml:
+        controller.save_stage_parameters()
+
+    mock_update_config_dict.assert_called_once()
+    mock_write_to_yaml.assert_called_once()
+    assert (
+        mock_write_to_yaml.call_args.kwargs["filename"]
+        == dummy_controller.configuration_path
+    )
+    assert (
+        mock_write_to_yaml.call_args.kwargs["filename"] != legacy_configuration_path
+    )
+    dummy_controller.configuration_controller.update_configuration.assert_called_once()
+    dummy_controller.execute.assert_called_once_with(
+        "update_stage_limits", microscope_name
+    )

--- a/test/controller/sub_controllers/test_advanced_stage_settings.py
+++ b/test/controller/sub_controllers/test_advanced_stage_settings.py
@@ -24,11 +24,9 @@ def test_save_stage_parameters_writes_to_parent_configuration_path(dummy_control
 
     controller.parent_controller = dummy_controller
     controller.current_microscope = microscope_name
-    controller.stage_dict = (
-        dummy_controller.configuration["configuration"]["microscopes"][microscope_name][
-            "stage"
-        ].copy()
-    )
+    controller.stage_dict = dummy_controller.configuration["configuration"][
+        "microscopes"
+    ][microscope_name]["stage"].copy()
 
     with patch(
         "navigate.controller.sub_controllers.stages_advanced.update_config_dict"
@@ -43,9 +41,7 @@ def test_save_stage_parameters_writes_to_parent_configuration_path(dummy_control
         mock_write_to_yaml.call_args.kwargs["filename"]
         == dummy_controller.configuration_path
     )
-    assert (
-        mock_write_to_yaml.call_args.kwargs["filename"] != legacy_configuration_path
-    )
+    assert mock_write_to_yaml.call_args.kwargs["filename"] != legacy_configuration_path
     dummy_controller.configuration_controller.update_configuration.assert_called_once()
     dummy_controller.execute.assert_called_once_with(
         "update_stage_limits", microscope_name

--- a/test/model/test_model.py
+++ b/test/model/test_model.py
@@ -73,6 +73,8 @@ def test_receive_last_frame_id_handles_coalesced_batches() -> None:
 
 @pytest.fixture(scope="module")
 def model():
+    from logging import NullHandler
+    from logging.handlers import QueueListener
     from types import SimpleNamespace
     from pathlib import Path
 
@@ -84,13 +86,17 @@ def model():
         verify_configuration,
         verify_positions_config,
     )
+    from navigate.log_files.log_functions import log_setup
     from navigate.tools.file_functions import load_yaml_file
 
     with Manager() as manager:
 
         # Use configuration files that ship with the code base
         configuration_directory = Path.joinpath(
-            Path(__file__).resolve().parent.parent.parent, "src", "navigate", "config"
+            Path(__file__).resolve().parent.parent.parent,
+            "src",
+            "navigate",
+            "config",
         )
         configuration_path = Path.joinpath(
             configuration_directory, "configuration.yaml"
@@ -121,22 +127,25 @@ def model():
         positions = verify_positions_config(positions)
         configuration["multi_positions"] = positions
 
-        queue = multiprocessing.Queue()
+        log_queue = multiprocessing.Queue()
+        log_listener = QueueListener(log_queue, NullHandler())
+        log_listener.start()
 
         model = Model(
             args=SimpleNamespace(synthetic_hardware=True),
             configuration=configuration,
             event_queue=event_queue,
-            log_queue=queue,
+            log_queue=log_queue,
         )
 
         model.__test_manager = manager
 
         yield model
-        while not queue.empty():
-            queue.get()
-        queue.close()
-        queue.join_thread()
+        # Restore file handlers before closing the queue-backed handlers.
+        log_setup("logging.yml")
+        log_listener.stop()
+        log_queue.close()
+        log_queue.join_thread()
 
 
 @pytest.mark.flaky(reruns=3, reruns_delay=2)
@@ -541,27 +550,31 @@ def test_load_feature_list_from_str(model):
     del feature_lists[-1]
 
 
-def test_load_feature_records(model):
+def test_load_feature_records(model, tmp_path, monkeypatch):
     feature_lists = model.feature_list
     l = len(feature_lists)  # noqa
 
-    from navigate.config.config import get_navigate_path
     from navigate.tools.file_functions import save_yaml_file, load_yaml_file
     from navigate.model.features.feature_related_functions import (
         convert_feature_list_to_str,
     )
 
-    feature_lists_path = get_navigate_path() + "/feature_lists"
+    navigate_home = tmp_path / "navigate_home"
+    monkeypatch.setattr(
+        "navigate.model.model.get_navigate_path",
+        lambda: str(navigate_home),
+    )
+    feature_lists_path = navigate_home / "feature_lists"
 
     if not os.path.exists(feature_lists_path):
         os.makedirs(feature_lists_path)
 
-    feature_records = load_yaml_file(f"{feature_lists_path}/__sequence.yml")
+    feature_records = load_yaml_file(feature_lists_path / "__sequence.yml")
     if not feature_records:
         feature_records = []
 
     save_yaml_file(
-        feature_lists_path,
+        str(feature_lists_path),
         {
             "module_name": None,
             "feature_list_name": "Test Feature List 5",
@@ -579,10 +592,10 @@ def test_load_feature_records(model):
     )
 
     del feature_lists[-1]
-    os.remove(f"{feature_lists_path}/__test_1.yml")
+    os.remove(feature_lists_path / "__test_1.yml")
 
     model.load_feature_records()
     assert len(feature_lists) == l + len(feature_records) * 2
-    feature_records_2 = load_yaml_file(f"{feature_lists_path}/__sequence.yml")
+    feature_records_2 = load_yaml_file(feature_lists_path / "__sequence.yml")
     assert feature_records == feature_records_2
-    os.remove(f"{feature_lists_path}/__sequence.yml")
+    os.remove(feature_lists_path / "__sequence.yml")


### PR DESCRIPTION
This PR fixes a bug where saving advanced camera or stage settings could write to the legacy default configuration file instead of the currently loaded configuration file.

However, there is a related broader behavior to revisit: on application exit, we still save files such as experiment, waveform_constants, and related configs back to the legacy default paths.
I’m still evaluating whether all runtime save flows should consistently write back to the currently loaded custom configuration set instead of the legacy defaults. That broader behavior is not changed in this PR.