### PR TITLE
Highlight active multiposition row during Z-stack acquisition

### DIFF
--- a/src/navigate/controller/sub_controllers/multiposition.py
+++ b/src/navigate/controller/sub_controllers/multiposition.py
@@ -312,6 +312,23 @@ class MultiPositionController(GUIController):
         """
         return self.table.model.df.shape[0]
 
+    def highlight_position(self, row_id: int) -> None:
+        """Highlight the position at a zero-based table row index.
+
+        Parameters
+        ----------
+        row_id : int
+            Zero-based index of the position row to highlight.
+        """
+        if not isinstance(row_id, (int, np.integer)) or not 0 <= row_id < (
+            self.get_position_num()
+        ):
+            return
+
+        self.table.currentrow = row_id
+        self.table.setSelectedRow(row_id)
+        self._refresh_table_view()
+
     def load_positions(self) -> None:
         """Load a yml or csv file.
 
@@ -482,4 +499,7 @@ class MultiPositionController(GUIController):
         dict[str, Callable]
             Dictionary of custom events with their corresponding functions.
         """
-        return {"remove_positions": self.remove_positions}
+        return {
+            "remove_positions": self.remove_positions,
+            "hightlight_position": self.highlight_position,
+        }

--- a/src/navigate/controller/sub_controllers/multiposition.py
+++ b/src/navigate/controller/sub_controllers/multiposition.py
@@ -325,8 +325,7 @@ class MultiPositionController(GUIController):
         ):
             return
 
-        self.table.currentrow = row_id
-        self.table.setSelectedRow(row_id)
+        self.table.movetoSelection(row=row_id)
         self._refresh_table_view()
 
     def load_positions(self) -> None:
@@ -501,5 +500,5 @@ class MultiPositionController(GUIController):
         """
         return {
             "remove_positions": self.remove_positions,
-            "hightlight_position": self.highlight_position,
+            "highlight_position": self.highlight_position,
         }

--- a/src/navigate/model/features/common_features.py
+++ b/src/navigate/model/features/common_features.py
@@ -1382,6 +1382,8 @@ class ZStackAcquisition:
 
         # move stage X, Y, Theta
         if self.need_to_move_new_position:
+            if len(self.positions) > 1:
+                self.model.event_queue.put(("hightlight_position", self.current_position_idx))
             self.need_to_move_new_position = False
             if self.current_position_idx > 0:
                 self.pre_position = self.current_position

--- a/src/navigate/model/features/common_features.py
+++ b/src/navigate/model/features/common_features.py
@@ -1383,7 +1383,9 @@ class ZStackAcquisition:
         # move stage X, Y, Theta
         if self.need_to_move_new_position:
             if len(self.positions) > 1:
-                self.model.event_queue.put(("hightlight_position", self.current_position_idx))
+                self.model.event_queue.put(
+                    ("highlight_position", self.current_position_idx)
+                )
             self.need_to_move_new_position = False
             if self.current_position_idx > 0:
                 self.pre_position = self.current_position

--- a/test/controller/sub_controllers/test_multiposition.py
+++ b/test/controller/sub_controllers/test_multiposition.py
@@ -164,3 +164,28 @@ def test_export_positions_csv(mock_asksave, multiposition_controller):
 
     controller.export_positions()
     export_df.to_csv.assert_called_once_with("/tmp/output.csv", index=False)
+
+
+def test_highlight_position_selects_valid_row(multiposition_controller):
+    """A valid position row becomes the table's selected row."""
+    controller = multiposition_controller
+    controller.table.model.df = pd.DataFrame({"X": [1, 2]})
+
+    controller.highlight_position(1)
+
+    assert controller.table.currentrow == 1
+    controller.table.setSelectedRow.assert_called_once_with(1)
+    controller.table.redraw.assert_called_once()
+    controller.table.tableChanged.assert_called_once()
+
+
+def test_highlight_position_ignores_invalid_row(multiposition_controller):
+    """Out-of-range rows leave the current selection unchanged."""
+    controller = multiposition_controller
+    controller.table.model.df = pd.DataFrame({"X": [1]})
+    controller.table.currentrow = 0
+
+    controller.highlight_position(1)
+
+    assert controller.table.currentrow == 0
+    controller.table.setSelectedRow.assert_not_called()

--- a/test/controller/sub_controllers/test_multiposition.py
+++ b/test/controller/sub_controllers/test_multiposition.py
@@ -166,15 +166,14 @@ def test_export_positions_csv(mock_asksave, multiposition_controller):
     export_df.to_csv.assert_called_once_with("/tmp/output.csv", index=False)
 
 
-def test_highlight_position_selects_valid_row(multiposition_controller):
-    """A valid position row becomes the table's selected row."""
+def test_highlight_position_moves_valid_row_into_view(multiposition_controller):
+    """A valid position row becomes selected and visible."""
     controller = multiposition_controller
     controller.table.model.df = pd.DataFrame({"X": [1, 2]})
 
     controller.highlight_position(1)
 
-    assert controller.table.currentrow == 1
-    controller.table.setSelectedRow.assert_called_once_with(1)
+    controller.table.movetoSelection.assert_called_once_with(row=1)
     controller.table.redraw.assert_called_once()
     controller.table.tableChanged.assert_called_once()
 
@@ -188,4 +187,13 @@ def test_highlight_position_ignores_invalid_row(multiposition_controller):
     controller.highlight_position(1)
 
     assert controller.table.currentrow == 0
-    controller.table.setSelectedRow.assert_not_called()
+    controller.table.movetoSelection.assert_not_called()
+
+
+def test_highlight_position_event_is_registered(multiposition_controller):
+    """The controller exposes the correctly spelled highlight event."""
+    controller = multiposition_controller
+
+    assert (
+        controller.custom_events["highlight_position"] == controller.highlight_position
+    )

--- a/test/model/features/test_common_features.py
+++ b/test/model/features/test_common_features.py
@@ -32,6 +32,8 @@
 
 
 import random
+from unittest.mock import MagicMock
+
 import pytest
 from navigate.model.features.common_features import (
     ASIZStackAcquisition,
@@ -156,6 +158,48 @@ def test_asi_z_stack_uses_channel_defocus_in_stage_move(
         record for record in model.signal_records if record[0] == "move_stage"
     ]
     assert move_stage_records[-1][1][0]["f_abs"] == pytest.approx(98.5)
+
+
+def test_z_stack_emits_highlight_event_for_active_position(
+    dummy_model_to_test_features, monkeypatch
+):
+    model = dummy_model_to_test_features
+    event_queue = MagicMock()
+    monkeypatch.setattr(model, "event_queue", event_queue, raising=False)
+    feature = ZStackAcquisition(model, saving_flag=False)
+    feature.stage_axes = ["x", "y", "z", "theta", "f"]
+    feature.axes_index = [0, 1, 2, 3, 4]
+    feature.tiling_axes = ["x", "y", "theta"]
+    feature.primary_z_axis = "z"
+    feature.primary_f_axis = "f"
+    feature.secondary_stack_settings = {}
+    feature.positions = [
+        [0.0, 0.0, 0.0, 0.0, 0.0],
+        [1.0, 2.0, 3.0, 4.0, 5.0],
+    ]
+    feature.current_position_idx = 1
+    feature.current_position = {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "theta": 0.0,
+        "f": 0.0,
+    }
+    feature.pre_position = feature.current_position
+    feature.need_to_move_new_position = True
+    feature.need_to_move_z_position = False
+    feature.start_z_position = 0.0
+    feature.start_focus = 0.0
+    feature.z_stack_distance = 0.0
+    feature.f_stack_distance = 0.0
+    feature.stage_distance_threshold = 1000
+    feature.defocus = [0.0]
+    feature.first_channel_defocus = 0.0
+    feature.current_channel_in_list = 0
+
+    feature.signal_func()
+
+    event_queue.put.assert_called_once_with(("highlight_position", 1))
 
 
 class TestZStack:


### PR DESCRIPTION
## Summary

- Add a multi-position controller event to select and highlight a table row by its zero-based position index.
- Update Z-stack acquisition to highlight the active position when acquiring across multiple positions.
- Add controller tests for valid and out-of-range row selection.